### PR TITLE
fix: resolve build errors

### DIFF
--- a/app/(withSidebar)/settings/event-rules/page.tsx
+++ b/app/(withSidebar)/settings/event-rules/page.tsx
@@ -26,7 +26,8 @@ import {
   Clock,
   HelpCircle,
   Plus,
-  Trash2
+  Trash2,
+  Edit
 } from "lucide-react";
 import { format } from "date-fns";
 

--- a/app/(withSidebar)/settings/system/audit-log/page.tsx
+++ b/app/(withSidebar)/settings/system/audit-log/page.tsx
@@ -369,7 +369,7 @@ export default function AuditLogPage() {
                   <PopoverContent className="w-auto p-0">
                     <Calendar
                       mode="single"
-                      selected={filters.dateFrom}
+                      selected={filters.dateFrom ?? undefined}
                       onSelect={(date) => setFilters({ ...filters, dateFrom: date || null })}
                       initialFocus
                     />
@@ -389,7 +389,7 @@ export default function AuditLogPage() {
                   <PopoverContent className="w-auto p-0">
                     <Calendar
                       mode="single"
-                      selected={filters.dateTo}
+                      selected={filters.dateTo ?? undefined}
                       onSelect={(date) => setFilters({ ...filters, dateTo: date || null })}
                       initialFocus
                     />

--- a/app/api/automation-rules/dry-run/route.ts
+++ b/app/api/automation-rules/dry-run/route.ts
@@ -35,10 +35,12 @@ export async function POST(req: Request) {
     let matchingEmployees = 0;
     let preview: any[] = [];
 
+    const triggerConfig = rule.triggerConfig as any;
+
     switch (rule.triggerType) {
       case 'DOCUMENT_EXPIRING':
         // Simulate document expiry check
-        const daysBefore = rule.triggerConfig?.daysBefore || 30;
+        const daysBefore = triggerConfig?.daysBefore || 30;
         const expiringDocs = await prisma.employmentCheck.count({
           where: {
             employee: {
@@ -62,7 +64,7 @@ export async function POST(req: Request) {
 
       case 'FORM_SUBMITTED':
         // Simulate form submission check
-        const formId = rule.triggerConfig?.formId;
+        const formId = triggerConfig?.formId;
         if (formId) {
           const recentSubmissions = await prisma.formSubmission.count({
             where: {
@@ -134,10 +136,11 @@ export async function POST(req: Request) {
     }
 
     // Simulate actions that would be executed
-    const actionsToRun = matchingEmployees * rule.actions.length;
-    
+    const actions = (rule.actions as any[]) || [];
+    const actionsToRun = matchingEmployees * actions.length;
+
     // Add action previews
-    rule.actions.forEach((action: any, index: number) => {
+    actions.forEach((action: any, index: number) => {
       let actionDescription = '';
       
       switch (action.type) {
@@ -172,7 +175,7 @@ export async function POST(req: Request) {
       actionsToRun,
       estimatedRuntime,
       preview,
-      conditions: rule.conditions?.length || 0,
+      conditions: ((rule.conditions as any[]) || []).length,
       wouldExecute: matchingEmployees > 0,
       timestamp: new Date().toISOString(),
     });

--- a/app/components/ui/Card.tsx
+++ b/app/components/ui/Card.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 
-interface CardProps {
+interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   title?: React.ReactNode;
   icon?: React.ReactNode;
   action?: React.ReactNode;
@@ -9,13 +9,21 @@ interface CardProps {
   className?: string;
 }
 
-export function Card({ title, icon, action, children, className }: CardProps) {
+export function Card({
+  title,
+  icon,
+  action,
+  children,
+  className,
+  ...props
+}: CardProps) {
   return (
     <div
       className={clsx(
         "glass rounded-3xl shadow-glass h-full transition-glass hover-glass hover-lift",
         className
       )}
+      {...props}
     >
       {(title || action) && (
         <CardHeader>


### PR DESCRIPTION
## Summary
- allow Card component to forward DOM props so onClick works for automation rule builder
- import missing Edit icon for event rule overrides
- handle nullable dates and JSON fields to satisfy TypeScript in audit log and automation dry run

## Testing
- `npm test` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c28ab187508331abfe0b78da0e31a0