### PR TITLE
Fix missing role property in employee overview query

### DIFF
--- a/app/(withSidebar)/employees/[id]/overview/page.tsx
+++ b/app/(withSidebar)/employees/[id]/overview/page.tsx
@@ -34,6 +34,7 @@ export default async function EmployeeOverviewPage({ params }: PageProps) {
           email: true,
           phone: true,
           createdAt: true,
+          role: true,
           jobRole: { select: { name: true } },
           department: { select: { name: true } },
           manager: {


### PR DESCRIPTION
## Summary
- include `role` in employee overview page Prisma query

## Testing
- `npm run lint` *(fails: invalid options)*
- `npm test`
- `timeout 100 npm run build` *(fails: can't reach database, export errors)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2061918833194feed83e4b7b046