### PR TITLE
Send exit interview form immediately

### DIFF
--- a/app/(withSidebar)/employees/[id]/offboarding/page.tsx
+++ b/app/(withSidebar)/employees/[id]/offboarding/page.tsx
@@ -379,15 +379,17 @@ export default function EmployeeOffboardingPage() {
                 </div>
               )}
 
-              {/* Manual Form Invitation Button */}
-              {offboarding.exitInterview.sendForm && 
-               offboarding.exitInterview.formTiming === 'ON_DATE' && 
-               offboarding.exitInterview.completionStatus === 'PENDING' && (
+              {/* Manual Form Invitation / Resend Button */}
+              {offboarding.exitInterview.sendForm &&
+               ['ON_DATE', 'NOW'].includes(offboarding.exitInterview.formTiming || '') &&
+               offboarding.exitInterview.completionStatus !== 'SUBMITTED' && (
                 <div className="border-t pt-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Send className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium">Manual Form Invitation</span>
+                      <span className="text-sm font-medium">
+                        {offboarding.exitInterview.formTiming === 'NOW' ? 'Resend Form' : 'Manual Form Invitation'}
+                      </span>
                     </div>
                     <Button
                       onClick={handleSendFormInvite}
@@ -403,13 +405,15 @@ export default function EmployeeOffboardingPage() {
                       ) : (
                         <>
                           <Send className="mr-2 h-4 w-4" />
-                          Send Form Now
+                          {offboarding.exitInterview.formTiming === 'NOW' ? 'Resend Form' : 'Send Form Now'}
                         </>
                       )}
                     </Button>
                   </div>
                   <p className="text-sm text-gray-500 mt-1">
-                    Manually trigger the exit interview form invitation (bypasses scheduled timing)
+                    {offboarding.exitInterview.formTiming === 'NOW'
+                      ? 'Resend the exit interview form invitation'
+                      : 'Manually trigger the exit interview form invitation (bypasses scheduled timing)'}
                   </p>
                 </div>
               )}

--- a/app/api/exit-interview/start/route.ts
+++ b/app/api/exit-interview/start/route.ts
@@ -1,21 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
-import { createHash } from "crypto";
 
+// Accept the token from the form link and locate the offboarding record
+// based on the stored completionTokenHash. No offboardingId is required
+// from the client as it can be derived from the lookup.
 const startSchema = z.object({
-  token: z.string().min(1),
-  offboardingId: z.string().min(1),
+  token: z.string().min(1)
 });
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { token, offboardingId } = startSchema.parse(body);
+    const { token } = startSchema.parse(body);
 
-    // Get offboarding record
+    // Find the offboarding record by its completion token
     const offboarding = await prisma.employeeOffboarding.findUnique({
-      where: { id: offboardingId },
+      where: { completionTokenHash: token },
       include: {
         employee: {
           include: { user: true }
@@ -28,12 +29,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Offboarding record not found" }, { status: 404 });
     }
 
-    // Validate token
-    const expectedHash = createHash('sha256').update(token + offboardingId).digest('hex');
-    if (offboarding.completionTokenHash !== expectedHash) {
-      return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 });
-    }
-
     // Check if already submitted
     if (offboarding.completionStatus === 'SUBMITTED') {
       return NextResponse.json({ error: "Form already submitted" }, { status: 400 });
@@ -42,7 +37,7 @@ export async function POST(req: NextRequest) {
     // Update completion status to STARTED if it's still PENDING
     if (offboarding.completionStatus === 'PENDING') {
       await prisma.employeeOffboarding.update({
-        where: { id: offboardingId },
+        where: { id: offboarding.id },
         data: {
           completionStatus: 'STARTED'
         }

--- a/app/api/exit-interview/submit/route.ts
+++ b/app/api/exit-interview/submit/route.ts
@@ -1,22 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
-import { createHash } from "crypto";
 
+// The employee submits answers using only the token from their email link.
+// The server derives the offboarding record from this token and associates
+// the answers accordingly.
 const submitSchema = z.object({
   token: z.string().min(1),
-  offboardingId: z.string().min(1),
   answersJson: z.record(z.any()).optional(),
 });
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { token, offboardingId, answersJson } = submitSchema.parse(body);
+    const { token, answersJson } = submitSchema.parse(body);
 
-    // Get offboarding record
+    // Locate the offboarding record using the supplied token
     const offboarding = await prisma.employeeOffboarding.findUnique({
-      where: { id: offboardingId },
+      where: { completionTokenHash: token },
       include: {
         employee: {
           include: { user: true }
@@ -27,12 +28,6 @@ export async function POST(req: NextRequest) {
 
     if (!offboarding) {
       return NextResponse.json({ error: "Offboarding record not found" }, { status: 404 });
-    }
-
-    // Validate token
-    const expectedHash = createHash('sha256').update(token + offboardingId).digest('hex');
-    if (offboarding.completionTokenHash !== expectedHash) {
-      return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 });
     }
 
     // Check if already submitted
@@ -48,7 +43,7 @@ export async function POST(req: NextRequest) {
     // Create submission record
     const submission = await prisma.exitInterviewSubmission.create({
       data: {
-        offboardingId,
+        offboardingId: offboarding.id,
         templateId: offboarding.formTemplateId,
         submittedBy: offboarding.employee.user.email,
         submittedAt: new Date(),
@@ -58,7 +53,7 @@ export async function POST(req: NextRequest) {
 
     // Update offboarding completion status
     await prisma.employeeOffboarding.update({
-      where: { id: offboardingId },
+      where: { id: offboarding.id },
       data: {
         completionStatus: 'SUBMITTED'
       }

--- a/app/api/offboarding/[employeeId]/exit-interview/route.ts
+++ b/app/api/offboarding/[employeeId]/exit-interview/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { exitInterviewSchema } from "./schema";
+import { generateCompletionToken } from "@/lib/email/send";
 
 export async function POST(
   req: NextRequest,
@@ -51,6 +52,39 @@ export async function POST(
         completed: data.completed ?? false,
       },
     });
+
+    // Update form invitation settings on the offboarding record when provided
+    if (
+      typeof data.sendForm !== "undefined" ||
+      typeof data.formTemplateId !== "undefined" ||
+      typeof data.formTiming !== "undefined"
+    ) {
+      const updateData: any = {
+        sendForm: data.sendForm ?? false,
+        formTemplateId: data.sendForm ? data.formTemplateId ?? null : null,
+        formTiming: data.sendForm ? data.formTiming ?? null : null,
+      };
+
+      if (data.sendForm) {
+        if (!offboarding.completionTokenHash) {
+          updateData.completionTokenHash = generateCompletionToken(offboarding.id);
+        }
+        updateData.completionStatus = "PENDING";
+        updateData.scheduledSendAt =
+          data.formTiming === "ON_DATE" && data.scheduledAt
+            ? new Date(data.scheduledAt)
+            : null;
+      } else {
+        updateData.completionStatus = null;
+        updateData.scheduledSendAt = null;
+        updateData.completionTokenHash = null;
+      }
+
+      await prisma.employeeOffboarding.update({
+        where: { id: offboarding.id },
+        data: updateData,
+      });
+    }
 
     let interviewer = null;
     if (exitInterview.interviewerId) {

--- a/app/api/offboarding/[employeeId]/exit-interview/schema.ts
+++ b/app/api/offboarding/[employeeId]/exit-interview/schema.ts
@@ -6,4 +6,7 @@ export const exitInterviewSchema = z.object({
   location: z.string().optional(),
   notes: z.string().optional(),
   completed: z.boolean().optional(),
+  sendForm: z.boolean().optional(),
+  formTemplateId: z.string().optional(),
+  formTiming: z.enum(['NOW', 'ON_DATE']).optional(),
 });

--- a/app/api/offboarding/schedule-due-sends/route.ts
+++ b/app/api/offboarding/schedule-due-sends/route.ts
@@ -24,16 +24,27 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Offboarding record not found" }, { status: 404 });
       }
 
-      if (!offboarding.sendForm || offboarding.formTiming !== 'ON_DATE') {
-        return NextResponse.json({ error: "This offboarding is not configured for scheduled form invitations" }, { status: 400 });
+      if (!offboarding.sendForm) {
+        return NextResponse.json({ error: "This offboarding is not configured for form invitations" }, { status: 400 });
       }
 
-      if (offboarding.completionStatus !== 'PENDING') {
-        return NextResponse.json({ error: "Form has already been started or submitted" }, { status: 400 });
+      if (offboarding.completionStatus === 'SUBMITTED') {
+        return NextResponse.json({ error: "Form has already been submitted" }, { status: 400 });
       }
 
-      // Send the form invitation
+      if (offboarding.formTiming !== 'ON_DATE' && offboarding.formTiming !== 'NOW') {
+        return NextResponse.json({ error: "This offboarding is not configured for form invitations" }, { status: 400 });
+      }
+
+      // Send the form invitation (supports manual resend for NOW forms)
       const emailSent = await sendExitInterviewFormInvite(offboarding.id);
+
+      if (!emailSent) {
+        return NextResponse.json(
+          { error: "Failed to send form invitation" },
+          { status: 500 }
+        );
+      }
 
       return NextResponse.json({
         success: true,

--- a/app/components/employees/OffboardingModal.tsx
+++ b/app/components/employees/OffboardingModal.tsx
@@ -210,7 +210,7 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
       const data = await response.json();
 
       if (formData.exitInterviewRequired && data.offboardingId) {
-        await fetch(`/api/offboarding/${data.offboardingId}/exit-interview`, {
+        await fetch(`/api/offboarding/${employee.id}/exit-interview`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -223,6 +223,15 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
             formTiming: formData.sendForm ? formData.formTiming : undefined,
           }),
         });
+
+        // Immediately send form invitation if configured to send now
+        if (formData.sendForm && formData.formTiming === 'NOW') {
+          await fetch('/api/offboarding/schedule-due-sends', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ offboardingId: data.offboardingId }),
+          });
+        }
       }
 
       toast({

--- a/app/exit-interview/[token]/page.tsx
+++ b/app/exit-interview/[token]/page.tsx
@@ -46,7 +46,6 @@ export default function ExitInterviewPage() {
   const [formData, setFormData] = useState<Record<string, any>>({});
   const [template, setTemplate] = useState<FormTemplate | null>(null);
   const [employee, setEmployee] = useState<Employee | null>(null);
-  const [offboardingId, setOffboardingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (token) {
@@ -65,10 +64,7 @@ export default function ExitInterviewPage() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          token,
-          offboardingId: 'temp' // We'll get the real ID from the response
-        }),
+        body: JSON.stringify({ token }),
       });
 
       if (!response.ok) {
@@ -79,7 +75,6 @@ export default function ExitInterviewPage() {
       const data = await response.json();
       setTemplate(data.formTemplate);
       setEmployee(data.employee);
-      setOffboardingId(data.offboardingId);
 
       // Initialize form data
       const initialData: Record<string, any> = {};
@@ -152,11 +147,6 @@ export default function ExitInterviewPage() {
       return;
     }
 
-    if (!offboardingId) {
-      toast.error('Form not properly loaded');
-      return;
-    }
-
     try {
       setSubmitting(true);
 
@@ -167,7 +157,6 @@ export default function ExitInterviewPage() {
         },
         body: JSON.stringify({
           token,
-          offboardingId,
           answersJson: formData
         }),
       });

--- a/app/lib/email/send.ts
+++ b/app/lib/email/send.ts
@@ -5,6 +5,7 @@ import { formatLondon } from '@/lib/time';
 import { createHash, randomBytes } from 'crypto';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM_EMAIL = process.env.FROM_EMAIL || "onboarding@resend.dev";
 
 export interface EmailRecipient {
   email: string;
@@ -101,7 +102,7 @@ export async function sendExitInterviewConfirmation(offboardingId: string): Prom
 
     // Send email to employee
     await resend.emails.send({
-      from: process.env.FROM_EMAIL || 'noreply@corenz.com',
+      from: FROM_EMAIL,
       to: employee.user.email,
       subject,
       html: htmlContent,
@@ -114,7 +115,7 @@ export async function sendExitInterviewConfirmation(offboardingId: string): Prom
 
     // Send copy to interviewer
     await resend.emails.send({
-      from: process.env.FROM_EMAIL || 'noreply@corenz.com',
+      from: FROM_EMAIL,
       to: interviewer.email,
       subject: `Copy: ${subject}`,
       html: htmlContent,
@@ -188,7 +189,7 @@ export async function sendExitInterviewFormInvite(offboardingId: string): Promis
     `;
 
     await resend.emails.send({
-      from: process.env.FROM_EMAIL || 'noreply@corenz.com',
+      from: FROM_EMAIL,
       to: employee.user.email,
       subject,
       html: htmlContent
@@ -259,7 +260,7 @@ export async function sendExitInterviewCancellation(offboardingId: string): Prom
 
     // Send cancellation to employee
     await resend.emails.send({
-      from: process.env.FROM_EMAIL || 'noreply@corenz.com',
+      from: FROM_EMAIL,
       to: employee.user.email,
       subject,
       html: htmlContent,
@@ -272,8 +273,8 @@ export async function sendExitInterviewCancellation(offboardingId: string): Prom
 
     // Send cancellation to interviewer
     if (interviewer.email) {
-      await resend.emails.send({
-        from: process.env.FROM_EMAIL || 'noreply@corenz.com',
+        await resend.emails.send({
+          from: FROM_EMAIL,
         to: interviewer.email,
         subject: `Copy: ${subject}`,
         html: htmlContent,

--- a/tests/exitInterviewSchema.test.ts
+++ b/tests/exitInterviewSchema.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { exitInterviewSchema } from '../app/api/offboarding/[id]/exit-interview/schema';
+import { exitInterviewSchema } from '../app/api/offboarding/[employeeId]/exit-interview/schema';
 
 const sample = {
   scheduledAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Use Resend sandbox sender by default so exit interview emails match credentials used elsewhere
- Return an error from scheduled-send endpoint when form invitations fail to dispatch
- Locate exit interview forms via completion token to prevent access errors when employees follow email links

## Testing
- `npm test`
- `npm run lint` *(interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae154bda88833198ba4f1d316a3783