### PR TITLE
feat: improve onboarding template editing

### DIFF
--- a/app/(withSidebar)/settings/onboarding/page.tsx
+++ b/app/(withSidebar)/settings/onboarding/page.tsx
@@ -18,6 +18,8 @@ type Template = {
   departments: { id: string; name: string }[];
   jobRoles: { id: string; name: string }[];
   steps: any[];
+  updatedAt?: string;
+  updatedBy?: { id: string; name?: string; email?: string } | null;
 };
 
 export default function OnboardingSettingsPage() {
@@ -64,7 +66,11 @@ export default function OnboardingSettingsPage() {
 
   const handleDelete = async (template: Template) => {
     if (!confirm("Delete this onboarding template?")) return;
-    const res = await fetch(`/api/onboarding/templates/${template.id}`, { method: "DELETE" });
+    const res = await fetch('/api/onboarding/templates', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: template.id }),
+    });
     if (res.ok) {
       toast("Template deleted");
       fetchTemplates();

--- a/app/api/onboarding/templates/route.ts
+++ b/app/api/onboarding/templates/route.ts
@@ -46,6 +46,8 @@ export async function GET(req: Request) {
       name: true,
       description: true,
       isActive: true, // ✅ Boolean field replaces status
+      updatedAt: true,
+      updatedBy: { select: { id: true, name: true, email: true } },
       departments: { select: { id: true, name: true } },
       jobRoles: { select: { id: true, name: true } },
       steps: {
@@ -97,6 +99,7 @@ export async function POST(req: Request) {
         description: description || "",
         companyId: session.user.companyId,
         isActive: Boolean(isActive), // ✅ Safe boolean
+        updatedById: session.user.id,
         departments: departments.length > 0 ? { connect: departments.map((id: string) => ({ id })) } : undefined,
         jobRoles: jobRoles.length > 0 ? { connect: jobRoles.map((id: string) => ({ id })) } : undefined,
         steps: filteredSteps.length > 0 ? { create: filteredSteps } : undefined,
@@ -105,6 +108,7 @@ export async function POST(req: Request) {
         departments: { select: { id: true, name: true } },
         jobRoles: { select: { id: true, name: true } },
         steps: true,
+        updatedBy: { select: { id: true, name: true, email: true } },
       },
     });
 
@@ -124,14 +128,39 @@ export async function PUT(req: Request) {
 
   try {
     const body = await req.json();
-    const { id, name, description, departments = [], jobRoles = [], isActive } = body;
+    const { id, name, description, departments = [], jobRoles = [], steps = [], isActive } = body;
+
+    // Rebuild steps
+    const filteredSteps = Array.isArray(steps)
+      ? (steps
+          .map((step: any, i: number) => {
+            const mappedType = typeMap[step.type];
+            if (!mappedType) return undefined;
+            const base = { type: mappedType, label: step.label || step.title || "", order: i + 1 };
+            if (mappedType === OnboardingStepType.ACKNOWLEDGE_DOCUMENT) {
+              return { ...base, documentId: step.documentId || null };
+            }
+            if (mappedType === OnboardingStepType.UPLOAD_DOCUMENT) {
+              return { ...base, uploadType: step.uploadType ? uploadTypeMap[step.uploadType] || null : null };
+            }
+            if (mappedType === OnboardingStepType.INSTRUCTION) {
+              return { ...base, instruction: step.description || "" };
+            }
+            return undefined;
+          })
+          .filter(isStep)) as Prisma.OnboardingStepCreateInput[]
+      : [];
+
+    // Replace steps to allow edits
+    await prisma.onboardingStep.deleteMany({ where: { templateId: id } });
 
     const template = await prisma.onboardingTemplate.update({
       where: { id },
       data: {
         name,
         description: description || "",
-        isActive: Boolean(isActive), // ✅ Handles toggle
+        isActive: Boolean(isActive),
+        updatedById: session.user.id,
         departments: {
           set: [],
           connect: departments.length > 0 ? departments.map((id: string) => ({ id })) : [],
@@ -140,11 +169,13 @@ export async function PUT(req: Request) {
           set: [],
           connect: jobRoles.length > 0 ? jobRoles.map((id: string) => ({ id })) : [],
         },
+        steps: filteredSteps.length > 0 ? { create: filteredSteps } : undefined,
       },
       include: {
         departments: { select: { id: true, name: true } },
         jobRoles: { select: { id: true, name: true } },
         steps: true,
+        updatedBy: { select: { id: true, name: true, email: true } },
       },
     });
 

--- a/app/components/onboarding/OnboardingTemplateEditor.tsx
+++ b/app/components/onboarding/OnboardingTemplateEditor.tsx
@@ -7,7 +7,7 @@ import Button from "@/components/ui/Button";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { MultiSelect } from "@/components/ui/MultiSelect";
-import { X, GripVertical, FileText, UploadCloud, FileEdit, Info } from "lucide-react";
+import { X, GripVertical, FileText, UploadCloud, FileEdit, Info, RotateCcw } from "lucide-react";
 import { toast } from "sonner";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { DialogFooter } from "@/components/ui/dialog";
@@ -20,6 +20,20 @@ const STEP_TYPES = [
   { value: "fill-form", label: "Fill Form", icon: FileEdit },
   { value: "instructions", label: "Welcome/Instructions", icon: Info },
 ];
+
+const dbTypeToUi: Record<string, string> = {
+  ACKNOWLEDGE_DOCUMENT: "acknowledge-document",
+  UPLOAD_DOCUMENT: "upload-document",
+  INSTRUCTION: "instructions",
+};
+
+const dbUploadTypeToUi: Record<string, string> = {
+  PASSPORT: "passport",
+  RIGHT_TO_WORK: "right-to-work",
+  DRIVER_LICENSE: "driver-licence",
+  TRAINING_CERTIFICATE: "training-certificate",
+  OTHER: "other",
+};
 
 // --- Key generator utility
 function getStepKey(step: any) {
@@ -246,8 +260,21 @@ export default function OnboardingTemplateEditor({
   const [steps, setSteps] = useState<any[]>(() =>
     template?.steps?.length
       ? template.steps.map((step: any) => ({
-          ...step,
-          key: step.id || step.key || (typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)),
+          key:
+            step.id ||
+            step.key ||
+            (typeof crypto !== "undefined" && crypto.randomUUID
+              ? crypto.randomUUID()
+              : Math.random().toString(36).slice(2)),
+          id: step.id,
+          type: dbTypeToUi[step.type] || step.type,
+          title: step.label || "",
+          description: step.instruction || "",
+          required: step.required ?? true,
+          documentId: step.documentId || "",
+          uploadType: step.uploadType ? dbUploadTypeToUi[step.uploadType] : "",
+          formId: step.formId || "",
+          formFields: step.formFields || [],
         }))
       : []
   );
@@ -290,6 +317,9 @@ export default function OnboardingTemplateEditor({
       toast.error("Template name required");
       return;
     }
+    toast.info(
+      "This will not affect previously completed versions of this template, and any outstanding templates will not be altered. This will purely be for any future new starters onboarding using this template"
+    );
     setSaving(true);
     const body = {
       id: template?.id,
@@ -305,14 +335,11 @@ export default function OnboardingTemplateEditor({
       })),
       isActive: publish,
     };
-    const res = await fetch(
-      template?.id ? `/api/onboarding/templates/${template.id}` : "/api/onboarding/templates",
-      {
-        method: template?.id ? "PATCH" : "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      }
-    );
+    const res = await fetch("/api/onboarding/templates", {
+      method: template?.id ? "PUT" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
     setSaving(false);
     setPublishing(false);
 
@@ -359,6 +386,15 @@ export default function OnboardingTemplateEditor({
     <div className="p-6">
       <div className="mb-4">
         <h2 className="text-xl font-bold mb-2">{template ? "Edit Onboarding Template" : "New Onboarding Template"}</h2>
+        {template?.updatedAt && (
+          <div className="flex items-center text-sm text-gray-500 gap-2 mb-2">
+            <RotateCcw className="h-4 w-4" />
+            <span>
+              Last updated {new Date(template.updatedAt).toLocaleString()} by{' '}
+              {template.updatedBy?.name || template.updatedBy?.email || 'Unknown'}
+            </span>
+          </div>
+        )}
         <Label>Template Name</Label>
         <Input className="mb-3" value={name} onChange={e => setName(e.target.value)} maxLength={60} />
         <Label>Description</Label>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   newsPosts                                    NewsPost[]
   onboardingAssignments                        OnboardingAssignment[]
   SavedReport                                  SavedReport[]
+  updatedTemplates                             OnboardingTemplate[] @relation("OnboardingTemplateUpdatedBy")
   
   // Offboarding relations
   offboardingInitiated                         EmployeeOffboarding[]  @relation("OffboardingInitiatedBy")
@@ -470,6 +471,7 @@ model OnboardingTemplate {
   companyId             String
   createdAt             DateTime               @default(now())
   updatedAt             DateTime               @updatedAt
+  updatedById           String?
   isActive              Boolean                @default(false)
   employees             Employee[]             @relation("OnboardingTemplateEmployees")
   onboardingAssignments OnboardingAssignment[]
@@ -478,6 +480,7 @@ model OnboardingTemplate {
   company               Company                @relation(fields: [companyId], references: [id])
   departments           Department[]           @relation("OnboardingTemplateDepartments")
   jobRoles              JobRole[]              @relation("OnboardingTemplateJobRoles")
+  updatedBy             User?                  @relation("OnboardingTemplateUpdatedBy", fields: [updatedById], references: [id])
 
   @@unique([companyId, name])
 }


### PR DESCRIPTION
## Summary
- allow onboarding steps to be edited and saved through API PUT route
- track who last updated an onboarding template and show version metadata in editor
- display informative notice when saving templates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive configuration prompt)*
- `npx prisma migrate dev --name add_onboarding_template_updated_by` *(fails: Can't reach database server)*
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b0cfeb08331b65194e401116e2e