### PR TITLE
feat: scope event categories by company

### DIFF
--- a/app/api/employees/[id]/entitlement/route.ts
+++ b/app/api/employees/[id]/entitlement/route.ts
@@ -13,15 +13,16 @@ export async function GET(
   try {
     const session = await getServerSession(authOptions);
 
-    if (!session || !session.user) {
+    if (!session || !session.user?.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const employeeId = params.id;
+    const companyId = session.user.companyId;
 
-    // ✅ Fetch entitlements with related event category
+    // ✅ Fetch entitlements with related event category scoped by company
     const entitlements = await prisma.leaveEntitlement.findMany({
-      where: { employeeId },
+      where: { employeeId, companyId },
       include: {
         eventCategory: {
           select: {
@@ -64,12 +65,13 @@ export async function POST(
   try {
     const session = await getServerSession(authOptions);
 
-    // ✅ Restrict to ADMIN only
-    if (!session || session.user.role !== "ADMIN") {
+    // ✅ Restrict to ADMIN only and ensure company scope
+    if (!session || session.user.role !== "ADMIN" || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const employeeId = params.id;
+    const companyId = session.user.companyId;
     const entitlements: { eventCategoryId: string; totalDays: number; daysAllocated?: number }[] = await req.json();
 
     for (const entitlement of entitlements) {
@@ -96,6 +98,7 @@ export async function POST(
           totalDays: entitlement.totalDays,
           usedDays: 0, // adjust if needed
           daysAllocated: entitlement.daysAllocated ?? 0,
+          companyId,
         },
       });
     }

--- a/app/api/employees/[id]/leave-requests/route.ts
+++ b/app/api/employees/[id]/leave-requests/route.ts
@@ -8,9 +8,12 @@ import { validateLeaveRequest } from "@/lib/validateLeaveRequest";
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       console.log("❌ Unauthenticated attempt to submit leave request");
-      return NextResponse.json({ success: false, error: "Unauthenticated" }, { status: 401 });
+      return NextResponse.json(
+        { success: false, error: "Unauthenticated" },
+        { status: 401 }
+      );
     }
 
     const userId = session.user.id;
@@ -76,12 +79,12 @@ export async function POST(req: Request, { params }: { params: { id: string } })
         employee: { connect: { id: employeeId } },
         requester: { connect: { id: userId } },
         eventCategory: { connect: { id: eventCategoryId } },
+        company: { connect: { id: session.user.companyId } },
         startDate: new Date(startDate),
         endDate: new Date(endDate),
         dayType: dayType ?? "FULL_DAY",
         reason: reason ?? "",
         paidStatus: eventCategoryName === "Sick Leave" ? paidStatus ?? "PAID" : null,
-        companyId: session.user.companyId,
       },
     });
 

--- a/app/api/employees/[id]/leave-requests/route.ts
+++ b/app/api/employees/[id]/leave-requests/route.ts
@@ -49,8 +49,8 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 403 });
     }
 
-    const eventCategory = await prisma.eventCategory.findUnique({
-      where: { id: eventCategoryId },
+    const eventCategory = await prisma.eventCategory.findFirst({
+      where: { id: eventCategoryId, companyId: session.user.companyId },
       select: { name: true },
     });
 
@@ -68,20 +68,22 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       startDate: new Date(startDate),
       endDate: new Date(endDate),
       isAdmin: session.user.role === "ADMIN",
+      companyId: session.user.companyId,
     });
 
     const newLeaveRequest = await prisma.leaveRequest.create({
-  data: {
-    employee: { connect: { id: employeeId } },
-    requester: { connect: { id: userId } },
-    eventCategory: { connect: { id: eventCategoryId } },
-    startDate: new Date(startDate),
-    endDate: new Date(endDate),
-    dayType: dayType ?? "FULL_DAY",
-    reason: reason ?? "",
-    paidStatus: eventCategoryName === "Sick Leave" ? paidStatus ?? "PAID" : null,
-  },
-});
+      data: {
+        employee: { connect: { id: employeeId } },
+        requester: { connect: { id: userId } },
+        eventCategory: { connect: { id: eventCategoryId } },
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+        dayType: dayType ?? "FULL_DAY",
+        reason: reason ?? "",
+        paidStatus: eventCategoryName === "Sick Leave" ? paidStatus ?? "PAID" : null,
+        companyId: session.user.companyId,
+      },
+    });
 
     if (employee.user.managerId) {
       const manager = await prisma.user.findUnique({

--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -287,6 +287,7 @@ export async function POST(req: Request) {
             name: "Holiday",
             categoryType: "TIME_OFF",
             isActive: true,
+            companyId,
           },
         });
 
@@ -300,6 +301,7 @@ export async function POST(req: Request) {
               adminOnly: false,
               color: "#10B981", // Green color
               isActive: true,
+              companyId,
             },
           });
         }
@@ -311,6 +313,7 @@ export async function POST(req: Request) {
               eventCategoryId: holidayCategory.id,
               totalDays: entitlementDays,
               usedDays: 0,
+              companyId,
             },
           });
         }

--- a/app/api/event-categories/archived/route.ts
+++ b/app/api/event-categories/archived/route.ts
@@ -2,19 +2,27 @@ export const dynamic = "force-dynamic";
 
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.companyId) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const archivedCategories = await prisma.eventCategory.findMany({
       where: {
+        companyId: session.user.companyId,
         OR: [
           { isActive: false },
-          { subcategories: { some: { isActive: false } } },
+          { subcategories: { some: { isActive: false, companyId: session.user.companyId } } },
         ],
       },
       include: {
         subcategories: {
-          where: { isActive: false },
+          where: { isActive: false, companyId: session.user.companyId },
         },
       },
       orderBy: {

--- a/app/api/event-categories/route.ts
+++ b/app/api/event-categories/route.ts
@@ -15,12 +15,17 @@ const EventCategorySchema = z.object({
 });
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.companyId) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const categories = await prisma.eventCategory.findMany({
-      where: { isActive: true },
+      where: { isActive: true, companyId: session.user.companyId },
       include: {
         subcategories: {
-          where: { isActive: true },
+          where: { isActive: true, companyId: session.user.companyId },
         },
       },
       orderBy: {
@@ -40,7 +45,7 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 403 });
   }
 
@@ -57,8 +62,8 @@ export async function POST(req: Request) {
 
     const { name, categoryType, requiresApproval, adminOnly } = parse.data;
 
-    const existing = await prisma.eventCategory.findUnique({
-      where: { name },
+    const existing = await prisma.eventCategory.findFirst({
+      where: { name, companyId: session.user.companyId },
     });
 
     if (existing) {
@@ -74,6 +79,7 @@ export async function POST(req: Request) {
         categoryType,
         requiresApproval,
         adminOnly,
+        companyId: session.user.companyId,
       },
     });
 

--- a/app/api/event-subcategories/route.ts
+++ b/app/api/event-subcategories/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
         defaultPaidStatus,
         isActive,
         eventCategory: { connect: { id: eventCategoryId } },
-        companyId: session.user.companyId,
+        company: { connect: { id: session.user.companyId } },
       },
     });
 

--- a/app/api/event-subcategories/route.ts
+++ b/app/api/event-subcategories/route.ts
@@ -15,8 +15,14 @@ const EventSubcategorySchema = z.object({
 });
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.companyId) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const subcategories = await prisma.eventSubcategory.findMany({
+      where: { companyId: session.user.companyId },
       include: {
         eventCategory: true,
       },
@@ -37,7 +43,7 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 403 });
   }
 
@@ -54,9 +60,8 @@ export async function POST(req: Request) {
 
     const { name, eventCategoryId, defaultPaidStatus, isActive } = parse.data;
 
-    // OPTIONAL: Prevent adding subcategories under system-defined categories
-    const parentCategory = await prisma.eventCategory.findUnique({
-      where: { id: eventCategoryId },
+    const parentCategory = await prisma.eventCategory.findFirst({
+      where: { id: eventCategoryId, companyId: session.user.companyId },
     });
 
     if (!parentCategory) {
@@ -66,20 +71,13 @@ export async function POST(req: Request) {
       );
     }
 
-    // UNCOMMENT TO BLOCK under system-defined categories:
-    // if (parentCategory.systemDefined) {
-    //   return NextResponse.json(
-    //     { success: false, error: "Cannot add subcategories under system-defined categories." },
-    //     { status: 400 }
-    //   );
-    // }
-
     const newSubcategory = await prisma.eventSubcategory.create({
       data: {
         name,
         defaultPaidStatus,
         isActive,
         eventCategory: { connect: { id: eventCategoryId } },
+        companyId: session.user.companyId,
       },
     });
 

--- a/app/lib/validateLeaveRequest.ts
+++ b/app/lib/validateLeaveRequest.ts
@@ -14,12 +14,14 @@ export async function validateLeaveRequest({
   startDate,
   endDate,
   isAdmin = false,
+  companyId,
 }: {
   employeeId: string;
   eventCategoryId: string;
   startDate: Date;
   endDate: Date;
   isAdmin?: boolean;
+  companyId: string;
 }) {
   console.log("🛠️ [validateLeaveRequest] START:", {
     employeeId,
@@ -29,8 +31,8 @@ export async function validateLeaveRequest({
     isAdmin,
   });
 
-  const eventCategory = await prisma.eventCategory.findUnique({
-    where: { id: eventCategoryId },
+  const eventCategory = await prisma.eventCategory.findFirst({
+    where: { id: eventCategoryId, companyId },
     select: { name: true },
   });
 
@@ -43,8 +45,8 @@ export async function validateLeaveRequest({
   const eventRule = await prisma.eventRule.findUnique({
     where: {
       companyId_eventCategoryId: {
-        companyId: "default-company-id",
-        eventCategoryId: eventCategoryId,
+        companyId,
+        eventCategoryId,
       },
     },
     select: {
@@ -87,6 +89,7 @@ export async function validateLeaveRequest({
   if (!isAdmin) {
     const blackoutDays = await prisma.blackoutDay.findMany({
       where: {
+        companyId,
         OR: [
           { allEvents: true },
           { eventCategoryIds: { has: eventCategoryId } },
@@ -117,6 +120,7 @@ export async function validateLeaveRequest({
     where: {
       employeeId,
       eventCategoryId,
+      companyId,
     },
   });
 

--- a/backfill.sql
+++ b/backfill.sql
@@ -2,3 +2,38 @@ UPDATE "Employee"
 SET "companyId" = "User"."companyId"
 FROM "User"
 WHERE "User"."id" = "Employee"."userId";
+
+-- Backfill EventCategory companyId using related records
+UPDATE "EventCategory" ec
+SET "companyId" = er."companyId"
+FROM "EventRule" er
+WHERE er."eventCategoryId" = ec."id" AND ec."companyId" IS NULL;
+
+UPDATE "EventCategory" ec
+SET "companyId" = e."companyId"
+FROM "LeaveEntitlement" le
+JOIN "Employee" e ON le."employeeId" = e."id"
+WHERE le."eventCategoryId" = ec."id" AND ec."companyId" IS NULL;
+
+UPDATE "EventCategory" ec
+SET "companyId" = e."companyId"
+FROM "LeaveRequest" lr
+JOIN "Employee" e ON lr."employeeId" = e."id"
+WHERE lr."eventCategoryId" = ec."id" AND ec."companyId" IS NULL;
+
+-- Propagate EventCategory companyId to EventSubcategory
+UPDATE "EventSubcategory" esc
+SET "companyId" = ec."companyId"
+FROM "EventCategory" ec
+WHERE esc."eventCategoryId" = ec."id";
+
+-- Backfill companyId for LeaveEntitlement and LeaveRequest from Employee
+UPDATE "LeaveEntitlement" le
+SET "companyId" = e."companyId"
+FROM "Employee" e
+WHERE le."employeeId" = e."id";
+
+UPDATE "LeaveRequest" lr
+SET "companyId" = e."companyId"
+FROM "Employee" e
+WHERE lr."employeeId" = e."id";

--- a/prisma/migrations/20251010120000_add_companyid_to_eventcategory/migration.sql
+++ b/prisma/migrations/20251010120000_add_companyid_to_eventcategory/migration.sql
@@ -1,0 +1,33 @@
+-- DropIndex
+DROP INDEX "public"."EventCategory_name_key";
+
+-- AlterTable
+ALTER TABLE "public"."EventCategory" ADD COLUMN     "companyId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."EventSubcategory" ADD COLUMN     "companyId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."LeaveRequest" ADD COLUMN     "companyId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."LeaveEntitlement" ADD COLUMN     "companyId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventCategory_companyId_name_key" ON "public"."EventCategory"("companyId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventSubcategory_companyId_name_key" ON "public"."EventSubcategory"("companyId", "name");
+
+-- AddForeignKey
+ALTER TABLE "public"."EventCategory" ADD CONSTRAINT "EventCategory_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EventSubcategory" ADD CONSTRAINT "EventSubcategory_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LeaveRequest" ADD CONSTRAINT "LeaveRequest_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LeaveEntitlement" ADD CONSTRAINT "LeaveEntitlement_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "public"."Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,16 +29,16 @@ model User {
   emailPreferences                             Json?
   profileImageUrl                              String?
   // Personal info (extended)
-  addressStreet                                 String?
-  addressCity                                   String?
-  addressPostcode                               String?
-  addressCountry                                String?
-  emergencyContactName                          String?
-  emergencyContactRelationship                  String?
-  emergencyContactPhone                         String?
-  nationalId                                    String?
-  pronouns                                      String?
-  genderOptionId                                String?
+  addressStreet                                String?
+  addressCity                                  String?
+  addressPostcode                              String?
+  addressCountry                               String?
+  emergencyContactName                         String?
+  emergencyContactRelationship                 String?
+  emergencyContactPhone                        String?
+  nationalId                                   String?
+  pronouns                                     String?
+  genderOptionId                               String?
   activationToken                              ActivationToken?
   departmentHeadOf                             Department[]           @relation("DepartmentHead")
   documents                                    Document[]
@@ -49,35 +49,35 @@ model User {
   newsPosts                                    NewsPost[]
   onboardingAssignments                        OnboardingAssignment[]
   SavedReport                                  SavedReport[]
-  updatedTemplates                             OnboardingTemplate[] @relation("OnboardingTemplateUpdatedBy")
+  updatedTemplates                             OnboardingTemplate[]   @relation("OnboardingTemplateUpdatedBy")
 
   // Offboarding relations
-  offboardingInitiated                         EmployeeOffboarding[]  @relation("OffboardingInitiatedBy")
-  offboardingAccessRemoved                     EmployeeOffboarding[]  @relation("OffboardingAccessRemovedBy")
-  offboardingHandoverAssigned                  EmployeeOffboarding[]  @relation("OffboardingHandoverAssignedTo")
-  offboardingHRReviewCompleted                 EmployeeOffboarding[]  @relation("OffboardingHRReviewCompletedBy")
-  offboardingAssetsReturnedTo                  EmployeeOffboarding[]  @relation("OffboardingAssetsReturnedTo")
-  exitInterviewConducted                       EmployeeOffboarding[]  @relation("ExitInterviewInterviewer")
-  tasksAssigned                                OffboardingTask[]      @relation("TaskAssignedTo")
-  tasksCompleted                               OffboardingTask[]      @relation("TaskCompletedBy")
+  offboardingInitiated         EmployeeOffboarding[] @relation("OffboardingInitiatedBy")
+  offboardingAccessRemoved     EmployeeOffboarding[] @relation("OffboardingAccessRemovedBy")
+  offboardingHandoverAssigned  EmployeeOffboarding[] @relation("OffboardingHandoverAssignedTo")
+  offboardingHRReviewCompleted EmployeeOffboarding[] @relation("OffboardingHRReviewCompletedBy")
+  offboardingAssetsReturnedTo  EmployeeOffboarding[] @relation("OffboardingAssetsReturnedTo")
+  exitInterviewConducted       EmployeeOffboarding[] @relation("ExitInterviewInterviewer")
+  tasksAssigned                OffboardingTask[]     @relation("TaskAssignedTo")
+  tasksCompleted               OffboardingTask[]     @relation("TaskCompletedBy")
 
   // Permission relations
-  permissionAuditChanges                       PermissionAudit[]      @relation("PermissionAuditChangedBy")
-  permissionAuditEmployees                     PermissionAudit[]      @relation("PermissionAuditEmployee")
+  permissionAuditChanges   PermissionAudit[] @relation("PermissionAuditChangedBy")
+  permissionAuditEmployees PermissionAudit[] @relation("PermissionAuditEmployee")
 
   // Personal info audit relations
-  personalInfoAuditsAsSubject                  PersonalInfoAudit[]    @relation("PersonalInfoAuditSubjectUser")
-  personalInfoAuditsChangedBy                  PersonalInfoAudit[]    @relation("PersonalInfoAuditChangedBy")
+  personalInfoAuditsAsSubject PersonalInfoAudit[] @relation("PersonalInfoAuditSubjectUser")
+  personalInfoAuditsChangedBy PersonalInfoAudit[] @relation("PersonalInfoAuditChangedBy")
 
   // Gender option relation
-  genderOption                                  GenderOption?          @relation(fields: [genderOptionId], references: [id])
+  genderOption GenderOption? @relation(fields: [genderOptionId], references: [id])
 
-  company                                      Company                @relation(fields: [companyId], references: [id])
-  department                                   Department?            @relation(fields: [departmentId], references: [id])
-  jobRole                                      JobRole?               @relation(fields: [jobRoleId], references: [id])
-  manager                                      User?                  @relation("ManagerSubordinates", fields: [managerId], references: [id])
-  subordinates                                 User[]                 @relation("ManagerSubordinates")
-  permissionProfile                            PermissionProfile?     @relation(fields: [permissionProfileId], references: [id])
+  company           Company            @relation(fields: [companyId], references: [id])
+  department        Department?        @relation(fields: [departmentId], references: [id])
+  jobRole           JobRole?           @relation(fields: [jobRoleId], references: [id])
+  manager           User?              @relation("ManagerSubordinates", fields: [managerId], references: [id])
+  subordinates      User[]             @relation("ManagerSubordinates")
+  permissionProfile PermissionProfile? @relation(fields: [permissionProfileId], references: [id])
 
   @@unique([email, companyId])
 }
@@ -91,25 +91,25 @@ model ActivationToken {
 }
 
 model Employee {
-  id                        String                             @id @default(cuid())
-  userId                    String                             @unique
-  isActive                  Boolean                            @default(true)
-  workingPatternId          String?
-  departmentId              String?
-  jobRoleId                 String?
-  onboardingStatus          Json?
-  onboardingTemplateId      String?
-  companyId                 String                           // <-- Added companyId column
-  
+  id                   String  @id @default(cuid())
+  userId               String  @unique
+  isActive             Boolean @default(true)
+  workingPatternId     String?
+  departmentId         String?
+  jobRoleId            String?
+  onboardingStatus     Json?
+  onboardingTemplateId String?
+  companyId            String // <-- Added companyId column
+
   // Offboarding fields
-  offboardingStatus         String?
-  offboardingDate           DateTime?
-  lastWorkingDate           DateTime?
-  noticePeriodDays          Int?
-  offboardingReason         String?
-  offboardingNotes          String?
-  
-  company                   Company                           @relation(fields: [companyId], references: [id]) // <-- Relation
+  offboardingStatus String?
+  offboardingDate   DateTime?
+  lastWorkingDate   DateTime?
+  noticePeriodDays  Int?
+  offboardingReason String?
+  offboardingNotes  String?
+
+  company Company @relation(fields: [companyId], references: [id]) // <-- Relation
 
   Document                  Document[]
   DocumentAcknowledgement   DocumentAcknowledgement[]
@@ -123,7 +123,7 @@ model Employee {
   employmentChecks          EmploymentCheck[]
   formAssignments           FormAssignment[]
   formSubmissions           FormSubmission[]
-  formDataRecords           FormDataRecord[]                   // NEW: Persistent form data
+  formDataRecords           FormDataRecord[] // NEW: Persistent form data
   leaveEntitlements         LeaveEntitlement[]
   leaveRequests             LeaveRequest[]
   onboardingInstances       OnboardingInstance[]
@@ -146,7 +146,7 @@ model EmployeeWorkingPatternAssignment {
 
 model EventCategory {
   id               String             @id @default(cuid())
-  name             String             @unique
+  name             String
   requiresApproval Boolean
   adminOnly        Boolean
   isActive         Boolean            @default(true)
@@ -155,22 +155,30 @@ model EventCategory {
   categoryType     String
   color            String?
   systemDefined    Boolean            @default(false)
+  companyId        String
+  company          Company            @relation(fields: [companyId], references: [id])
   eventRules       EventRule[]
   subcategories    EventSubcategory[]
   LeaveEntitlement LeaveEntitlement[]
   leaveRequests    LeaveRequest[]
+
+  @@unique([companyId, name])
 }
 
 model EventSubcategory {
   id                String         @id @default(cuid())
   name              String
   eventCategoryId   String
+  companyId         String
   defaultPaidStatus PaidStatus     @default(PAID)
   isActive          Boolean        @default(true)
   createdAt         DateTime       @default(now())
   updatedAt         DateTime       @updatedAt
   eventCategory     EventCategory  @relation(fields: [eventCategoryId], references: [id])
+  company           Company        @relation(fields: [companyId], references: [id])
   LeaveRequest      LeaveRequest[]
+
+  @@unique([companyId, name])
 }
 
 model LeaveRequest {
@@ -188,11 +196,13 @@ model LeaveRequest {
   dayType          DayType
   eventCategoryId  String
   requesterId      String
+  companyId        String
   approvedBy       User?             @relation("LeaveRequest_approvedByIdToUser", fields: [approvedById], references: [id])
   employee         Employee          @relation(fields: [employeeId], references: [id])
   eventCategory    EventCategory     @relation(fields: [eventCategoryId], references: [id])
   requester        User              @relation("RequestingUser", fields: [requesterId], references: [id])
   EventSubcategory EventSubcategory? @relation(fields: [sickReasonId], references: [id])
+  company          Company           @relation(fields: [companyId], references: [id])
 }
 
 model LeaveEntitlement {
@@ -206,8 +216,10 @@ model LeaveEntitlement {
   eventCategoryId String
   carryoverDays   Float         @default(0)
   carryoverExpiry DateTime?
+  companyId       String
   employee        Employee      @relation(fields: [employeeId], references: [id])
   eventCategory   EventCategory @relation(fields: [eventCategoryId], references: [id])
+  company         Company       @relation(fields: [companyId], references: [id])
 
   @@unique([employeeId, eventCategoryId])
 }
@@ -254,6 +266,10 @@ model Company {
   permissionProfiles  PermissionProfile[]
   genderOptions       GenderOption[]
   workingPatterns     WorkingPattern[]
+  eventCategories     EventCategory[]
+  eventSubcategories  EventSubcategory[]
+  leaveRequests       LeaveRequest[]
+  leaveEntitlements   LeaveEntitlement[]
 }
 
 model JobRole {
@@ -283,7 +299,7 @@ model WorkingPattern {
   updatedAt          DateTime                           @updatedAt
   description        String?
   companyId          String
-  company            Company                           @relation(fields: [companyId], references: [id])
+  company            Company                            @relation(fields: [companyId], references: [id])
   employees          Employee[]
   assignments        EmployeeWorkingPatternAssignment[]
   WorkingPatternWeek WorkingPatternWeek[]
@@ -359,7 +375,7 @@ model SavedReport {
   pagination  Json?
   sort        Json?
   fields      String[]
-  Company     Company @relation(fields: [companyId], references: [id])
+  Company     Company  @relation(fields: [companyId], references: [id])
   user        User     @relation(fields: [createdBy], references: [id])
 
   @@unique([name, companyId])
@@ -529,10 +545,10 @@ model OnboardingStep {
   documentId              String?
   uploadType              OnboardingUploadType?
   instruction             String?
-  formId                  String?                 // <-- Already correctly defined
-  document                Document?               @relation(fields: [documentId], references: [id])
-  form                    Form?                   @relation(fields: [formId], references: [id])
-  template                OnboardingTemplate      @relation(fields: [templateId], references: [id])
+  formId                  String? // <-- Already correctly defined
+  document                Document?                @relation(fields: [documentId], references: [id])
+  form                    Form?                    @relation(fields: [formId], references: [id])
+  template                OnboardingTemplate       @relation(fields: [templateId], references: [id])
   onboardingStepInstances OnboardingStepInstance[]
 
   @@unique([templateId, label])
@@ -630,30 +646,30 @@ model FormSubmission {
 }
 
 model FormDataRecord {
-  id          String   @id @default(cuid())
-  formId      String
-  employeeId  String
-  data        Json     // Persistent data that can be updated
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  employee    Employee @relation(fields: [employeeId], references: [id])
-  form        Form     @relation(fields: [formId], references: [id])
+  id         String   @id @default(cuid())
+  formId     String
+  employeeId String
+  data       Json // Persistent data that can be updated
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  employee   Employee @relation(fields: [employeeId], references: [id])
+  form       Form     @relation(fields: [formId], references: [id])
 
   @@unique([formId, employeeId]) // One data record per employee per form
 }
 
 model PermissionProfile {
-  id          String        @id @default(cuid())
+  id          String   @id @default(cuid())
   companyId   String
   name        String
   description String?
-  permissions Json          // JSON object mapping screens to permission actions
-  builtIn     Boolean       @default(false)
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
+  permissions Json // JSON object mapping screens to permission actions
+  builtIn     Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  company     Company       @relation(fields: [companyId], references: [id])
-  users       User[]
+  company      Company           @relation(fields: [companyId], references: [id])
+  users        User[]
   oldAuditLogs PermissionAudit[] @relation("PermissionAuditOldProfile")
   newAuditLogs PermissionAudit[] @relation("PermissionAuditNewProfile")
 
@@ -661,20 +677,20 @@ model PermissionProfile {
 }
 
 model PermissionAudit {
-  id               String   @id @default(cuid())
-  employeeId       String
-  changedById      String
-  oldProfileId     String?
-  newProfileId     String?
-  oldPermissions   Json?    // Snapshot of old profile permissions
-  newPermissions   Json?    // Snapshot of new profile permissions
-  note             String?
-  changedAt        DateTime @default(now())
+  id             String   @id @default(cuid())
+  employeeId     String
+  changedById    String
+  oldProfileId   String?
+  newProfileId   String?
+  oldPermissions Json? // Snapshot of old profile permissions
+  newPermissions Json? // Snapshot of new profile permissions
+  note           String?
+  changedAt      DateTime @default(now())
 
-  employee         User     @relation("PermissionAuditEmployee", fields: [employeeId], references: [id])
-  changedBy        User     @relation("PermissionAuditChangedBy", fields: [changedById], references: [id])
-  oldProfile       PermissionProfile? @relation("PermissionAuditOldProfile", fields: [oldProfileId], references: [id])
-  newProfile       PermissionProfile? @relation("PermissionAuditNewProfile", fields: [newProfileId], references: [id])
+  employee   User               @relation("PermissionAuditEmployee", fields: [employeeId], references: [id])
+  changedBy  User               @relation("PermissionAuditChangedBy", fields: [changedById], references: [id])
+  oldProfile PermissionProfile? @relation("PermissionAuditOldProfile", fields: [oldProfileId], references: [id])
+  newProfile PermissionProfile? @relation("PermissionAuditNewProfile", fields: [newProfileId], references: [id])
 
   @@index([employeeId])
   @@index([changedAt])
@@ -682,40 +698,40 @@ model PermissionAudit {
 
 // Records field-level changes to a user's personal information
 model PersonalInfoAudit {
-  id          String   @id @default(cuid())
-  companyId   String
+  id            String   @id @default(cuid())
+  companyId     String
   subjectUserId String
-  changedById String
-  field       String
-  oldValue    String?
-  newValue    String?
-  changedAt   DateTime @default(now())
+  changedById   String
+  field         String
+  oldValue      String?
+  newValue      String?
+  changedAt     DateTime @default(now())
 
-  subjectUser User     @relation("PersonalInfoAuditSubjectUser", fields: [subjectUserId], references: [id])
-  changedBy   User     @relation("PersonalInfoAuditChangedBy", fields: [changedById], references: [id])
+  subjectUser User @relation("PersonalInfoAuditSubjectUser", fields: [subjectUserId], references: [id])
+  changedBy   User @relation("PersonalInfoAuditChangedBy", fields: [changedById], references: [id])
 
   @@index([companyId, subjectUserId, changedAt])
 }
 
 model GenderOption {
-  id         String   @id @default(cuid())
-  companyId  String
-  key        String
-  label      String
-  order      Int       @default(0)
-  active     Boolean   @default(true)
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
+  id        String   @id @default(cuid())
+  companyId String
+  key       String
+  label     String
+  order     Int      @default(0)
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  company    Company   @relation(fields: [companyId], references: [id])
-  users      User[]
+  company Company @relation(fields: [companyId], references: [id])
+  users   User[]
 
   @@unique([companyId, key])
   @@index([companyId, active])
 }
 
 enum FormType {
-  SUBMISSION  // One-time submission forms (current behavior)
+  SUBMISSION // One-time submission forms (current behavior)
   DATA_SCREEN // Persistent data screens (new behavior)
 }
 
@@ -770,98 +786,98 @@ enum OnboardingUploadType {
 }
 
 model EmployeeOffboarding {
-  id                        String    @id @default(cuid())
-  employeeId                String    @unique
-  initiatedById             String
-  initiatedAt               DateTime  @default(now())
-  completedAt               DateTime?
-  status                    OffboardingStatus @default(IN_PROGRESS)
-  
+  id            String            @id @default(cuid())
+  employeeId    String            @unique
+  initiatedById String
+  initiatedAt   DateTime          @default(now())
+  completedAt   DateTime?
+  status        OffboardingStatus @default(IN_PROGRESS)
+
   // Key Dates
-  resignationDate           DateTime?
-  lastWorkingDate           DateTime
-  noticePeriodDays          Int?
-  actualLeaveDate           DateTime?
-  
+  resignationDate  DateTime?
+  lastWorkingDate  DateTime
+  noticePeriodDays Int?
+  actualLeaveDate  DateTime?
+
   // Reason & Classification
-  offboardingType           OffboardingType
-  offboardingReason         String?
-  isVoluntary               Boolean   @default(true)
-  
+  offboardingType   OffboardingType
+  offboardingReason String?
+  isVoluntary       Boolean         @default(true)
+
   // Access Management
-  removeAccessImmediately   Boolean   @default(false)
-  accessRemovedAt           DateTime?
-  accessRemovedBy           String?
-  
+  removeAccessImmediately Boolean   @default(false)
+  accessRemovedAt         DateTime?
+  accessRemovedBy         String?
+
   // Asset Management
-  assetsToReturn            Json?
-  assetsReturned            Boolean   @default(false)
-  assetsReturnedAt          DateTime?
-  assetsReturnedTo          String?
-  
+  assetsToReturn   Json?
+  assetsReturned   Boolean   @default(false)
+  assetsReturnedAt DateTime?
+  assetsReturnedTo String?
+
   // Knowledge Transfer
-  handoverRequired          Boolean   @default(false)
-  handoverAssignedTo        String?
-  handoverCompleted         Boolean   @default(false)
-  handoverCompletedAt       DateTime?
-  handoverNotes             String?
-  
+  handoverRequired    Boolean   @default(false)
+  handoverAssignedTo  String?
+  handoverCompleted   Boolean   @default(false)
+  handoverCompletedAt DateTime?
+  handoverNotes       String?
+
   // Final Pay & Benefits
-  finalPayCalculated        Boolean   @default(false)
-  finalPayAmount            Decimal?  @db.Decimal(10,2)
-  unusedLeaveHours          Decimal?  @db.Decimal(8,2)
-  unusedLeavePayment        Decimal?  @db.Decimal(10,2)
-  benefitsEndDate           DateTime?
-  
+  finalPayCalculated Boolean   @default(false)
+  finalPayAmount     Decimal?  @db.Decimal(10, 2)
+  unusedLeaveHours   Decimal?  @db.Decimal(8, 2)
+  unusedLeavePayment Decimal?  @db.Decimal(10, 2)
+  benefitsEndDate    DateTime?
+
   // Exit Process - Enhanced with new fields
-  exitInterviewRequired     Boolean   @default(false)
-  exitInterviewScheduled    Boolean   @default(false)
-  exitInterviewDate         DateTime? // store start in UTC
-  exitInterviewEnd          DateTime? // optional: derive +60m by default
-  interviewerUserId         String?
-  interviewerName           String?   // denormalize if interviewer not a user
-  interviewerEmail          String?   // for ICS/attendee
-  location                  String?   // optional
-  exitInterviewNotes        String?
-  
+  exitInterviewRequired  Boolean   @default(false)
+  exitInterviewScheduled Boolean   @default(false)
+  exitInterviewDate      DateTime? // store start in UTC
+  exitInterviewEnd       DateTime? // optional: derive +60m by default
+  interviewerUserId      String?
+  interviewerName        String? // denormalize if interviewer not a user
+  interviewerEmail       String? // for ICS/attendee
+  location               String? // optional
+  exitInterviewNotes     String?
+
   // Exit Interview Form Management
-  sendForm                  Boolean   @default(false)
-  formTemplateId            String?   // ExitInterviewFormTemplate.id
-  formTiming                ExitInterviewFormTiming?
-  inviteIcsUid              String?   // UID used in ICS for updates/cancellation
-  inviteLastSentAt          DateTime?
-  scheduledSendAt           DateTime? // if ON_DATE
-  completionTokenHash       String?   // token hash for employee link (/exit-interview/[token])
-  completionStatus          ExitInterviewCompletionStatus @default(PENDING)
-  
+  sendForm            Boolean                       @default(false)
+  formTemplateId      String? // ExitInterviewFormTemplate.id
+  formTiming          ExitInterviewFormTiming?
+  inviteIcsUid        String? // UID used in ICS for updates/cancellation
+  inviteLastSentAt    DateTime?
+  scheduledSendAt     DateTime? // if ON_DATE
+  completionTokenHash String? // token hash for employee link (/exit-interview/[token])
+  completionStatus    ExitInterviewCompletionStatus @default(PENDING)
+
   // Administrative
-  hrReviewRequired          Boolean   @default(true)
-  hrReviewCompleted         Boolean   @default(false)
-  hrReviewCompletedBy       String?
-  hrReviewCompletedAt       DateTime?
-  hrNotes                   String?
-  
+  hrReviewRequired    Boolean   @default(true)
+  hrReviewCompleted   Boolean   @default(false)
+  hrReviewCompletedBy String?
+  hrReviewCompletedAt DateTime?
+  hrNotes             String?
+
   // References & Documentation
-  referenceContactAllowed   Boolean   @default(true)
-  documentationArchived     Boolean   @default(false)
-  complianceCheckCompleted  Boolean   @default(false)
-  
-  createdAt                 DateTime  @default(now())
-  updatedAt                 DateTime  @updatedAt
+  referenceContactAllowed  Boolean @default(true)
+  documentationArchived    Boolean @default(false)
+  complianceCheckCompleted Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // Relations
-  employee                  Employee  @relation(fields: [employeeId], references: [id], onDelete: Cascade)
-  initiatedBy               User      @relation("OffboardingInitiatedBy", fields: [initiatedById], references: [id])
-  accessRemovedByUser       User?     @relation("OffboardingAccessRemovedBy", fields: [accessRemovedBy], references: [id])
-  handoverAssignedToUser    User?     @relation("OffboardingHandoverAssignedTo", fields: [handoverAssignedTo], references: [id])
-  hrReviewCompletedByUser   User?     @relation("OffboardingHRReviewCompletedBy", fields: [hrReviewCompletedBy], references: [id])
-  assetsReturnedToUser      User?     @relation("OffboardingAssetsReturnedTo", fields: [assetsReturnedTo], references: [id])
-  interviewerUser           User?     @relation("ExitInterviewInterviewer", fields: [interviewerUserId], references: [id])
-  formTemplate              ExitInterviewFormTemplate? @relation(fields: [formTemplateId], references: [id])
+  employee                Employee                   @relation(fields: [employeeId], references: [id], onDelete: Cascade)
+  initiatedBy             User                       @relation("OffboardingInitiatedBy", fields: [initiatedById], references: [id])
+  accessRemovedByUser     User?                      @relation("OffboardingAccessRemovedBy", fields: [accessRemovedBy], references: [id])
+  handoverAssignedToUser  User?                      @relation("OffboardingHandoverAssignedTo", fields: [handoverAssignedTo], references: [id])
+  hrReviewCompletedByUser User?                      @relation("OffboardingHRReviewCompletedBy", fields: [hrReviewCompletedBy], references: [id])
+  assetsReturnedToUser    User?                      @relation("OffboardingAssetsReturnedTo", fields: [assetsReturnedTo], references: [id])
+  interviewerUser         User?                      @relation("ExitInterviewInterviewer", fields: [interviewerUserId], references: [id])
+  formTemplate            ExitInterviewFormTemplate? @relation(fields: [formTemplateId], references: [id])
 
-  tasks                     OffboardingTask[]
-  exitInterview             ExitInterview?
-  exitInterviewSubmissions  ExitInterviewSubmission[]
+  tasks                    OffboardingTask[]
+  exitInterview            ExitInterview?
+  exitInterviewSubmissions ExitInterviewSubmission[]
 
   @@index([employeeId])
   @@index([status])
@@ -871,25 +887,25 @@ model EmployeeOffboarding {
 }
 
 model OffboardingTask {
-  id            String    @id @default(cuid())
+  id            String       @id @default(cuid())
   offboardingId String
   title         String
   description   String?
   category      TaskCategory
-  isRequired    Boolean   @default(true)
+  isRequired    Boolean      @default(true)
   assignedTo    String?
   dueDate       DateTime?
   completedAt   DateTime?
   completedBy   String?
   notes         String?
-  order         Int       @default(0)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  order         Int          @default(0)
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
 
   // Relations
-  offboarding   EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
-  assignedToUser User?              @relation("TaskAssignedTo", fields: [assignedTo], references: [id])
-  completedByUser User?             @relation("TaskCompletedBy", fields: [completedBy], references: [id])
+  offboarding     EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
+  assignedToUser  User?               @relation("TaskAssignedTo", fields: [assignedTo], references: [id])
+  completedByUser User?               @relation("TaskCompletedBy", fields: [completedBy], references: [id])
 
   @@index([offboardingId])
   @@index([category])
@@ -897,47 +913,47 @@ model OffboardingTask {
 }
 
 model ExitInterview {
-  id            String   @id @default(cuid())
-  offboardingId String   @unique
+  id            String    @id @default(cuid())
+  offboardingId String    @unique
   scheduledAt   DateTime?
   interviewerId String?
   location      String?
   notes         String?
-  completed     Boolean  @default(false)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  completed     Boolean   @default(false)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 
-  offboarding   EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
+  offboarding EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
 
   @@index([offboardingId])
 }
 
 model ExitInterviewFormTemplate {
-  id            String   @id @default(cuid())
-  name          String
-  description   String?
+  id          String   @id @default(cuid())
+  name        String
+  description String?
   // schemaJson stores the screen-designer-like form definition
-  schemaJson    Json
-  isActive      Boolean  @default(true)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  schemaJson  Json
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  offboardings  EmployeeOffboarding[]
-  submissions   ExitInterviewSubmission[]
+  offboardings EmployeeOffboarding[]
+  submissions  ExitInterviewSubmission[]
 
   @@index([isActive])
 }
 
 model ExitInterviewSubmission {
-  id            String   @id @default(cuid())
+  id            String    @id @default(cuid())
   offboardingId String
   templateId    String
   submittedBy   String? // employeeId or email
   submittedAt   DateTime?
   answersJson   Json?
 
-  offboarding   EmployeeOffboarding @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
-  template      ExitInterviewFormTemplate @relation(fields: [templateId], references: [id])
+  offboarding EmployeeOffboarding       @relation(fields: [offboardingId], references: [id], onDelete: Cascade)
+  template    ExitInterviewFormTemplate @relation(fields: [templateId], references: [id])
 
   @@index([offboardingId])
   @@index([templateId])
@@ -979,4 +995,3 @@ enum ExitInterviewCompletionStatus {
   STARTED
   SUBMITTED
 }
-

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -249,7 +249,7 @@ async function main() {
   for (const category of systemCategories) {
     console.log(`⏳ Attempting to upsert category: ${category.name}`);
     const result = await prisma.eventCategory.upsert({
-      where: { name: category.name },
+      where: { companyId_name: { companyId: company.id, name: category.name } },
       update: {
         systemDefined: true,
         categoryType: category.categoryType,
@@ -257,7 +257,7 @@ async function main() {
         adminOnly: category.adminOnly,
         color: category.color,
       },
-      create: category,
+      create: { ...category, company: { connect: { id: company.id } } },
     });
     console.log(`✅ Category upserted: ${result.name} (${result.id})`);
 


### PR DESCRIPTION
## Summary
- scope event category endpoints to the authenticated user's company
- add multi-tenant companyId field to event category and related models
- add SQL migration and backfill for new company scoping

## Testing
- `npx prisma migrate dev --name add-event-category-company-id --create-only` *(fails: Can't reach database server)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c12359c8788331befed431a50b064a