### PR TITLE
Require onboarding template selection and streamline invites

### DIFF
--- a/app/(withSidebar)/employees/EmployeesPageClient.tsx
+++ b/app/(withSidebar)/employees/EmployeesPageClient.tsx
@@ -135,47 +135,6 @@ function EmployeesContent() {
     }
   };
 
-  // 🟢 Handle onboarding
-  const [startingId, setStartingId] = useState<string | null>(null);
-  const handleStartOnboarding = async (employeeId: string) => {
-    if (!employeeId) return;
-    try {
-      setStartingId(employeeId);
-      const res = await fetch(`/api/onboarding/start`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ employeeId }),
-      });
-
-      if (res.status === 401) {
-        toast.error("You are not authorized to start onboarding");
-        return;
-      }
-      if (res.status === 404) {
-        const data = await res.json();
-        toast.error(data.error || "Employee not found");
-        return;
-      }
-      if (res.status === 409) {
-        const data = await res.json();
-        toast.warning(data.error || "Onboarding already in progress");
-        return;
-      }
-      if (!res.ok) {
-        const data = await res.json();
-        toast.error(data.error || "Failed to start onboarding");
-        return;
-      }
-
-      toast.success("Onboarding started");
-      fetchData(activeTab);
-    } catch (e) {
-      toast.error("Network error while starting onboarding");
-    } finally {
-      setStartingId(null);
-    }
-  };
-
   // 🟠 Handle offboarding
   const handleStartOffboarding = (employee: Employee) => {
     setSelectedEmployee(employee);
@@ -448,10 +407,7 @@ function EmployeesContent() {
                             }
                           }}
                         >
-                          Send login invite
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => startingId ? undefined : handleStartOnboarding(emp.id)} className={startingId === emp.id ? "opacity-50 cursor-not-allowed" : ""}>
-                          {startingId === emp.id ? "Starting…" : "Start Onboarding"}
+                          Resend invite
                         </DropdownMenuItem>
                         {emp.isActive && !emp.offboardingRecord && (
                           <DropdownMenuItem 

--- a/app/activate/ActivateClient.tsx
+++ b/app/activate/ActivateClient.tsx
@@ -7,7 +7,7 @@ export default function ActivateClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams?.get('token') ?? '';
-  const employeeId = searchParams?.get('employeeId') ?? '';
+  const redirect = searchParams?.get('redirect') ?? '/dashboard';
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -42,9 +42,7 @@ export default function ActivateClient() {
       if (!res.ok) throw new Error(data?.error || 'Something went wrong.');
 
       setSuccess('Password set! Redirecting...');
-      const target = employeeId
-        ? `/login?next=/${employeeId}/onboarding`
-        : '/login';
+      const target = `/login?next=${encodeURIComponent(redirect)}`;
       setTimeout(() => router.push(target), 1500);
     } catch (err: any) {
       setError(err.message || 'Unexpected error');

--- a/app/api/employees/[id]/send-invite/route.ts
+++ b/app/api/employees/[id]/send-invite/route.ts
@@ -27,7 +27,10 @@ export async function POST(_req: NextRequest, { params }: { params: { id: string
       create: { userId: employee.user.id, token: activationToken },
     });
 
-    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&employeeId=${employeeId}`;
+    const redirectPath = employee.onboardingTemplateId
+      ? `/${employee.id}/onboarding`
+      : `/dashboard`;
+    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
 
     await resend.emails.send({
       from: "onboarding@resend.dev",
@@ -35,7 +38,7 @@ export async function POST(_req: NextRequest, { params }: { params: { id: string
       subject: "Activate Your CoreNZ Account",
       html: `
         <p>Hi ${employee.user.firstName || ''},</p>
-        <p>Welcome to CoreNZ! Please click the link below to activate your account and set your password:</p>
+        <p>Welcome to CoreNZ! Please click the link below to activate your account and get started:</p>
         <p><a href="${activationLink}">Activate Your Account</a></p>
       `,
     });

--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -107,7 +107,6 @@ export async function POST(req: Request) {
       jobRoleId,
       departmentId,
       managerId,
-      startOnboarding,
       sendInviteNow,
       onboardingTemplateId,
     } = await req.json();
@@ -115,6 +114,13 @@ export async function POST(req: Request) {
     if (!firstName || !lastName || !email || !startDate || !role) {
       return NextResponse.json(
         { success: false, error: "Missing required fields." },
+        { status: 400 }
+      );
+    }
+
+    if (!onboardingTemplateId) {
+      return NextResponse.json(
+        { success: false, error: "Need to select onboarding template" },
         { status: 400 }
       );
     }
@@ -175,14 +181,17 @@ export async function POST(req: Request) {
     });
 
     // ✅ Create Employee linked to User
+    const normalizedTemplateId =
+      onboardingTemplateId === "none" ? undefined : onboardingTemplateId;
+
     const employee = await prisma.employee.create({
       data: {
         user: { connect: { id: user.id } },
         isActive: true,
         department: departmentId ? { connect: { id: departmentId } } : undefined,
         company: { connect: { id: companyId! } }, // ✅ use relation connect
-        onboardingTemplate: onboardingTemplateId
-          ? { connect: { id: onboardingTemplateId } }
+        onboardingTemplate: normalizedTemplateId
+          ? { connect: { id: normalizedTemplateId } }
           : undefined,
       },
     });
@@ -195,7 +204,10 @@ export async function POST(req: Request) {
       },
     });
 
-    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&employeeId=${employee.id}`;
+    const redirectPath = normalizedTemplateId
+      ? `/${employee.id}/onboarding`
+      : `/dashboard`;
+    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
 
     if (sendInviteNow) {
       await resend.emails.send({
@@ -204,26 +216,25 @@ export async function POST(req: Request) {
         subject: "Activate Your CoreNZ Account",
         html: `
           <p>Hi ${firstName},</p>
-          <p>Welcome to CoreNZ! Please click the link below to activate your account and set your password:</p>
+          <p>Welcome to CoreNZ! Please click the link below to activate your account and get started:</p>
           <p><a href="${activationLink}">Activate Your Account</a></p>
         `,
       });
     }
 
     // ✅ Optional onboarding trigger
-    if (startOnboarding) {
+    if (normalizedTemplateId) {
       try {
-        // Hit our start endpoint to create instance + assignment and send onboarding email
         const startRes = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/onboarding/start`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            // forward auth cookies so the onboarding API can authenticate the request
             cookie: req.headers.get("cookie") ?? "",
           },
           body: JSON.stringify({
             employeeId: employee.id,
-            templateId: onboardingTemplateId,
+            templateId: normalizedTemplateId,
+            sendEmail: false,
           }),
         });
 

--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { employeeId, templateId: rawTemplateId } = await req.json();
+    const { employeeId, templateId: rawTemplateId, sendEmail = true } = await req.json();
     if (!employeeId) {
       return NextResponse.json({ error: "employeeId is required" }, { status: 400 });
     }
@@ -119,25 +119,26 @@ export async function POST(req: NextRequest) {
       return { assignment, onboardingInstance };
     });
 
-    // Send onboarding invitation to employee
-    try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL || "";
-      const onboardingLink = `${baseUrl}/${employee.id}/onboarding`;
-      const loginWithNext = `${baseUrl}/login?next=/${employee.id}/onboarding`;
-      await resend.emails.send({
-        from: "CoreNZ Notifications <onboarding@resend.dev>",
-        to: user.email,
-        subject: "Welcome to CoreNZ – Your onboarding is ready",
-        html: `
-          <p>Hi ${user.firstName || "there"},</p>
-          <p>Your onboarding has been started. Please log in and complete your onboarding steps.</p>
-          <p><a href="${loginWithNext}">Login to start onboarding</a></p>
-          <p>Thank you,<br/>HR Team</p>
-        `,
-      });
-    } catch (e) {
-      console.error("Failed to send onboarding email:", e);
-      // continue without failing the request
+    if (sendEmail) {
+      try {
+        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL || "";
+        const onboardingLink = `${baseUrl}/${employee.id}/onboarding`;
+        const loginWithNext = `${baseUrl}/login?next=/${employee.id}/onboarding`;
+        await resend.emails.send({
+          from: "CoreNZ Notifications <onboarding@resend.dev>",
+          to: user.email,
+          subject: "Welcome to CoreNZ – Your onboarding is ready",
+          html: `
+            <p>Hi ${user.firstName || "there"},</p>
+            <p>Your onboarding has been started. Please log in and complete your onboarding steps.</p>
+            <p><a href="${loginWithNext}">Login to start onboarding</a></p>
+            <p>Thank you,<br/>HR Team</p>
+          `,
+        });
+      } catch (e) {
+        console.error("Failed to send onboarding email:", e);
+        // continue without failing the request
+      }
     }
 
     return NextResponse.json(result, { status: 201 });

--- a/app/components/employees/AddEmployeeModal.tsx
+++ b/app/components/employees/AddEmployeeModal.tsx
@@ -6,8 +6,9 @@ import { Input } from "@/components/ui/Input";
 import NewDepartmentModal from "@/components/shared/NewDepartmentModal";
 import NewJobRoleModal from "@/components/shared/NewJobRoleModal";
 import { useSession } from "next-auth/react";
+import { toast } from "sonner";
 
-// 👇 Toggles
+// 👇 Toggle
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 
@@ -46,8 +47,7 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
     onboardingTemplateId: "",
   });
 
-  // Toggles
-  const [startOnboarding, setStartOnboarding] = useState(true);
+  // Toggle
   const [sendInviteNow, setSendInviteNow] = useState(true);
 
   const fetchData = async () => {
@@ -83,17 +83,16 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      if (startOnboarding && !formData.onboardingTemplateId) {
-        setError("Please select an onboarding template");
+      if (!formData.onboardingTemplateId) {
+        toast.error("Need to select onboarding template");
         return;
       }
 
       const payload = {
         ...formData,
         companyId: session?.user?.companyId,
-        startOnboarding, // 👈 Pass to backend
-        sendInviteNow,   // 👈 Pass to backend
-        onboardingTemplateId: startOnboarding ? formData.onboardingTemplateId : undefined,
+        sendInviteNow, // 👈 Pass to backend
+        onboardingTemplateId: formData.onboardingTemplateId,
       };
 
       const res = await fetch("/api/employees", {
@@ -122,7 +121,6 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
         managerId: "",
         onboardingTemplateId: "",
       });
-      setStartOnboarding(true);
       setSendInviteNow(true);
 
       onClose();
@@ -201,40 +199,27 @@ export default function AddEmployeeModal({ open, onClose, onSuccess }: AddEmploy
               )}
             </select>
 
-            {/* Toggles */}
+            {/* Toggle */}
             <div className="flex flex-col gap-3">
               <div className="flex items-center gap-2">
                 <Switch checked={sendInviteNow} onChange={(checked: boolean) => setSendInviteNow(checked)} />
                 <Label className="text-sm">Send login invite now</Label>
               </div>
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={startOnboarding}
-                  onChange={(checked: boolean) => {
-                    setStartOnboarding(checked);
-                    if (!checked) {
-                      setFormData((prev) => ({ ...prev, onboardingTemplateId: "" }));
-                    }
-                  }}
-                />
-                <Label className="text-sm">Start onboarding now (will email onboarding link)</Label>
-              </div>
             </div>
 
-            {startOnboarding && (
-              <select
-                name="onboardingTemplateId"
-                value={formData.onboardingTemplateId}
-                onChange={handleChange}
-                className="w-full border border-gray-300 rounded-md px-3 py-2"
-                required
-              >
-                <option value="">Select Onboarding Template</option>
-                {filteredTemplates.map((t) => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-            )}
+            <select
+              name="onboardingTemplateId"
+              value={formData.onboardingTemplateId}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              required
+            >
+              <option value="">Select Onboarding Template</option>
+              <option value="none">None</option>
+              {filteredTemplates.map((t) => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
+            </select>
 
             <div className="flex justify-end space-x-2">
               <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>


### PR DESCRIPTION
## Summary
- Remove onboarding toggle and enforce selecting an onboarding template (including 'None') when adding employees
- Simplify activation email and redirect employees without a template to the dashboard
- Drop Start Onboarding action from employee list and keep a single Resend invite option

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Next.js eslint config prompt)


------
https://chatgpt.com/codex/tasks/task_e_68ac38a7f65c833197f570ce359d08e2