### PR TITLE
feat: basic exit interview scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Clean version - fixed large file issue
+
+## Offboarding Exit Interview
+
+This update introduces a basic exit interview workflow for employee offboarding. After initiating an offboarding you can optionally schedule an interview and assign an interviewer.
+
+### Environment
+- No new environment variables are required.
+
+### Testing locally
+1. Run Prisma migrations: `npx prisma migrate dev`.
+2. Start the dev server: `npm run dev`.
+3. Execute tests: `npm test`.
+
 ...

--- a/app/api/employees/[id]/offboard/route.ts
+++ b/app/api/employees/[id]/offboard/route.ts
@@ -218,6 +218,7 @@ export async function GET(
             email: true,
           },
         },
+        exitInterview: true,
         tasks: {
           include: {
             assignedToUser: {
@@ -249,7 +250,22 @@ export async function GET(
       );
     }
 
-    return NextResponse.json(offboardingRecord);
+    let interviewer = null;
+    if (offboardingRecord.exitInterview?.interviewerId) {
+      interviewer = await prisma.user.findUnique({
+        where: { id: offboardingRecord.exitInterview.interviewerId },
+        select: { id: true, firstName: true, lastName: true, email: true },
+      });
+    }
+
+    const response = {
+      ...offboardingRecord,
+      exitInterview: offboardingRecord.exitInterview
+        ? { ...offboardingRecord.exitInterview, interviewer }
+        : null,
+    };
+
+    return NextResponse.json(response);
   } catch (error) {
     console.error("Error fetching offboarding record:", error);
     return NextResponse.json(

--- a/app/api/offboarding/[id]/exit-interview/route.ts
+++ b/app/api/offboarding/[id]/exit-interview/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { exitInterviewSchema } from "./schema";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = exitInterviewSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const offboardingId = params.id;
+    const data = parsed.data;
+
+    const offboarding = await prisma.employeeOffboarding.findUnique({
+      where: { id: offboardingId },
+    });
+
+    if (!offboarding) {
+      return NextResponse.json({ error: "Offboarding not found" }, { status: 404 });
+    }
+
+    const exitInterview = await prisma.exitInterview.upsert({
+      where: { offboardingId },
+      update: {
+        scheduledAt: data.scheduledAt ? new Date(data.scheduledAt) : null,
+        interviewerId: data.interviewerId ?? null,
+        location: data.location ?? null,
+        notes: data.notes ?? null,
+        completed: data.completed ?? undefined,
+        updatedAt: new Date(),
+      },
+      create: {
+        offboardingId,
+        scheduledAt: data.scheduledAt ? new Date(data.scheduledAt) : null,
+        interviewerId: data.interviewerId ?? null,
+        location: data.location ?? null,
+        notes: data.notes ?? null,
+        completed: data.completed ?? false,
+      },
+    });
+
+    let interviewer = null;
+    if (exitInterview.interviewerId) {
+      interviewer = await prisma.user.findUnique({
+        where: { id: exitInterview.interviewerId },
+        select: { id: true, firstName: true, lastName: true, email: true },
+      });
+    }
+
+    return NextResponse.json({ exitInterview: { ...exitInterview, interviewer } });
+  } catch (error) {
+    console.error("Error saving exit interview:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/offboarding/[id]/exit-interview/schema.ts
+++ b/app/api/offboarding/[id]/exit-interview/schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const exitInterviewSchema = z.object({
+  scheduledAt: z.string().datetime().optional(),
+  interviewerId: z.string().optional(),
+  location: z.string().optional(),
+  notes: z.string().optional(),
+  completed: z.boolean().optional(),
+});

--- a/app/components/employees/OffboardingModal.tsx
+++ b/app/components/employees/OffboardingModal.tsx
@@ -41,6 +41,8 @@ interface OffboardingFormData {
   handoverRequired: boolean;
   handoverAssignedTo: string;
   exitInterviewRequired: boolean;
+  exitInterviewDate: Date | null;
+  exitInterviewInterviewer: string;
   assetsToReturn: string[];
   hrNotes: string;
 }
@@ -81,6 +83,8 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
     handoverRequired: false,
     handoverAssignedTo: "",
     exitInterviewRequired: false,
+    exitInterviewDate: null,
+    exitInterviewInterviewer: "",
     assetsToReturn: [],
     hrNotes: "",
   });
@@ -101,6 +105,8 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
         handoverRequired: false,
         handoverAssignedTo: "",
         exitInterviewRequired: false,
+        exitInterviewDate: null,
+        exitInterviewInterviewer: "",
         assetsToReturn: [],
         hrNotes: "",
       });
@@ -135,9 +141,23 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
 
     try {
       const payload = {
-        ...formData,
-        noticePeriodDays: formData.noticePeriodDays ? parseInt(formData.noticePeriodDays) : null,
-        assetsToReturn: formData.assetsToReturn.length > 0 ? formData.assetsToReturn : null,
+        lastWorkingDate: formData.lastWorkingDate,
+        offboardingType: formData.offboardingType,
+        offboardingReason: formData.offboardingReason,
+        isVoluntary: formData.isVoluntary,
+        noticePeriodDays: formData.noticePeriodDays
+          ? parseInt(formData.noticePeriodDays)
+          : null,
+        resignationDate: formData.resignationDate,
+        removeAccessImmediately: formData.removeAccessImmediately,
+        handoverRequired: formData.handoverRequired,
+        handoverAssignedTo: formData.handoverAssignedTo,
+        exitInterviewRequired: formData.exitInterviewRequired,
+        assetsToReturn:
+          formData.assetsToReturn.length > 0
+            ? formData.assetsToReturn
+            : null,
+        hrNotes: formData.hrNotes,
       };
 
       const response = await fetch(`/api/employees/${employee.id}/offboard`, {
@@ -151,6 +171,21 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || "Failed to start offboarding");
+      }
+
+      const data = await response.json();
+
+      if (formData.exitInterviewRequired && data.offboardingId) {
+        await fetch(`/api/offboarding/${data.offboardingId}/exit-interview`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scheduledAt: formData.exitInterviewDate
+              ? formData.exitInterviewDate.toISOString()
+              : undefined,
+            interviewerId: formData.exitInterviewInterviewer || undefined,
+          }),
+        });
       }
 
       toast({
@@ -434,15 +469,63 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
                 Exit Process
               </h3>
               
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="exitInterviewRequired"
-                  checked={formData.exitInterviewRequired}
-                  onCheckedChange={(checked) => setFormData(prev => ({ ...prev, exitInterviewRequired: checked as boolean }))}
-                />
-                <Label htmlFor="exitInterviewRequired">Schedule exit interview</Label>
-              </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="exitInterviewRequired"
+                checked={formData.exitInterviewRequired}
+                onCheckedChange={(checked) => setFormData(prev => ({ ...prev, exitInterviewRequired: checked as boolean }))}
+              />
+              <Label htmlFor="exitInterviewRequired">Schedule exit interview</Label>
             </div>
+
+            {formData.exitInterviewRequired && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                <div>
+                  <Label htmlFor="exitInterviewDate">Interview date</Label>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={"w-full justify-start text-left font-normal"}
+                      >
+                        {formData.exitInterviewDate
+                          ? format(formData.exitInterviewDate, "PPP")
+                          : <span>Pick a date</span>}
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={formData.exitInterviewDate || undefined}
+                        onSelect={(date) => setFormData(prev => ({ ...prev, exitInterviewDate: date || null }))}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <div>
+                  <Label htmlFor="exitInterviewInterviewer">Interviewer</Label>
+                  <Select
+                    value={formData.exitInterviewInterviewer}
+                    onValueChange={(value) => setFormData(prev => ({ ...prev, exitInterviewInterviewer: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select interviewer" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {employees.map(emp => (
+                        <SelectItem key={emp.id} value={emp.id}>
+                          {emp.firstName} {emp.lastName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+          </div>
 
             {/* HR Notes */}
             <div>

--- a/prisma/migrations/20250826120000_add_exit_interview/migration.sql
+++ b/prisma/migrations/20250826120000_add_exit_interview/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "ExitInterview" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "offboardingId" TEXT NOT NULL,
+  "scheduledAt" TIMESTAMP(3),
+  "interviewerId" TEXT,
+  "location" TEXT,
+  "notes" TEXT,
+  "completed" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ExitInterview_offboardingId_fkey" FOREIGN KEY ("offboardingId") REFERENCES "EmployeeOffboarding"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "ExitInterview_offboardingId_key" ON "ExitInterview"("offboardingId");
+CREATE INDEX "ExitInterview_offboardingId_idx" ON "ExitInterview"("offboardingId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -734,8 +734,9 @@ model EmployeeOffboarding {
   handoverAssignedToUser    User?     @relation("OffboardingHandoverAssignedTo", fields: [handoverAssignedTo], references: [id])
   hrReviewCompletedByUser   User?     @relation("OffboardingHRReviewCompletedBy", fields: [hrReviewCompletedBy], references: [id])
   assetsReturnedToUser      User?     @relation("OffboardingAssetsReturnedTo", fields: [assetsReturnedTo], references: [id])
-  
+
   tasks                     OffboardingTask[]
+  exitInterview             ExitInterview?
 
   @@index([employeeId])
   @@index([status])
@@ -766,6 +767,22 @@ model OffboardingTask {
   @@index([offboardingId])
   @@index([category])
   @@index([assignedTo])
+}
+
+model ExitInterview {
+  id            String   @id @default(cuid())
+  offboardingId String   @unique
+  scheduledAt   DateTime?
+  interviewerId String?
+  location      String?
+  notes         String?
+  completed     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  offboarding   EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
+
+  @@index([offboardingId])
 }
 
 enum OffboardingStatus {

--- a/tests/exitInterviewSchema.test.ts
+++ b/tests/exitInterviewSchema.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { exitInterviewSchema } from '../app/api/offboarding/[id]/exit-interview/schema';
+
+const sample = {
+  scheduledAt: new Date().toISOString(),
+  interviewerId: 'user123',
+  location: 'Meeting room',
+  notes: 'Bring laptop',
+  completed: false,
+};
+
+test('exitInterviewSchema parses sample payload', () => {
+  const parsed = exitInterviewSchema.parse(sample);
+  assert.equal(parsed.location, 'Meeting room');
+});


### PR DESCRIPTION
## Summary
- add exit interview model and migration
- support creating/updating exit interview via API
- extend offboarding modal to schedule interview with interviewer
- document new workflow and add schema tests

## Testing
- `npm test`
- `npm run build` *(fails: Can't reach database server at `nozomi.proxy.rlwy.net:11874`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8a97a23483318225e5cc41a612ce