### PR TITLE
feat: allow specifying time and duration for exit interviews

### DIFF
--- a/app/api/offboarding/[employeeId]/exit-interview/route.ts
+++ b/app/api/offboarding/[employeeId]/exit-interview/route.ts
@@ -35,7 +35,10 @@ export async function POST(
 
     // Update the main offboarding record with exit interview details
     const scheduledDate = data.scheduledAt ? new Date(data.scheduledAt) : null;
-    const exitInterviewEnd = scheduledDate ? new Date(scheduledDate.getTime() + 60 * 60 * 1000) : null;
+    const duration = data.durationMinutes ?? 60;
+    const exitInterviewEnd = scheduledDate
+      ? new Date(scheduledDate.getTime() + duration * 60 * 1000)
+      : null;
 
     // Validate interviewer exists if provided
     let validInterviewerId = null;

--- a/app/api/offboarding/[employeeId]/exit-interview/schema.ts
+++ b/app/api/offboarding/[employeeId]/exit-interview/schema.ts
@@ -2,6 +2,15 @@ import { z } from "zod";
 
 export const exitInterviewSchema = z.object({
   scheduledAt: z.string().datetime().optional(),
+  durationMinutes: z
+    .number()
+    .int()
+    .min(10)
+    .max(60)
+    .optional()
+    .refine((n) => n % 10 === 0, {
+      message: "Duration must be in 10-minute increments",
+    }),
   interviewerId: z.string().optional(),
   location: z.string().optional(),
   notes: z.string().optional(),

--- a/app/api/offboarding/initiate/route.ts
+++ b/app/api/offboarding/initiate/route.ts
@@ -12,6 +12,15 @@ const initiateSchema = z.object({
   employeeId: z.string().min(1),
   exitInterviewDate: z.string().optional(), // YYYY-MM-DD
   exitInterviewTime: z.string().optional(), // HH:mm
+  exitInterviewDuration: z
+    .number()
+    .int()
+    .min(10)
+    .max(60)
+    .optional()
+    .refine((n) => n % 10 === 0, {
+      message: "Duration must be in 10-minute increments",
+    }),
   interviewerUserId: z.string().optional(),
   interviewerName: z.string().optional(),
   interviewerEmail: z.string().email().optional(),
@@ -41,6 +50,7 @@ export async function POST(req: NextRequest) {
       employeeId,
       exitInterviewDate,
       exitInterviewTime,
+      exitInterviewDuration,
       interviewerUserId,
       interviewerName,
       interviewerEmail,
@@ -89,8 +99,10 @@ export async function POST(req: NextRequest) {
 
     if (exitInterviewDate && exitInterviewTime) {
       exitInterviewDateUTC = toUTCFromLondon(exitInterviewDate, exitInterviewTime);
-      // Default to 1 hour duration
-      exitInterviewEndUTC = new Date(exitInterviewDateUTC.getTime() + 60 * 60 * 1000);
+      const duration = exitInterviewDuration ?? 60;
+      exitInterviewEndUTC = new Date(
+        exitInterviewDateUTC.getTime() + duration * 60 * 1000
+      );
     }
 
     // Validate form template if provided

--- a/app/components/employees/EnhancedOffboardingModal.tsx
+++ b/app/components/employees/EnhancedOffboardingModal.tsx
@@ -47,6 +47,7 @@ interface OffboardingFormData {
   // Exit Interview Details
   exitInterviewDate: Date | undefined;
   exitInterviewTime: string;
+  exitInterviewDuration: number;
   interviewerUserId: string;
   interviewerName: string;
   interviewerEmail: string;
@@ -75,6 +76,7 @@ export default function EnhancedOffboardingModal({ open, onClose, employee, onSu
   const [formData, setFormData] = useState<OffboardingFormData>({
     exitInterviewDate: undefined,
     exitInterviewTime: "09:00",
+    exitInterviewDuration: 60,
     interviewerUserId: "",
     interviewerName: "",
     interviewerEmail: "",
@@ -126,6 +128,7 @@ export default function EnhancedOffboardingModal({ open, onClose, employee, onSu
     setFormData({
       exitInterviewDate: undefined,
       exitInterviewTime: "09:00",
+      exitInterviewDuration: 60,
       interviewerUserId: "",
       interviewerName: "",
       interviewerEmail: "",
@@ -191,6 +194,7 @@ export default function EnhancedOffboardingModal({ open, onClose, employee, onSu
           employeeId: employee.id,
           exitInterviewDate: formData.exitInterviewDate ? format(formData.exitInterviewDate, 'yyyy-MM-dd') : null,
           exitInterviewTime: formData.exitInterviewTime,
+          exitInterviewDuration: formData.exitInterviewDuration,
           interviewerUserId: formData.interviewerUserId || null,
           interviewerName: formData.interviewerName || null,
           interviewerEmail: formData.interviewerEmail || null,
@@ -247,7 +251,7 @@ export default function EnhancedOffboardingModal({ open, onClose, employee, onSu
               Exit Interview Details
             </h3>
             
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
                 <Label htmlFor="exitInterviewDate">Interview Date</Label>
                 <Popover>
@@ -283,6 +287,30 @@ export default function EnhancedOffboardingModal({ open, onClose, employee, onSu
                   onChange={(e) => setFormData(prev => ({ ...prev, exitInterviewTime: e.target.value }))}
                   required
                 />
+              </div>
+
+              <div>
+                <Label htmlFor="exitInterviewDuration">Duration</Label>
+                <Select
+                  value={formData.exitInterviewDuration.toString()}
+                  onValueChange={(value) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      exitInterviewDuration: parseInt(value),
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select duration" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[10, 20, 30, 40, 50, 60].map((m) => (
+                      <SelectItem key={m} value={m.toString()}>
+                        {m} minutes
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 

--- a/app/components/employees/OffboardingModal.tsx
+++ b/app/components/employees/OffboardingModal.tsx
@@ -12,6 +12,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CalendarIcon, AlertCircle, User, Clock, Shield, Package, Users, FileText, CheckCircle, FormInput } from "lucide-react";
 import { format } from "date-fns";
+import { toUTCFromLondon } from "@/lib/time";
 import { useToast } from "@/hooks/use-toast";
 
 interface Employee {
@@ -49,6 +50,8 @@ interface OffboardingFormData {
   handoverAssignedTo: string;
   exitInterviewRequired: boolean;
   exitInterviewDate: Date | null;
+  exitInterviewTime: string;
+  exitInterviewDuration: number;
   exitInterviewInterviewer: string;
   sendForm: boolean;
   formTemplateId: string;
@@ -95,6 +98,8 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
     handoverAssignedTo: "",
     exitInterviewRequired: false,
     exitInterviewDate: null,
+    exitInterviewTime: "09:00",
+    exitInterviewDuration: 60,
     exitInterviewInterviewer: "",
     sendForm: false,
     formTemplateId: "",
@@ -121,6 +126,8 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
         handoverAssignedTo: "",
         exitInterviewRequired: false,
         exitInterviewDate: null,
+        exitInterviewTime: "09:00",
+        exitInterviewDuration: 60,
         exitInterviewInterviewer: "",
         sendForm: false,
         formTemplateId: "",
@@ -214,8 +221,16 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
         console.log('Setting up exit interview for employee:', employee.id);
         try {
           const finalFormTemplateId = formData.sendForm ? (formData.formTemplateId || formTemplates[0]?.id) : undefined;
+          const scheduledAt = formData.exitInterviewDate
+            ? toUTCFromLondon(
+                format(formData.exitInterviewDate, 'yyyy-MM-dd'),
+                formData.exitInterviewTime
+              ).toISOString()
+            : undefined;
+
           console.log('Sending exit interview data:', {
-            scheduledAt: formData.exitInterviewDate?.toISOString(),
+            scheduledAt,
+            durationMinutes: formData.exitInterviewDuration,
             interviewerId: formData.exitInterviewInterviewer,
             sendForm: formData.sendForm,
             formTemplateId: finalFormTemplateId,
@@ -227,9 +242,8 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              scheduledAt: formData.exitInterviewDate
-                ? formData.exitInterviewDate.toISOString()
-                : undefined,
+              scheduledAt,
+              durationMinutes: formData.exitInterviewDuration,
               interviewerId: formData.exitInterviewInterviewer || undefined,
               sendForm: formData.sendForm,
               formTemplateId: finalFormTemplateId,
@@ -589,16 +603,57 @@ export default function OffboardingModal({ open, onClose, employee, onSuccess }:
                     </Popover>
                   </div>
                   <div>
+                    <Label htmlFor="exitInterviewTime">Interview time</Label>
+                    <Input
+                      type="time"
+                      value={formData.exitInterviewTime}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          exitInterviewTime: e.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="exitInterviewDuration">Duration</Label>
+                    <Select
+                      value={formData.exitInterviewDuration.toString()}
+                      onValueChange={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          exitInterviewDuration: parseInt(value),
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select duration" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {[10, 20, 30, 40, 50, 60].map((m) => (
+                          <SelectItem key={m} value={m.toString()}>
+                            {m} minutes
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
                     <Label htmlFor="exitInterviewInterviewer">Interviewer</Label>
                     <Select
                       value={formData.exitInterviewInterviewer}
-                      onValueChange={(value) => setFormData(prev => ({ ...prev, exitInterviewInterviewer: value }))}
+                      onValueChange={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          exitInterviewInterviewer: value,
+                        }))
+                      }
                     >
                       <SelectTrigger>
                         <SelectValue placeholder="Select interviewer" />
                       </SelectTrigger>
                       <SelectContent>
-                        {employees.map(emp => (
+                        {employees.map((emp) => (
                           <SelectItem key={emp.id} value={emp.userId}>
                             {emp.firstName} {emp.lastName}
                           </SelectItem>

--- a/tests/exitInterviewSchema.test.ts
+++ b/tests/exitInterviewSchema.test.ts
@@ -4,6 +4,7 @@ import { exitInterviewSchema } from '../app/api/offboarding/[employeeId]/exit-in
 
 const sample = {
   scheduledAt: new Date().toISOString(),
+  durationMinutes: 30,
   interviewerId: 'user123',
   location: 'Meeting room',
   notes: 'Bring laptop',


### PR DESCRIPTION
## Summary
- allow setting custom exit interview time and duration
- validate 10–60 minute duration increments and store end time
- update UI forms and tests for new scheduling options

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e0eb94083318a490a73ebbc8672