### PR TITLE
Allow resending exit interview forms

### DIFF
--- a/app/(withSidebar)/employees/[id]/offboarding/page.tsx
+++ b/app/(withSidebar)/employees/[id]/offboarding/page.tsx
@@ -379,15 +379,17 @@ export default function EmployeeOffboardingPage() {
                 </div>
               )}
 
-              {/* Manual Form Invitation Button */}
-              {offboarding.exitInterview.sendForm && 
-               offboarding.exitInterview.formTiming === 'ON_DATE' && 
-               offboarding.exitInterview.completionStatus === 'PENDING' && (
+              {/* Manual Form Invitation / Resend Button */}
+              {offboarding.exitInterview.sendForm &&
+               ['ON_DATE', 'NOW'].includes(offboarding.exitInterview.formTiming || '') &&
+               offboarding.exitInterview.completionStatus !== 'SUBMITTED' && (
                 <div className="border-t pt-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Send className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium">Manual Form Invitation</span>
+                      <span className="text-sm font-medium">
+                        {offboarding.exitInterview.formTiming === 'NOW' ? 'Resend Form' : 'Manual Form Invitation'}
+                      </span>
                     </div>
                     <Button
                       onClick={handleSendFormInvite}
@@ -403,13 +405,15 @@ export default function EmployeeOffboardingPage() {
                       ) : (
                         <>
                           <Send className="mr-2 h-4 w-4" />
-                          Send Form Now
+                          {offboarding.exitInterview.formTiming === 'NOW' ? 'Resend Form' : 'Send Form Now'}
                         </>
                       )}
                     </Button>
                   </div>
                   <p className="text-sm text-gray-500 mt-1">
-                    Manually trigger the exit interview form invitation (bypasses scheduled timing)
+                    {offboarding.exitInterview.formTiming === 'NOW'
+                      ? 'Resend the exit interview form invitation'
+                      : 'Manually trigger the exit interview form invitation (bypasses scheduled timing)'}
                   </p>
                 </div>
               )}

--- a/app/api/offboarding/schedule-due-sends/route.ts
+++ b/app/api/offboarding/schedule-due-sends/route.ts
@@ -24,15 +24,19 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Offboarding record not found" }, { status: 404 });
       }
 
-      if (!offboarding.sendForm || offboarding.formTiming !== 'ON_DATE') {
-        return NextResponse.json({ error: "This offboarding is not configured for scheduled form invitations" }, { status: 400 });
+      if (!offboarding.sendForm) {
+        return NextResponse.json({ error: "This offboarding is not configured for form invitations" }, { status: 400 });
       }
 
-      if (offboarding.completionStatus !== 'PENDING') {
-        return NextResponse.json({ error: "Form has already been started or submitted" }, { status: 400 });
+      if (offboarding.completionStatus === 'SUBMITTED') {
+        return NextResponse.json({ error: "Form has already been submitted" }, { status: 400 });
       }
 
-      // Send the form invitation
+      if (offboarding.formTiming !== 'ON_DATE' && offboarding.formTiming !== 'NOW') {
+        return NextResponse.json({ error: "This offboarding is not configured for form invitations" }, { status: 400 });
+      }
+
+      // Send the form invitation (supports manual resend for NOW forms)
       const emailSent = await sendExitInterviewFormInvite(offboarding.id);
 
       return NextResponse.json({

--- a/tests/exitInterviewSchema.test.ts
+++ b/tests/exitInterviewSchema.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { exitInterviewSchema } from '../app/api/offboarding/[id]/exit-interview/schema';
+import { exitInterviewSchema } from '../app/api/offboarding/[employeeId]/exit-interview/schema';
 
 const sample = {
   scheduledAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Support resending exit interview form invitations for NOW and ON_DATE forms
- Add resend button on offboarding page when form invite hasn't been submitted
- Fix test import path for exit interview schema

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae154bda88833198ba4f1d316a3783