### PR TITLE
Scope onboarding to company for security

### DIFF
--- a/app/api/onboarding/assignments/route.ts
+++ b/app/api/onboarding/assignments/route.ts
@@ -6,13 +6,17 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session?.user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (!session?.user?.id || !session.user.companyId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
 
-  // Find any active assignment for this user
+  // Find any active assignment for this user scoped to their company
   const assignment = await prisma.onboardingAssignment.findFirst({
     where: {
       userId: session.user.id,
       completedAt: null,
+      template: { companyId: session.user.companyId },
+      user: { companyId: session.user.companyId },
     },
     include: { template: { include: { steps: true } } },
   });
@@ -22,7 +26,9 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session?.user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (!session?.user?.id || !session.user.companyId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
 
   const { templateId, userId, employeeId } = await req.json();
 
@@ -30,23 +36,36 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "templateId, userId, and employeeId are required" }, { status: 400 });
   }
 
-  // ✅ Fetch template with steps
-  const template = await prisma.onboardingTemplate.findUnique({
-    where: { id: templateId },
+  // Ensure template belongs to company
+  const template = await prisma.onboardingTemplate.findFirst({
+    where: { id: templateId, companyId: session.user.companyId },
     include: { steps: true },
   });
-
   if (!template) {
     return NextResponse.json({ error: "Template not found" }, { status: 404 });
   }
 
-  // ✅ Transaction: Create assignment, instance, and seed steps atomically
+  // Ensure employee belongs to company
+  const employee = await prisma.employee.findFirst({
+    where: { id: employeeId, companyId: session.user.companyId },
+    include: { user: true },
+  });
+  if (!employee) {
+    return NextResponse.json({ error: "Employee not found" }, { status: 404 });
+  }
+
+  // Optional: validate provided userId matches employee's userId
+  if (employee.userId !== userId) {
+    return NextResponse.json({ error: "User does not match employee" }, { status: 400 });
+  }
+
+  // Transaction: Create assignment, instance, and seed steps atomically
   const result = await prisma.$transaction(async (tx) => {
     // 1. Create onboarding assignment
     const assignment = await tx.onboardingAssignment.create({
       data: {
-        userId,
-        templateId,
+        userId: employee.userId,
+        templateId: template.id,
         progress: [],
       },
     });
@@ -54,8 +73,8 @@ export async function POST(req: NextRequest) {
     // 2. Create onboarding instance
     const onboardingInstance = await tx.onboardingInstance.create({
       data: {
-        employeeId,
-        templateId,
+        employeeId: employee.id,
+        templateId: template.id,
         status: "active",
         startedAt: new Date(),
       },
@@ -79,7 +98,9 @@ export async function POST(req: NextRequest) {
 
 export async function PATCH(req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session?.user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (!session?.user?.id || !session.user.companyId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
 
   const { onboardingInstanceId } = await req.json();
 
@@ -87,9 +108,13 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "onboardingInstanceId is required" }, { status: 400 });
   }
 
-  // Fetch instance with steps and related assignment
-  const instance = await prisma.onboardingInstance.findUnique({
-    where: { id: onboardingInstanceId },
+  // Fetch instance with steps and related assignment, scoped to company
+  const instance = await prisma.onboardingInstance.findFirst({
+    where: {
+      id: onboardingInstanceId,
+      employee: { companyId: session.user.companyId },
+      template: { companyId: session.user.companyId },
+    },
     include: {
       steps: true,
       employee: { include: { user: true } },
@@ -108,6 +133,8 @@ export async function PATCH(req: NextRequest) {
         userId: instance.employee.userId,
         templateId: instance.templateId,
         completedAt: null,
+        template: { companyId: session.user.companyId },
+        user: { companyId: session.user.companyId },
       },
       data: { completedAt: new Date() },
     });

--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -5,11 +5,11 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { resend } from "@/lib/resend";
 
-async function findBestOnboardingTemplate(employee: any) {
+async function findBestOnboardingTemplate(employee: any, companyId: string) {
   // 1. By Job Role
   if (employee.jobRoleId) {
     const byJobRole = await prisma.onboardingTemplate.findFirst({
-      where: { jobRoles: { some: { id: employee.jobRoleId } }, isActive: true },
+      where: { jobRoles: { some: { id: employee.jobRoleId } }, isActive: true, companyId },
       include: { steps: true },
     });
     if (byJobRole) return byJobRole;
@@ -18,19 +18,19 @@ async function findBestOnboardingTemplate(employee: any) {
   // 2. By Department
   if (employee.departmentId) {
     const byDept = await prisma.onboardingTemplate.findFirst({
-      where: { departments: { some: { id: employee.departmentId } }, isActive: true },
+      where: { departments: { some: { id: employee.departmentId } }, isActive: true, companyId },
       include: { steps: true },
     });
     if (byDept) return byDept;
   }
 
   // 3. Default (fallback)
-  return prisma.onboardingTemplate.findFirst({ where: { isDefault: true, isActive: true }, include: { steps: true } });
+  return prisma.onboardingTemplate.findFirst({ where: { isDefault: true, isActive: true, companyId }, include: { steps: true } });
 }
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session?.user) {
+  if (!session?.user?.id || !session.user.companyId) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
@@ -45,9 +45,9 @@ export async function POST(req: NextRequest) {
         ? rawTemplateId
         : undefined;
 
-    // Fetch employee with related user, dept, role
-    const employee = await prisma.employee.findUnique({
-      where: { id: employeeId },
+    // Fetch employee with related user, dept, role scoped to company
+    const employee = await prisma.employee.findFirst({
+      where: { id: employeeId, companyId: session.user.companyId },
       include: { user: true, department: true, jobRole: true },
     });
 
@@ -73,13 +73,13 @@ export async function POST(req: NextRequest) {
         where: {
           id: templateId,
           isActive: true,
-          companyId: employee.companyId ?? undefined,
+          companyId: session.user.companyId,
         },
         include: { steps: true },
       });
     }
     if (!template) {
-      template = await findBestOnboardingTemplate(employee);
+      template = await findBestOnboardingTemplate(employee, session.user.companyId);
     }
     if (!template) {
       return NextResponse.json({ error: "No onboarding template found" }, { status: 400 });


### PR DESCRIPTION
## Summary
- require `session.user.companyId` in onboarding assignment handlers
- restrict assignments and template selection to the requester's company
- verify employee and template ownership before creating or completing assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c091d775e08331af019882a75a1139