### PR TITLE
propagate full field metadata during form drag

### DIFF
--- a/app/components/forms/FormBuilder/FieldPalette.tsx
+++ b/app/components/forms/FormBuilder/FieldPalette.tsx
@@ -26,7 +26,7 @@ export function FieldPalette() {
         <h3 className="font-semibold mb-3 text-lg">Field Types</h3>
         <div className="flex flex-col gap-2">
           {FIELD_TYPES.map((field) => (
-            <DraggableField key={field.type} id={field.type} label={field.label} hint={field.hint} />
+            <DraggableField key={field.type} field={field} />
           ))}
         </div>
       </div>
@@ -34,8 +34,11 @@ export function FieldPalette() {
   );
 }
 
-function DraggableField({ id, label, hint }: { id: string; label: string; hint: string }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id });
+function DraggableField({ field }: { field: { type: string; label: string; hint: string } }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: field.type,
+    data: field,
+  });
 
   const style = {
     transform: CSS.Translate.toString(transform),
@@ -56,10 +59,10 @@ function DraggableField({ id, label, hint }: { id: string; label: string; hint: 
             isDragging ? 'ring-2 ring-blue-400' : ''
           }`}
         >
-          {label}
+          {field.label}
         </div>
       </TooltipTrigger>
-      <TooltipContent side="right">{hint}</TooltipContent>
+      <TooltipContent side="right">{field.hint}</TooltipContent>
     </Tooltip>
   );
 }

--- a/app/components/forms/FormBuilder/FormBuilder.tsx
+++ b/app/components/forms/FormBuilder/FormBuilder.tsx
@@ -67,8 +67,14 @@ export default function FormBuilder({ onSave, initialData }: FormBuilderProps) {
     if (!over) return
 
     // Add new field from palette
-    if (over.id === 'canvas' && !fields.find((f) => f.id === active.id)) {
-      const newField: FormField = { id: uuidv4(), type: String(active.id), label: 'Untitled Field', required: false }
+    const dragged = active.data?.current as { type: string; label: string } | undefined
+    if (over.id === 'canvas' && dragged && !fields.find((f) => f.id === active.id)) {
+      const newField: FormField = {
+        id: uuidv4(),
+        type: dragged.type,
+        label: dragged.label || 'Untitled Field',
+        required: false,
+      }
       setFields((prev) => [...prev, newField])
       setSelectedField(newField)
       toast.success(`Added ${newField.type} field`)
@@ -178,9 +184,11 @@ export default function FormBuilder({ onSave, initialData }: FormBuilderProps) {
 
       <DndContext
         onDragEnd={handleDragEnd}
-        onDragStart={(e) =>
-          setActiveDragField({ id: 'temp', type: String(e.active.id), label: String(e.active.id), required: false })
-        }
+        onDragStart={(e) => {
+          const dragged = e.active.data?.current as { type: string; label: string } | undefined
+          if (!dragged) return
+          setActiveDragField({ id: 'temp', type: dragged.type, label: dragged.label, required: false })
+        }}
       >
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <FieldPalette />


### PR DESCRIPTION
## Summary
- pass field metadata through DraggableField using dnd-kit data
- use active data to set temporary and saved fields on drag start/end

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6894bb1e79e48331a855f5b9c2976af1