### PR TITLE
Persist onboarding form responses

### DIFF
--- a/app/components/onboarding/OnboardingStepRenderer.tsx
+++ b/app/components/onboarding/OnboardingStepRenderer.tsx
@@ -154,7 +154,12 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
             employeeId={employeeId}
             onSubmitSuccess={(data) => {
               setLoading(true);
-              onComplete(data);
+              // Wrap the response so API can persist it
+              onComplete({ formResponse: data });
+              // Ensure any uploaded docs appear in employee documents list
+              window.dispatchEvent(
+                new CustomEvent('employee-documents-updated', { detail: { employeeId } })
+              );
             }}
           />
         </Card>
@@ -167,7 +172,13 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
         <Card className="p-4">
           <div className="mb-2 font-semibold">{title}</div>
           <div className="mb-3 text-sm">{desc}</div>
-          <form onSubmit={e => { e.preventDefault(); setLoading(true); onComplete(formValues); }}>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              setLoading(true);
+              onComplete({ formResponse: formValues });
+            }}
+          >
             {step.formFields.map((f, idx) => (
               <div key={idx} className="mb-2">
                 <label>{f.label}</label>

--- a/tests/onboardingStepRenderer.test.ts
+++ b/tests/onboardingStepRenderer.test.ts
@@ -38,3 +38,28 @@ test('passes employeeId to DynamicFormRenderer', () => {
   );
   assert.equal(capturedProps.employeeId, 'emp123');
 });
+
+test('wraps submitted data and dispatches document update', () => {
+  const step = { id: 's1', type: 'fill-form', formId: 'f1', title: 'Form', description: '' };
+  let received: any = null;
+  const events: any[] = [];
+  // listen for custom event
+  (global as any).window = {
+    dispatchEvent: (e: any) => events.push(e.detail),
+    addEventListener: () => {},
+  } as any;
+
+  renderToString(
+    React.createElement(OnboardingStepRenderer, {
+      step,
+      onComplete: (d: any) => { received = d; },
+      employeeId: 'emp123',
+    })
+  );
+
+  // simulate form submission
+  capturedProps.onSubmitSuccess({ foo: 'bar' });
+
+  assert.deepEqual(received, { formResponse: { foo: 'bar' } });
+  assert.deepEqual(events[0], { employeeId: 'emp123' });
+});


### PR DESCRIPTION
## Summary
- ensure onboarding form responses are sent in `formResponse` envelope and trigger document list refresh
- cover form submission wrapper and event dispatch in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acbc6d54ec8331902ec57fe6cfc567