### PR TITLE
Require companyId for user-related models

### DIFF
--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
 export async function POST(req: Request) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session || !session.user) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/app/api/reports/save/route.ts
+++ b/app/api/reports/save/route.ts
@@ -6,14 +6,14 @@ import { authOptions } from "@/lib/auth-options";
 export async function POST(req: Request) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
     }
 
     const { name, fields, category } = await req.json();
-if (!fields || !Array.isArray(fields) || fields.length === 0) {
-  return NextResponse.json({ error: "No fields selected." }, { status: 400 });
-}
+    if (!fields || !Array.isArray(fields) || fields.length === 0) {
+      return NextResponse.json({ error: "No fields selected." }, { status: 400 });
+    }
 
     const newReport = await prisma.savedReport.create({
       data: {
@@ -21,7 +21,7 @@ if (!fields || !Array.isArray(fields) || fields.length === 0) {
         category: category || "Uncategorised",
         fields, // ✅ native array, no stringify
         createdBy: session.user.id,
-        companyId: session.user.companyId ?? null,
+        companyId: session.user.companyId,
       },
     });
 

--- a/pages/api/seed-user.ts
+++ b/pages/api/seed-user.ts
@@ -9,6 +9,10 @@ export default async function handler(
 ) {
   try {
     const hashedPassword = await bcrypt.hash("password123", 10);
+    const company = await prisma.company.findFirst();
+    if (!company) {
+      throw new Error("No company found. Seed companies before creating users.");
+    }
 
     const user = await prisma.user.create({
       data: {
@@ -16,6 +20,7 @@ export default async function handler(
         password: hashedPassword,
         name: "Test User",
         role: "ADMIN",
+        company: { connect: { id: company.id } },
       },
     });
 

--- a/prisma/migrations/20250910120000_require_company_id/migration.sql
+++ b/prisma/migrations/20250910120000_require_company_id/migration.sql
@@ -1,0 +1,36 @@
+-- DropForeignKey
+ALTER TABLE "public"."User" DROP CONSTRAINT "User_companyId_fkey";
+ALTER TABLE "public"."Employee" DROP CONSTRAINT "Employee_companyId_fkey";
+ALTER TABLE "public"."SavedReport" DROP CONSTRAINT "SavedReport_companyId_fkey";
+
+-- Backfill existing data
+UPDATE "public"."User" u
+SET "companyId" = e."companyId"
+FROM "public"."Employee" e
+WHERE u."id" = e."userId" AND u."companyId" IS NULL AND e."companyId" IS NOT NULL;
+
+UPDATE "public"."SavedReport" sr
+SET "companyId" = u."companyId"
+FROM "public"."User" u
+WHERE sr."companyId" IS NULL AND sr."createdBy" = u."id" AND u."companyId" IS NOT NULL;
+
+DELETE FROM "public"."SavedReport" WHERE "companyId" IS NULL;
+DELETE FROM "public"."Employee" WHERE "companyId" IS NULL;
+DELETE FROM "public"."User" WHERE "companyId" IS NULL;
+
+-- DropIndex
+DROP INDEX "public"."User_email_key";
+
+-- AlterTable
+ALTER TABLE "public"."User" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "public"."Employee" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "public"."SavedReport" ALTER COLUMN "companyId" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_companyId_key" ON "public"."User"("email", "companyId");
+CREATE UNIQUE INDEX "SavedReport_name_companyId_key" ON "public"."SavedReport"("name", "companyId");
+
+-- AddForeignKey
+ALTER TABLE "public"."User" ADD CONSTRAINT "User_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "public"."Employee" ADD CONSTRAINT "Employee_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "public"."SavedReport" ADD CONSTRAINT "SavedReport_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 model User {
   id                                           String                 @id @default(cuid())
-  email                                        String                 @unique
+  email                                        String
   password                                     String
   role                                         Role                   @default(EMPLOYEE)
   permissionProfileId                          String?
@@ -25,7 +25,7 @@ model User {
   managerId                                    String?
   phone                                        String?
   dateOfBirth                                  DateTime?
-  companyId                                    String?
+  companyId                                    String
   emailPreferences                             Json?
   profileImageUrl                              String?
   // Personal info (extended)
@@ -72,12 +72,14 @@ model User {
   // Gender option relation
   genderOption                                  GenderOption?          @relation(fields: [genderOptionId], references: [id])
 
-  company                                      Company?               @relation(fields: [companyId], references: [id])
+  company                                      Company                @relation(fields: [companyId], references: [id])
   department                                   Department?            @relation(fields: [departmentId], references: [id])
   jobRole                                      JobRole?               @relation(fields: [jobRoleId], references: [id])
   manager                                      User?                  @relation("ManagerSubordinates", fields: [managerId], references: [id])
   subordinates                                 User[]                 @relation("ManagerSubordinates")
   permissionProfile                            PermissionProfile?     @relation(fields: [permissionProfileId], references: [id])
+
+  @@unique([email, companyId])
 }
 
 model ActivationToken {
@@ -97,7 +99,7 @@ model Employee {
   jobRoleId                 String?
   onboardingStatus          Json?
   onboardingTemplateId      String?
-  companyId                 String?                           // <-- Added companyId column
+  companyId                 String                           // <-- Added companyId column
   
   // Offboarding fields
   offboardingStatus         String?
@@ -107,7 +109,7 @@ model Employee {
   offboardingReason         String?
   offboardingNotes          String?
   
-  company                   Company?                          @relation(fields: [companyId], references: [id]) // <-- Relation
+  company                   Company                           @relation(fields: [companyId], references: [id]) // <-- Relation
 
   Document                  Document[]
   DocumentAcknowledgement   DocumentAcknowledgement[]
@@ -343,7 +345,7 @@ model FieldMetadata {
 
 model SavedReport {
   name        String
-  companyId   String?
+  companyId   String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   category    String
@@ -354,8 +356,10 @@ model SavedReport {
   pagination  Json?
   sort        Json?
   fields      String[]
-  Company     Company? @relation(fields: [companyId], references: [id])
+  Company     Company @relation(fields: [companyId], references: [id])
   user        User     @relation(fields: [createdBy], references: [id])
+
+  @@unique([name, companyId])
 }
 
 model Document {


### PR DESCRIPTION
## Summary
- make companyId required on User, Employee and SavedReport models
- enforce company-scoped uniqueness for user emails and saved report names
- ensure report creation and seed user logic always provide a companyId
- add migration to backfill or remove rows lacking companyId

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c087817e588331816d82016e1153a4