### PR TITLE
Require company context for working patterns

### DIFF
--- a/app/api/working-patterns/route.ts
+++ b/app/api/working-patterns/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
 
 // Zod schema for creating a new pattern
 const WorkingPatternCreateSchema = z.object({
@@ -21,8 +23,13 @@ const WorkingPatternCreateSchema = z.object({
 
 export async function GET() {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.companyId) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
     const patterns = await prisma.workingPattern.findMany({
-      where: { active: true },
+      where: { companyId: session.user.companyId, active: true },
       orderBy: { name: "asc" },
       include: {
         WorkingPatternWeek: {
@@ -60,6 +67,11 @@ export async function GET() {
 
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.companyId) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await req.json();
     const { name, description, weeks } = WorkingPatternCreateSchema.parse(body);
 
@@ -67,6 +79,7 @@ export async function POST(req: Request) {
       data: {
         name,
         description,
+        companyId: session.user.companyId,
         WorkingPatternWeek: {
           create: weeks.map((week) => ({
             weekNumber: week.weekNumber,

--- a/prisma/migrations/20250910153000_add_company_id_to_working_pattern/migration.sql
+++ b/prisma/migrations/20250910153000_add_company_id_to_working_pattern/migration.sql
@@ -1,0 +1,23 @@
+-- Add companyId column to WorkingPattern and backfill existing records
+ALTER TABLE "WorkingPattern" ADD COLUMN "companyId" TEXT;
+
+-- Populate companyId based on linked employees
+UPDATE "WorkingPattern" wp
+SET "companyId" = (
+  SELECT e."companyId"
+  FROM "Employee" e
+  WHERE e."workingPatternId" = wp."id"
+  LIMIT 1
+)
+WHERE "companyId" IS NULL;
+
+-- Fallback: assign first company if still null
+UPDATE "WorkingPattern"
+SET "companyId" = (SELECT "id" FROM "Company" LIMIT 1)
+WHERE "companyId" IS NULL;
+
+-- Make column required and add foreign key
+ALTER TABLE "WorkingPattern" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "WorkingPattern"
+ADD CONSTRAINT "WorkingPattern_companyId_fkey"
+FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,6 +253,7 @@ model Company {
   employees           Employee[]
   permissionProfiles  PermissionProfile[]
   genderOptions       GenderOption[]
+  workingPatterns     WorkingPattern[]
 }
 
 model JobRole {
@@ -281,6 +282,8 @@ model WorkingPattern {
   createdAt          DateTime                           @default(now())
   updatedAt          DateTime                           @updatedAt
   description        String?
+  companyId          String
+  company            Company                           @relation(fields: [companyId], references: [id])
   employees          Employee[]
   assignments        EmployeeWorkingPatternAssignment[]
   WorkingPatternWeek WorkingPatternWeek[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -26,7 +26,7 @@ async function main() {
 
   // ✅ 3. Standard Working Pattern (Monday-Friday, 9am-5pm)
   let standardWorkingPattern = await prisma.workingPattern.findFirst({
-    where: { name: 'Standard (Mon-Fri, 9am-5pm)' },
+    where: { name: 'Standard (Mon-Fri, 9am-5pm)', companyId: company.id },
   });
 
   if (!standardWorkingPattern) {
@@ -34,6 +34,7 @@ async function main() {
       data: {
         name: 'Standard (Mon-Fri, 9am-5pm)',
         description: 'Standard Monday to Friday working pattern from 9am to 5pm',
+        companyId: company.id,
         WorkingPatternWeek: {
           create: [
             {


### PR DESCRIPTION
## Summary
- secure working pattern API with company-aware sessions
- scope working patterns to a company and backfill existing data
- seed default working pattern per tenant

## Testing
- `npx prisma generate`
- `npx prisma migrate dev --name add-company-id-to-working-pattern` *(fails: Can't reach database server at `nozomi.proxy.rlwy.net:11874`)*
- `npm run lint` *(fails: Invalid Options: - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08e22bd0883319f140530be589376