### PR TITLE
Fix admin dashboard widget layout and widen news section

### DIFF
--- a/app/(withSidebar)/dashboard/admin/AdminDashboardClient.tsx
+++ b/app/(withSidebar)/dashboard/admin/AdminDashboardClient.tsx
@@ -280,44 +280,6 @@ export default function AdminDashboardClient({
     );
   }
 
-  // Recent Activity Section
-  if (section === "recent-activity") {
-    return (
-      <DashboardWidget title="Recent Activity" icon={UserPlus} className="h-full">
-        <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 glass-subtle rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-              <span className="text-sm font-medium">New Hires</span>
-            </div>
-            <span className="text-xl font-bold text-green-600">{metrics?.newStartersThisMonth || 0}</span>
-          </div>
-          <div className="flex items-center justify-between p-3 glass-subtle rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-amber-500 rounded-full"></div>
-              <span className="text-sm font-medium">Pending Reviews</span>
-            </div>
-            <span className="text-xl font-bold text-amber-600">2</span>
-          </div>
-          <div className="flex items-center justify-between p-3 glass-subtle rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-red-500 rounded-full"></div>
-              <span className="text-sm font-medium">Expiring Docs</span>
-            </div>
-            <span className="text-xl font-bold text-red-600">3</span>
-          </div>
-          <div className="flex items-center justify-between p-3 glass-subtle rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-              <span className="text-sm font-medium">Training Due</span>
-            </div>
-            <span className="text-xl font-bold text-blue-600">5</span>
-          </div>
-        </div>
-      </DashboardWidget>
-    );
-  }
-
   // People Metrics Section
   if (section === "people-metrics") {
     return (

--- a/app/(withSidebar)/dashboard/admin/page.tsx
+++ b/app/(withSidebar)/dashboard/admin/page.tsx
@@ -67,8 +67,8 @@ export default async function AdminDashboardPage() {
       {/* Dashboard Grid - Full screen layout */}
       <main className="flex-1 p-4 overflow-hidden">
         <div className="h-full flex flex-col gap-4">
-          {/* Top Row - 5 cards with proper heights */}
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 h-48">
+          {/* Top Row - 4 cards with flexible height */}
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 min-h-[18rem]">
             {/* Holiday Balance Card - Compact */}
             <LeaveSummaryCard employeeId={user.employee.id} />
 
@@ -86,13 +86,6 @@ export default async function AdminDashboardPage() {
               section="calendar"
             />
 
-            {/* Recent Activity */}
-            <AdminDashboardClient
-              employeeId={user.employee.id}
-              firstName={user.firstName ?? ""}
-              section="recent-activity"
-            />
-
             {/* People Metrics */}
             <AdminDashboardClient
               employeeId={user.employee.id}
@@ -103,21 +96,21 @@ export default async function AdminDashboardPage() {
 
           {/* Bottom Row - 2 cards filling remaining space */}
           <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 flex-1 min-h-0 overflow-hidden">
-            {/* News Widget - Fixed height container */}
+            {/* Action Items - Fixed height container */}
             <div className="flex flex-col min-h-0">
               <AdminDashboardClient
                 employeeId={user.employee.id}
                 firstName={user.firstName ?? ""}
-                section="news"
+                section="action-items"
               />
             </div>
 
-            {/* Action Items - spans 3 columns with fixed height container */}
+            {/* News Widget - spans 3 columns with fixed height container */}
             <div className="lg:col-span-3 flex flex-col min-h-0">
               <AdminDashboardClient
                 employeeId={user.employee.id}
                 firstName={user.firstName ?? ""}
-                section="action-items"
+                section="news"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- ensure admin dashboard top row widgets have flexible height with `min-h-[18rem]`
- swap Latest news and Action Items widgets so news spans three columns and action items one
- remove Recent Activity widget and adjust top row to four columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05dde22fc8331a1c2fa71b145cf7d