### PR TITLE
fix: remove duplicate role selection

### DIFF
--- a/app/(withSidebar)/employees/[id]/overview/page.tsx
+++ b/app/(withSidebar)/employees/[id]/overview/page.tsx
@@ -35,7 +35,6 @@ export default async function EmployeeOverviewPage({ params }: PageProps) {
           phone: true,
           role: true,
           createdAt: true,
-          role: true,
           jobRole: { select: { name: true } },
           department: { select: { name: true } },
           manager: {


### PR DESCRIPTION
## Summary
- remove duplicate `role` field from Employee overview user select

## Testing
- `npm test`
- `npm run build` *(fails: Can't reach database server at `nozomi.proxy.rlwy.net:11874`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0fa4288c8331a4d1ffda3fc6dae3