### PR TITLE
Persist onboarding form responses

### DIFF
--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -114,7 +114,12 @@ export function EnhancedFormRenderer({ formId, employeeId, onDataChange }: Enhan
             if (!uploadResult?.document) { toast.error(`Failed to upload file for ${field.label}`); return; }
             data[field.id] = uploadResult.document;
           } catch { toast.error(`Upload error: ${field.label}`); return; }
-        } else data[field.id] = null;
+        } else if (rawData[field.id]?.url) {
+          // keep existing document if no new file selected
+          data[field.id] = rawData[field.id];
+        } else {
+          data[field.id] = null;
+        }
       }
     }
 
@@ -173,17 +178,33 @@ export function EnhancedFormRenderer({ formId, employeeId, onDataChange }: Enhan
   );
 }
 
-function renderField(field: FormField, register: any, watch: any, setValue: any) {
+export function renderField(field: FormField, register: any, watch: any, setValue: any) {
   const baseInput = 'border rounded px-3 py-2 w-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400 transition';
 
   switch (field.type) {
     case 'file':
+      const existing = watch(field.id);
       return (
-        <input
-          type="file"
-          className="border rounded px-3 py-2 w-full text-sm"
-          {...register(field.id, { required: field.required })}
-        />
+        <div className="space-y-2">
+          {existing?.url && (
+            <div className="space-y-2">
+              <iframe src={existing.url} className="w-full h-64 rounded border" />
+              <a
+                href={existing.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline block"
+              >
+                {existing.name || 'View document'}
+              </a>
+            </div>
+          )}
+          <input
+            type="file"
+            className="border rounded px-3 py-2 w-full text-sm"
+            {...register(field.id, { required: field.required })}
+          />
+        </div>
       );
 
     case 'text':

--- a/app/components/onboarding/OnboardingStepRenderer.tsx
+++ b/app/components/onboarding/OnboardingStepRenderer.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/textarea";
 import { useSession } from "next-auth/react";
 import { DynamicFormRenderer } from "@/components/forms/DynamicFormRenderer";
+import { EnhancedFormRenderer } from "@/components/forms/EnhancedFormRenderer";
 import { toast } from "sonner";
 
 type OnboardingStepProps = {
@@ -17,6 +18,7 @@ type OnboardingStepProps = {
     instruction?: string;
     formFields?: { label: string; type: string }[];
     formId?: string; // ID of reusable form schema
+    form?: { formType: "SUBMISSION" | "DATA_SCREEN" };
     document?: { id: string; name: string; url: string };
     category?: string;
   };
@@ -32,6 +34,18 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
   const [ack, setAck] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [formValues, setFormValues] = useState<{ [key: string]: string }>({});
+  const [formType, setFormType] = useState<"SUBMISSION" | "DATA_SCREEN" | null>(step.form?.formType || null);
+
+  useEffect(() => {
+    if (!formType && step.formId) {
+      fetch(`/api/forms/${step.formId}`)
+        .then((res) => res.ok ? res.json() : null)
+        .then((data) => {
+          if (data?.formType) setFormType(data.formType);
+        })
+        .catch(() => {});
+    }
+  }, [formType, step.formId]);
 
   const title = step.title || step.label || "Untitled Step";
   const desc = step.description || step.instruction || "";
@@ -145,18 +159,39 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
   // ✅ Fill Form
   if (step.type === "fill-form" || step.type === "form_fill") {
     if (step.formId) {
+      if (!formType) {
+        return (
+          <Card className="p-4">
+            <div className="mb-2 font-semibold">{title}</div>
+            <div className="mb-3 text-sm">{desc}</div>
+            <div>Loading form...</div>
+          </Card>
+        );
+      }
+
+      const handleComplete = (data: any) => {
+        setLoading(true);
+        onComplete({ formResponse: data });
+        window.dispatchEvent(new CustomEvent('employee-documents-updated', { detail: { employeeId } }));
+      };
+
       return (
         <Card className="p-4">
           <div className="mb-2 font-semibold">{title}</div>
           <div className="mb-3 text-sm">{desc}</div>
-          <DynamicFormRenderer
-            formId={step.formId}
-            employeeId={employeeId}
-            onSubmitSuccess={(data) => {
-              setLoading(true);
-              onComplete(data);
-            }}
-          />
+          {formType === 'DATA_SCREEN' ? (
+            <EnhancedFormRenderer
+              formId={step.formId}
+              employeeId={employeeId || ''}
+              onDataChange={handleComplete}
+            />
+          ) : (
+            <DynamicFormRenderer
+              formId={step.formId}
+              employeeId={employeeId}
+              onSubmitSuccess={handleComplete}
+            />
+          )}
         </Card>
       );
     }
@@ -167,7 +202,13 @@ export default function OnboardingStepRenderer({ step, onComplete, readOnly = fa
         <Card className="p-4">
           <div className="mb-2 font-semibold">{title}</div>
           <div className="mb-3 text-sm">{desc}</div>
-          <form onSubmit={e => { e.preventDefault(); setLoading(true); onComplete(formValues); }}>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              setLoading(true);
+              onComplete({ formResponse: formValues });
+            }}
+          >
             {step.formFields.map((f, idx) => (
               <div key={idx} className="mb-2">
                 <label>{f.label}</label>

--- a/tests/enhancedFormRenderer.test.ts
+++ b/tests/enhancedFormRenderer.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { renderField } from '../app/components/forms/EnhancedFormRenderer';
+
+(global as any).React = React;
+
+test('renders existing document preview for file fields', () => {
+  const field: any = { id: 'f1', type: 'file', label: 'Doc', required: false };
+  const register = () => ({ });
+  const watch = (id: string) => id === 'f1' ? { url: '/docs/test.pdf', name: 'test.pdf' } : null;
+  const html = renderToString(
+    renderField(field, register, watch, () => {})
+  );
+  assert.ok(html.includes('<iframe'));
+  assert.ok(html.includes('/docs/test.pdf'));
+  assert.ok(html.includes('test.pdf'));
+});

--- a/tests/onboardingStepRenderer.test.ts
+++ b/tests/onboardingStepRenderer.test.ts
@@ -5,6 +5,7 @@ import { renderToString } from 'react-dom/server';
 import Module from 'module';
 
 let capturedProps: any = null;
+let capturedEnhancedProps: any = null;
 (global as any).React = React;
 
 const originalLoad = (Module as any)._load;
@@ -13,6 +14,14 @@ const originalLoad = (Module as any)._load;
     return {
       DynamicFormRenderer: (props: any) => {
         capturedProps = props;
+        return React.createElement('div');
+      },
+    };
+  }
+  if (request === '@/components/forms/EnhancedFormRenderer') {
+    return {
+      EnhancedFormRenderer: (props: any) => {
+        capturedEnhancedProps = props;
         return React.createElement('div');
       },
     };
@@ -28,7 +37,7 @@ const originalLoad = (Module as any)._load;
 const OnboardingStepRenderer = require('../app/components/onboarding/OnboardingStepRenderer').default;
 
 test('passes employeeId to DynamicFormRenderer', () => {
-  const step = { id: 's1', type: 'fill-form', formId: 'f1', title: 'Form', description: '' };
+  const step = { id: 's1', type: 'fill-form', formId: 'f1', form: { formType: 'SUBMISSION' }, title: 'Form', description: '' };
   renderToString(
     React.createElement(OnboardingStepRenderer, {
       step,
@@ -37,4 +46,52 @@ test('passes employeeId to DynamicFormRenderer', () => {
     })
   );
   assert.equal(capturedProps.employeeId, 'emp123');
+});
+
+test('wraps submitted data and dispatches document update', () => {
+  const step = { id: 's1', type: 'fill-form', formId: 'f1', form: { formType: 'SUBMISSION' }, title: 'Form', description: '' };
+  let received: any = null;
+  const events: any[] = [];
+  // listen for custom event
+  (global as any).window = {
+    dispatchEvent: (e: any) => events.push(e.detail),
+    addEventListener: () => {},
+  } as any;
+
+  renderToString(
+    React.createElement(OnboardingStepRenderer, {
+      step,
+      onComplete: (d: any) => { received = d; },
+      employeeId: 'emp123',
+    })
+  );
+
+  // simulate form submission
+  capturedProps.onSubmitSuccess({ foo: 'bar' });
+
+  assert.deepEqual(received, { formResponse: { foo: 'bar' } });
+  assert.deepEqual(events[0], { employeeId: 'emp123' });
+});
+
+test('uses EnhancedFormRenderer for data screen forms', () => {
+  const step = { id: 's1', type: 'fill-form', formId: 'f1', form: { formType: 'DATA_SCREEN' }, title: 'Form', description: '' };
+  let received: any = null;
+  const events: any[] = [];
+  (global as any).window = {
+    dispatchEvent: (e: any) => events.push(e.detail),
+    addEventListener: () => {},
+  } as any;
+
+  renderToString(
+    React.createElement(OnboardingStepRenderer, {
+      step,
+      onComplete: (d: any) => { received = d; },
+      employeeId: 'emp123',
+    })
+  );
+
+  capturedEnhancedProps.onDataChange({ baz: 'qux' });
+
+  assert.deepEqual(received, { formResponse: { baz: 'qux' } });
+  assert.deepEqual(events[0], { employeeId: 'emp123' });
 });


### PR DESCRIPTION
## Summary
- route onboarding forms to EnhancedFormRenderer when underlying form is a data screen
- ensure completed data-screen forms dispatch document updates and persist responses
- cover data-screen handling in onboarding renderer tests
- preview saved documents within data-screen forms and retain existing files on resave

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acbc6d54ec8331902ec57fe6cfc567