### PR TITLE
fix: persist form steps in onboarding templates

### DIFF
--- a/app/api/onboarding/instances/[employeeId]/route.ts
+++ b/app/api/onboarding/instances/[employeeId]/route.ts
@@ -6,6 +6,7 @@ const mapStepType = (type: string) => {
     case 'ACKNOWLEDGE_DOCUMENT': return 'acknowledge-document';
     case 'UPLOAD_DOCUMENT': return 'upload-document';
     case 'INSTRUCTION': return 'instructions';
+    case 'FORM_FILL': return 'fill-form';
     default: return type.toLowerCase();
   }
 };
@@ -29,7 +30,10 @@ export async function GET(
         template: {
           include: {
             steps: {
-              include: { document: true }, // include linked document for ACK steps
+              include: {
+                document: true,
+                form: { select: { id: true, name: true } },
+              }, // include linked document for ACK steps
             },
           },
         },
@@ -58,6 +62,7 @@ export async function GET(
               url: tStep.document.url,
             }
           : undefined,
+        formId: tStep.formId ?? undefined,
         order: tStep.order,
         status: instStep?.status || 'pending',
       };

--- a/app/api/onboarding/templates/actions.ts
+++ b/app/api/onboarding/templates/actions.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@/lib/prisma';
+import { mapSteps } from './stepMapper';
+
+export async function createTemplate(
+  session: any,
+  body: any,
+  prismaClient = prisma
+) {
+  const { name, description, departments = [], jobRoles = [], steps = [], isActive = false } = body;
+  const filteredSteps = mapSteps(steps);
+  return prismaClient.onboardingTemplate.create({
+    data: {
+      name,
+      description: description || '',
+      companyId: session.user.companyId,
+      isActive: Boolean(isActive),
+      updatedById: session.user.id,
+      departments: departments.length > 0 ? { connect: departments.map((id: string) => ({ id })) } : undefined,
+      jobRoles: jobRoles.length > 0 ? { connect: jobRoles.map((id: string) => ({ id })) } : undefined,
+      steps: filteredSteps.length > 0 ? { create: filteredSteps } : undefined,
+    },
+    include: {
+      departments: { select: { id: true, name: true } },
+      jobRoles: { select: { id: true, name: true } },
+      steps: true,
+      updatedBy: { select: { id: true, name: true, email: true } },
+    },
+  });
+}

--- a/app/api/onboarding/templates/route.ts
+++ b/app/api/onboarding/templates/route.ts
@@ -2,35 +2,9 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { Prisma, OnboardingStepType, OnboardingUploadType } from "@prisma/client";
-
-// Type guard to validate onboarding steps
-function isStep(
-  step: any
-): step is {
-  type: OnboardingStepType;
-  label: string;
-  order: number;
-  documentId?: string | null;
-  uploadType?: OnboardingUploadType | null;
-  instruction?: string | null;
-} {
-  return !!step;
-}
-
-const typeMap: Record<string, OnboardingStepType> = {
-  "acknowledge-document": OnboardingStepType.ACKNOWLEDGE_DOCUMENT,
-  "upload-document": OnboardingStepType.UPLOAD_DOCUMENT,
-  "instructions": OnboardingStepType.INSTRUCTION,
-};
-
-const uploadTypeMap: Record<string, OnboardingUploadType> = {
-  "passport": OnboardingUploadType.PASSPORT,
-  "right-to-work": OnboardingUploadType.RIGHT_TO_WORK,
-  "driver-licence": OnboardingUploadType.DRIVER_LICENSE,
-  "training-certificate": OnboardingUploadType.TRAINING_CERTIFICATE,
-  "other": OnboardingUploadType.OTHER,
-};
+import { Prisma } from "@prisma/client";
+import { mapSteps } from "./stepMapper";
+import { createTemplate } from "./actions";
 
 // ✅ GET - Fetch Templates
 export async function GET(req: Request) {
@@ -52,7 +26,10 @@ export async function GET(req: Request) {
       jobRoles: { select: { id: true, name: true } },
       steps: {
         orderBy: { order: "asc" },
-        include: { document: { select: { id: true, name: true } } },
+        include: {
+          document: { select: { id: true, name: true } },
+          form: { select: { id: true, name: true } },
+        },
       },
     },
     orderBy: { createdAt: "asc" },
@@ -70,47 +47,7 @@ export async function POST(req: Request) {
 
   try {
     const body = await req.json();
-    const { name, description, departments = [], jobRoles = [], steps = [], isActive = false } = body;
-
-    // Filter steps to only allow valid enums
-    const filteredSteps = Array.isArray(steps)
-      ? (steps
-          .map((step: any, i: number) => {
-            const mappedType = typeMap[step.type];
-            if (!mappedType) return undefined;
-            const base = { type: mappedType, label: step.label || step.title || "", order: i + 1 };
-            if (mappedType === OnboardingStepType.ACKNOWLEDGE_DOCUMENT) {
-              return { ...base, documentId: step.documentId || null };
-            }
-            if (mappedType === OnboardingStepType.UPLOAD_DOCUMENT) {
-              return { ...base, uploadType: step.uploadType ? uploadTypeMap[step.uploadType] || null : null };
-            }
-            if (mappedType === OnboardingStepType.INSTRUCTION) {
-              return { ...base, instruction: step.description || "" };
-            }
-            return undefined;
-          })
-          .filter(isStep)) as Prisma.OnboardingStepCreateInput[]
-      : [];
-
-    const template = await prisma.onboardingTemplate.create({
-      data: {
-        name,
-        description: description || "",
-        companyId: session.user.companyId,
-        isActive: Boolean(isActive), // ✅ Safe boolean
-        updatedById: session.user.id,
-        departments: departments.length > 0 ? { connect: departments.map((id: string) => ({ id })) } : undefined,
-        jobRoles: jobRoles.length > 0 ? { connect: jobRoles.map((id: string) => ({ id })) } : undefined,
-        steps: filteredSteps.length > 0 ? { create: filteredSteps } : undefined,
-      },
-      include: {
-        departments: { select: { id: true, name: true } },
-        jobRoles: { select: { id: true, name: true } },
-        steps: true,
-        updatedBy: { select: { id: true, name: true, email: true } },
-      },
-    });
+    const template = await createTemplate(session, body);
 
     return NextResponse.json(template);
   } catch (err) {
@@ -130,28 +67,8 @@ export async function PUT(req: Request) {
     const body = await req.json();
     const { id, name, description, departments = [], jobRoles = [], steps = [], isActive } = body;
 
-    // Rebuild steps
-    const filteredSteps = Array.isArray(steps)
-      ? (steps
-          .map((step: any, i: number) => {
-            const mappedType = typeMap[step.type];
-            if (!mappedType) return undefined;
-            const base = { type: mappedType, label: step.label || step.title || "", order: i + 1 };
-            if (mappedType === OnboardingStepType.ACKNOWLEDGE_DOCUMENT) {
-              return { ...base, documentId: step.documentId || null };
-            }
-            if (mappedType === OnboardingStepType.UPLOAD_DOCUMENT) {
-              return { ...base, uploadType: step.uploadType ? uploadTypeMap[step.uploadType] || null : null };
-            }
-            if (mappedType === OnboardingStepType.INSTRUCTION) {
-              return { ...base, instruction: step.description || "" };
-            }
-            return undefined;
-          })
-          .filter(isStep)) as Prisma.OnboardingStepCreateInput[]
-      : [];
+    const filteredSteps = mapSteps(steps);
 
-    // Replace steps to allow edits
     await prisma.onboardingStep.deleteMany({ where: { templateId: id } });
 
     const template = await prisma.onboardingTemplate.update({

--- a/app/api/onboarding/templates/stepMapper.ts
+++ b/app/api/onboarding/templates/stepMapper.ts
@@ -1,0 +1,53 @@
+import { Prisma, OnboardingStepType, OnboardingUploadType } from '@prisma/client';
+
+const typeMap: Record<string, OnboardingStepType> = {
+  'acknowledge-document': OnboardingStepType.ACKNOWLEDGE_DOCUMENT,
+  'upload-document': OnboardingStepType.UPLOAD_DOCUMENT,
+  'instructions': OnboardingStepType.INSTRUCTION,
+  'fill-form': OnboardingStepType.FORM_FILL,
+};
+
+const uploadTypeMap: Record<string, OnboardingUploadType> = {
+  'passport': OnboardingUploadType.PASSPORT,
+  'right-to-work': OnboardingUploadType.RIGHT_TO_WORK,
+  'driver-licence': OnboardingUploadType.DRIVER_LICENSE,
+  'training-certificate': OnboardingUploadType.TRAINING_CERTIFICATE,
+  'other': OnboardingUploadType.OTHER,
+};
+
+function isStep(step: any): step is {
+  type: OnboardingStepType;
+  label: string;
+  order: number;
+  documentId?: string | null;
+  uploadType?: OnboardingUploadType | null;
+  instruction?: string | null;
+  formId?: string | null;
+} {
+  return !!step;
+}
+
+export function mapSteps(steps: any[]): Prisma.OnboardingStepCreateInput[] {
+  return Array.isArray(steps)
+    ? (steps
+        .map((step: any, i: number) => {
+          const mappedType = typeMap[step.type];
+          if (!mappedType) return undefined;
+          const base = { type: mappedType, label: step.label || step.title || '', order: i + 1 };
+          if (mappedType === OnboardingStepType.ACKNOWLEDGE_DOCUMENT) {
+            return { ...base, documentId: step.documentId || null };
+          }
+          if (mappedType === OnboardingStepType.UPLOAD_DOCUMENT) {
+            return { ...base, uploadType: step.uploadType ? uploadTypeMap[step.uploadType] || null : null };
+          }
+          if (mappedType === OnboardingStepType.INSTRUCTION) {
+            return { ...base, instruction: step.description || '' };
+          }
+          if (mappedType === OnboardingStepType.FORM_FILL) {
+            return { ...base, formId: step.formId || null };
+          }
+          return undefined;
+        })
+        .filter(isStep)) as Prisma.OnboardingStepCreateInput[]
+    : [];
+}

--- a/app/components/onboarding/OnboardingStepRenderer.tsx
+++ b/app/components/onboarding/OnboardingStepRenderer.tsx
@@ -118,7 +118,7 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
   }
 
   // ✅ Fill Form
-  if (step.type === "fill-form") {
+  if (step.type === "fill-form" || step.type === "form_fill") {
     if (step.formId) {
       return (
         <Card className="p-4">

--- a/app/components/onboarding/OnboardingTemplateEditor.tsx
+++ b/app/components/onboarding/OnboardingTemplateEditor.tsx
@@ -25,6 +25,7 @@ const dbTypeToUi: Record<string, string> = {
   ACKNOWLEDGE_DOCUMENT: "acknowledge-document",
   UPLOAD_DOCUMENT: "upload-document",
   INSTRUCTION: "instructions",
+  FORM_FILL: "fill-form",
 };
 
 const dbUploadTypeToUi: Record<string, string> = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "tsx --test tests/**/*.test.ts"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/prisma/migrations/20250825160000_add_form_fill_step/migration.sql
+++ b/prisma/migrations/20250825160000_add_form_fill_step/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "OnboardingStepType" ADD VALUE IF NOT EXISTS 'FORM_FILL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -651,6 +651,7 @@ enum OnboardingStepType {
   ACKNOWLEDGE_DOCUMENT
   UPLOAD_DOCUMENT
   INSTRUCTION
+  FORM_FILL
 }
 
 enum OnboardingUploadType {

--- a/tests/onboardingInstances.test.ts
+++ b/tests/onboardingInstances.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/db';
+
+import { prisma } from '../app/lib/prisma';
+import { GET } from '../app/api/onboarding/instances/[employeeId]/route';
+
+// Ensure NextRequest is available for instantiation
+import { NextRequest } from 'next/server';
+
+test('GET onboarding instance maps FORM_FILL steps', async () => {
+  (prisma as any).onboardingInstance = {
+    findFirst: async () => ({
+      id: 'inst1',
+      steps: [],
+      template: {
+        name: 'Template',
+        steps: [
+          {
+            id: 'step1',
+            type: 'FORM_FILL',
+            label: 'Fill Form',
+            instruction: null,
+            uploadType: null,
+            documentId: null,
+            document: null,
+            formId: 'form123',
+            order: 1,
+          },
+        ],
+      },
+    }),
+  };
+
+  const req = new NextRequest('http://localhost');
+  const res = await GET(req, { params: { employeeId: 'e1' } });
+  const data = await res.json();
+  assert.equal(data.steps[0].type, 'fill-form');
+  assert.equal(data.steps[0].formId, 'form123');
+});

--- a/tests/onboardingTemplates.test.ts
+++ b/tests/onboardingTemplates.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+
+// Ensure Prisma client can be instantiated without real DB
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/db';
+
+import { OnboardingStepType } from '@prisma/client';
+import { prisma } from '../app/lib/prisma';
+
+test('mapSteps includes FORM_FILL steps', async () => {
+  const { mapSteps } = await import('../app/api/onboarding/templates/stepMapper');
+  const result = mapSteps([
+    { type: 'fill-form', label: 'Form step', formId: 'form123' },
+  ]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].type, OnboardingStepType.FORM_FILL);
+  assert.equal(result[0].formId, 'form123');
+});
+
+test('createTemplate persists FORM_FILL step and returns it', async () => {
+  const prismaMock = {
+    onboardingTemplate: {
+      create: async (args: any) => ({
+        ...args.data,
+        steps: args.data.steps?.create || [],
+      }),
+    },
+  };
+
+  const { createTemplate } = await import('../app/api/onboarding/templates/actions');
+
+  const session = { user: { companyId: 'c1', id: 'u1' } };
+  const body = {
+    name: 'Template',
+    description: '',
+    steps: [
+      { type: 'fill-form', label: 'Fill Form', formId: 'form123' },
+    ],
+  };
+
+  const result = await createTemplate(session, body, prismaMock as any);
+  assert.equal(result.steps.length, 1);
+  assert.equal(result.steps[0].type, OnboardingStepType.FORM_FILL);
+  assert.equal(result.steps[0].formId, 'form123');
+});


### PR DESCRIPTION
## Summary
- allow FORM_FILL steps in onboarding template API and schema
- map FORM_FILL steps in editor and API serializers
- test step mapping and template creation with forms
- map FORM_FILL steps for onboarding instances and render them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac861537c48331bca7e633640a7620