### PR TITLE
feat: select onboarding template when adding employee

### DIFF
--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -109,6 +109,7 @@ export async function POST(req: Request) {
       managerId,
       startOnboarding,
       sendInviteNow,
+      onboardingTemplateId,
     } = await req.json();
 
     if (!firstName || !lastName || !email || !startDate || !role) {
@@ -169,13 +170,16 @@ export async function POST(req: Request) {
 
     // ✅ Create Employee linked to User
     const employee = await prisma.employee.create({
-  data: {
-    user: { connect: { id: user.id } },
-    isActive: true,
-    department: departmentId ? { connect: { id: departmentId } } : undefined,
-    company: { connect: { id: companyId! } }, // ✅ FIXED: use relation connect
-  },
-});
+      data: {
+        user: { connect: { id: user.id } },
+        isActive: true,
+        department: departmentId ? { connect: { id: departmentId } } : undefined,
+        company: { connect: { id: companyId! } }, // ✅ FIXED: use relation connect
+        onboardingTemplate: onboardingTemplateId
+          ? { connect: { id: onboardingTemplateId } }
+          : undefined,
+      },
+    });
 
     // Create activation token now; email optionally sent now or later
     await prisma.activationToken.create({
@@ -207,7 +211,7 @@ export async function POST(req: Request) {
         const startRes = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/onboarding/start`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ employeeId: employee.id }),
+          body: JSON.stringify({ employeeId: employee.id, templateId: onboardingTemplateId }),
         });
         if (!startRes.ok) {
           console.warn("Onboarding start failed:", await startRes.text());

--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { employeeId } = await req.json();
+    const { employeeId, templateId } = await req.json();
     if (!employeeId) {
       return NextResponse.json({ error: "employeeId is required" }, { status: 400 });
     }
@@ -83,7 +83,16 @@ export async function POST(req: NextRequest) {
     }
 
     // Find a template to use
-    const template = await findBestOnboardingTemplate(employee);
+    let template: any;
+    if (templateId) {
+      template = await prisma.onboardingTemplate.findFirst({
+        where: { id: templateId, isActive: true, companyId: employee.companyId },
+        include: { steps: true },
+      });
+    }
+    if (!template) {
+      template = await findBestOnboardingTemplate(employee);
+    }
     if (!template) {
       return NextResponse.json({ error: "No onboarding template found" }, { status: 400 });
     }

--- a/app/components/employees/AddEmployeeModal.tsx
+++ b/app/components/employees/AddEmployeeModal.tsx
@@ -22,6 +22,7 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
   const [departments, setDepartments] = useState<any[]>([]);
   const [jobRoles, setJobRoles] = useState<any[]>([]);
   const [employees, setEmployees] = useState<any[]>([]);
+  const [templates, setTemplates] = useState<any[]>([]);
   const [error, setError] = useState("");
   const [isDeptModalOpen, setDeptModalOpen] = useState(false);
   const [isRoleModalOpen, setRoleModalOpen] = useState(false);
@@ -36,6 +37,7 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
     departmentId: "",
     jobRoleId: "",
     managerId: "",
+    onboardingTemplateId: "",
   });
 
   // 👇 NEW: toggles
@@ -44,14 +46,16 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
 
   const fetchData = async () => {
     try {
-      const [empRes, deptRes, roleRes] = await Promise.all([
+      const [empRes, deptRes, roleRes, templateRes] = await Promise.all([
         fetch("/api/employees").then((r) => r.json()),
         fetch("/api/departments").then((r) => r.json()),
         fetch("/api/job-roles").then((r) => r.json()),
+        fetch("/api/onboarding/templates").then((r) => r.json()),
       ]);
       setEmployees(empRes.filter((emp: any) => emp.user));
       setDepartments(Array.isArray(deptRes) ? deptRes : deptRes.departments || []);
       setJobRoles(Array.isArray(roleRes) ? roleRes : roleRes.jobRoles || []);
+      setTemplates(Array.isArray(templateRes) ? templateRes : templateRes.templates || []);
     } catch {
       setError("Failed to load data");
     }
@@ -68,11 +72,17 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
+      if (startOnboarding && !formData.onboardingTemplateId) {
+        setError("Please select an onboarding template");
+        return;
+      }
+
       const payload = {
         ...formData,
         companyId: session?.user?.companyId,
         startOnboarding, // 👈 Pass to backend!
-        sendInviteNow,   // 👈 Pass to backend!
+        sendInviteNow, // 👈 Pass to backend!
+        onboardingTemplateId: startOnboarding ? formData.onboardingTemplateId : undefined,
       };
 
       const res = await fetch("/api/employees", {
@@ -99,6 +109,7 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
         departmentId: "",
         jobRoleId: "",
         managerId: "",
+        onboardingTemplateId: "",
       });
       setStartOnboarding(true); // reset toggle
       setSendInviteNow(true);
@@ -111,6 +122,12 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
   };
 
   if (!open) return null;
+
+  const filteredTemplates = templates.filter((t) => {
+    const matchesDept = formData.departmentId && t.departments?.some((d: any) => d.id === formData.departmentId);
+    const matchesRole = formData.jobRoleId && t.jobRoles?.some((j: any) => j.id === formData.jobRoleId);
+    return matchesDept || matchesRole;
+  });
 
   return (
     <>
@@ -169,6 +186,21 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
                 <Label className="text-sm">Start onboarding now (will email onboarding link)</Label>
               </div>
             </div>
+
+            {startOnboarding && (
+              <select
+                name="onboardingTemplateId"
+                value={formData.onboardingTemplateId}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-md px-3 py-2"
+                required
+              >
+                <option value="">Select Onboarding Template</option>
+                {filteredTemplates.map((t) => (
+                  <option key={t.id} value={t.id}>{t.name}</option>
+                ))}
+              </select>
+            )}
 
             <div className="flex justify-end space-x-2">
               <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>


### PR DESCRIPTION
## Summary
- allow admins to choose an onboarding template during employee creation
- filter available templates by selected department and job role
- use chosen template when starting onboarding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e6e0aa908331991f497fcaea4a22