### PR TITLE
Fix Supabase config and onboarding upload errors

### DIFF
--- a/app/components/onboarding/OnboardingStepRenderer.tsx
+++ b/app/components/onboarding/OnboardingStepRenderer.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/textarea";
 import { useSession } from "next-auth/react";
 import { DynamicFormRenderer } from "@/components/forms/DynamicFormRenderer";
+import { toast } from "sonner";
 
 type OnboardingStepProps = {
   step: {
@@ -88,16 +89,23 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
                   formData.append("canViewEmployee", "true");
                   formData.append("requiresAck", "false");
 
-                  const res = await fetch("/api/documents/upload-employee", { method: "POST", body: formData });
-                  if (!res.ok) {
-                    console.error("Upload failed");
-                    setLoading(false);
-                    return;
-                  }
+                  try {
+                    const res = await fetch("/api/documents/upload-employee", { method: "POST", body: formData });
+                    if (!res.ok) {
+                      toast("Failed to upload document");
+                      setLoading(false);
+                      return;
+                    }
 
-                  // ✅ Auto-refresh onboarding UI and employee docs
-                  await onComplete();
-                  window.dispatchEvent(new CustomEvent("employee-documents-updated", { detail: { employeeId } }));
+                    toast("Document uploaded");
+                    // ✅ Auto-refresh onboarding UI and employee docs
+                    await onComplete();
+                    window.dispatchEvent(new CustomEvent("employee-documents-updated", { detail: { employeeId } }));
+                  } catch (err) {
+                    console.error(err);
+                    toast("Failed to upload document");
+                    setLoading(false);
+                  }
                 }}
               >
                 Upload & Complete

--- a/app/lib/supabase-admin.ts
+++ b/app/lib/supabase-admin.ts
@@ -1,10 +1,15 @@
-// /lib/supabase-admin.ts
-
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Allow the admin client to fall back to the public env vars if the
+// service-role variables are not provided. This prevents runtime failures
+// during onboarding uploads when only the public keys are configured.
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Missing Supabase configuration');
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
 
 export default supabase;


### PR DESCRIPTION
## Summary
- handle missing Supabase env vars with fallback to public config
- surface onboarding upload errors to users with toast messages

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Next.js interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68aa155d484c83319e57d5ec262bbeed