### PR TITLE
Fix offboarding route submissions include

### DIFF
--- a/app/api/offboarding/[employeeId]/route.ts
+++ b/app/api/offboarding/[employeeId]/route.ts
@@ -47,7 +47,7 @@ export async function GET(
             schemaJson: true
           }
         },
-        submissions: {
+        exitInterviewSubmissions: {
           include: {
             template: {
               select: {
@@ -116,7 +116,7 @@ export async function GET(
       },
 
       // Form submissions
-      formSubmissions: offboarding.submissions.map(submission => ({
+      formSubmissions: offboarding.exitInterviewSubmissions.map(submission => ({
         id: submission.id,
         templateName: submission.template.name,
         templateSchema: submission.template.schemaJson,

--- a/tests/exitInterviewRoute.test.ts
+++ b/tests/exitInterviewRoute.test.ts
@@ -12,6 +12,7 @@ test('POST /api/offboarding/[employeeId]/exit-interview validates formTemplateId
         prisma: {
           employeeOffboarding: {
             findUnique: async () => ({ id: 'o1', completionTokenHash: null }),
+            update: async () => ({}),
           },
           exitInterview: {
             upsert: async () => ({ interviewerId: null }),


### PR DESCRIPTION
## Summary
- use correct exitInterviewSubmissions relation for offboarding lookups
- stub prisma update in exit interview route test

## Testing
- `npm test`
- `npm run build` *(fails: Can't reach database server at `nozomi.proxy.rlwy.net:11874`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85513b30833198482c675bcc656e