### PR TITLE
fix: add permission profile migration

### DIFF
--- a/app/(withSidebar)/employees/[id]/overview/page.tsx
+++ b/app/(withSidebar)/employees/[id]/overview/page.tsx
@@ -35,7 +35,6 @@ export default async function EmployeeOverviewPage({ params }: PageProps) {
           phone: true,
           role: true,
           createdAt: true,
-          role: true,
           jobRole: { select: { name: true } },
           department: { select: { name: true } },
           manager: {

--- a/prisma/migrations/20250908_add_permission_profiles/migration.sql
+++ b/prisma/migrations/20250908_add_permission_profiles/migration.sql
@@ -1,0 +1,64 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "permissionProfileId" TEXT,
+ALTER COLUMN "role" SET DEFAULT 'EMPLOYEE';
+
+-- AlterTable
+ALTER TABLE "public"."Form" DROP COLUMN "visibleToRoles",
+ADD COLUMN     "visibleToRoles" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "public"."PermissionProfile" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "permissions" JSONB NOT NULL,
+    "builtIn" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PermissionProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PermissionAudit" (
+    "id" TEXT NOT NULL,
+    "employeeId" TEXT NOT NULL,
+    "changedById" TEXT NOT NULL,
+    "oldProfileId" TEXT,
+    "newProfileId" TEXT NOT NULL,
+    "oldPermissions" JSONB,
+    "newPermissions" JSONB NOT NULL,
+    "note" TEXT,
+    "changedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PermissionAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PermissionProfile_companyId_name_key" ON "public"."PermissionProfile"("companyId", "name");
+
+-- CreateIndex
+CREATE INDEX "PermissionAudit_employeeId_idx" ON "public"."PermissionAudit"("employeeId");
+
+-- CreateIndex
+CREATE INDEX "PermissionAudit_changedAt_idx" ON "public"."PermissionAudit"("changedAt");
+
+-- AddForeignKey
+ALTER TABLE "public"."User" ADD CONSTRAINT "User_permissionProfileId_fkey" FOREIGN KEY ("permissionProfileId") REFERENCES "public"."PermissionProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PermissionProfile" ADD CONSTRAINT "PermissionProfile_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PermissionAudit" ADD CONSTRAINT "PermissionAudit_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PermissionAudit" ADD CONSTRAINT "PermissionAudit_changedById_fkey" FOREIGN KEY ("changedById") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PermissionAudit" ADD CONSTRAINT "PermissionAudit_oldProfileId_fkey" FOREIGN KEY ("oldProfileId") REFERENCES "public"."PermissionProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PermissionAudit" ADD CONSTRAINT "PermissionAudit_newProfileId_fkey" FOREIGN KEY ("newProfileId") REFERENCES "public"."PermissionProfile"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,9 +1,12 @@
 const { PrismaClient } = require('@prisma/client');
 const bcrypt = require('bcryptjs');
+const { execSync } = require('child_process');
 
 const prisma = new PrismaClient();
 
 async function main() {
+  // Ensure the database schema is up to date before seeding
+  execSync('npx prisma migrate deploy', { stdio: 'inherit' });
   // ✅ 1. Create Company
   const company = await prisma.company.upsert({
     where: { name: 'CoreNZ' },
@@ -20,7 +23,20 @@ async function main() {
   });
   console.log(`✅ Department created: ${department.name} (${department.id})`);
 
-  // ✅ 3. Admin User & Employees
+  // ✅ 3. Default Permission Profile
+  const defaultProfile = await prisma.permissionProfile.upsert({
+    where: { companyId_name: { companyId: company.id, name: 'Default' } },
+    update: {},
+    create: {
+      companyId: company.id,
+      name: 'Default',
+      description: 'Default permission profile',
+      permissions: {},
+      builtIn: true,
+    },
+  });
+
+  // ✅ 4. Admin User & Employees
   const hashedPassword = await bcrypt.hash('Admin123!', 10);
   const adminUser = await prisma.user.upsert({
     where: { email: 'admin@corenz.com' },
@@ -33,6 +49,7 @@ async function main() {
       password: hashedPassword,
       companyId: company.id,
       departmentId: department.id,
+      permissionProfileId: defaultProfile.id,
     },
   });
 
@@ -64,6 +81,7 @@ async function main() {
         password: hashedPassword,
         companyId: company.id, // ✅ FIXED: Added missing companyId
         departmentId: department.id,
+        permissionProfileId: defaultProfile.id,
       },
     });
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,29 +1,104 @@
-const { PrismaClient } = require('@prisma/client');
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import { execSync } from 'child_process';
+
 const prisma = new PrismaClient();
 
 async function main() {
+  // Ensure the database schema is up to date before seeding
+  execSync('npx prisma migrate deploy', { stdio: 'inherit' });
+
   // ✅ 1. Create Company
   const company = await prisma.company.upsert({
     where: { name: 'CoreNZ' },
     update: {},
-    create: {
-      name: 'CoreNZ',
-    },
+    create: { name: 'CoreNZ' },
   });
   console.log(`✅ Company created: ${company.name} (${company.id})`);
 
   // ✅ 2. Create Department linked to Company
   const department = await prisma.department.upsert({
-    where: { name: 'Sales' },
-    update: { companyId: company.id },
-    create: {
-      name: 'Sales',
-      companyId: company.id,
-    },
+    where: { companyId_name: { companyId: company.id, name: 'Sales' } },
+    update: {},
+    create: { name: 'Sales', companyId: company.id },
   });
   console.log(`✅ Department created: ${department.name} (${department.id})`);
 
-  // ✅ 3. Create system-defined EventCategories
+  // ✅ 3. Default Permission Profile
+  const defaultProfile = await prisma.permissionProfile.upsert({
+    where: { companyId_name: { companyId: company.id, name: 'Default' } },
+    update: {},
+    create: {
+      companyId: company.id,
+      name: 'Default',
+      description: 'Default permission profile',
+      permissions: {},
+      builtIn: true,
+    },
+  });
+
+  // ✅ 4. Admin User & Employees
+  const hashedPassword = await bcrypt.hash('Admin123!', 10);
+  const adminUser = await prisma.user.upsert({
+    where: { email: 'admin@corenz.com' },
+    update: {},
+    create: {
+      email: 'admin@corenz.com',
+      firstName: 'System',
+      lastName: 'Admin',
+      role: 'ADMIN',
+      password: hashedPassword,
+      companyId: company.id,
+      departmentId: department.id,
+      permissionProfileId: defaultProfile.id,
+    },
+  });
+
+  await prisma.employee.upsert({
+    where: { userId: adminUser.id },
+    update: {},
+    create: {
+      userId: adminUser.id,
+      departmentId: department.id,
+      companyId: company.id,
+      isActive: true,
+    },
+  });
+
+  const sampleEmployees = [
+    { email: 'john.doe@corenz.com', firstName: 'John', lastName: 'Doe' },
+    { email: 'jane.smith@corenz.com', firstName: 'Jane', lastName: 'Smith' },
+  ];
+
+  for (const emp of sampleEmployees) {
+    const user = await prisma.user.upsert({
+      where: { email: emp.email },
+      update: {},
+      create: {
+        email: emp.email,
+        firstName: emp.firstName,
+        lastName: emp.lastName,
+        role: 'EMPLOYEE',
+        password: hashedPassword,
+        companyId: company.id,
+        departmentId: department.id,
+        permissionProfileId: defaultProfile.id,
+      },
+    });
+
+    await prisma.employee.upsert({
+      where: { userId: user.id },
+      update: {},
+      create: {
+        userId: user.id,
+        departmentId: department.id,
+        companyId: company.id,
+        isActive: true,
+      },
+    });
+  }
+
+  // ✅ 5. Create system-defined EventCategories
   const systemCategories = [
     {
       name: 'Annual Leave',


### PR DESCRIPTION
## Summary
- add Prisma migration creating permission profile tables and user reference
- run migrations before seeding and assign a default permission profile

## Testing
- `npm test`
- `npm run build` *(fails: Can't reach database server at `nozomi.proxy.rlwy.net:11874`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0fa4288c8331a4d1ffda3fc6dae3