### PR TITLE
Fix admin dashboard widget overlap by adjusting top row height

### DIFF
--- a/app/(withSidebar)/dashboard/admin/page.tsx
+++ b/app/(withSidebar)/dashboard/admin/page.tsx
@@ -67,8 +67,8 @@ export default async function AdminDashboardPage() {
       {/* Dashboard Grid - Full screen layout */}
       <main className="flex-1 p-4 overflow-hidden">
         <div className="h-full flex flex-col gap-4">
-          {/* Top Row - 5 cards with proper heights */}
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 h-48">
+          {/* Top Row - 5 cards with flexible height */}
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 min-h-[18rem]">
             {/* Holiday Balance Card - Compact */}
             <LeaveSummaryCard employeeId={user.employee.id} />
 


### PR DESCRIPTION
## Summary
- ensure admin dashboard top row widgets have flexible height with `min-h-[18rem]`
- update comment to reflect flexible height layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05dde22fc8331a1c2fa71b145cf7d