### PR TITLE
feat: add breadcrumb visibility control

### DIFF
--- a/app/(withSidebar)/settings/automation-rules/page.tsx
+++ b/app/(withSidebar)/settings/automation-rules/page.tsx
@@ -435,6 +435,7 @@ export default function AutomationRulesPage() {
       title="Automation Rules"
       description="Create and manage no-code automation rules to streamline HR processes"
       breadcrumbs={breadcrumbConfigs.settingsSection("Automation Rules")}
+      showHomeIcon={false}
       action={
         <Button onClick={openCreateDialog}>
           <Plus className="w-4 h-4 mr-2" />

--- a/app/(withSidebar)/settings/forms/[id]/analytics/page.tsx
+++ b/app/(withSidebar)/settings/forms/[id]/analytics/page.tsx
@@ -8,9 +8,20 @@ export default function FormAnalyticsPage() {
   const params = useParams();
   const formId = params?.id ? String(params.id) : '';
 
+  const breadcrumbItems = [
+    { label: 'Settings', href: '/settings' },
+    { label: 'Forms & Surveys', href: '/settings/forms' },
+    { label: 'Form Analytics', isCurrentPage: true }
+  ];
+
   if (!formId) {
     return (
-      <PageShell title="Form Analytics" description="View submission statistics and insights">
+      <PageShell
+        title="Form Analytics"
+        description="View submission statistics and insights"
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
         <div className="flex items-center justify-center h-64 text-gray-500">
           Invalid form ID.
         </div>
@@ -19,9 +30,11 @@ export default function FormAnalyticsPage() {
   }
 
   return (
-    <PageShell 
-      title="Form Analytics" 
+    <PageShell
+      title="Form Analytics"
       description="View submission statistics and insights"
+      breadcrumbs={{ items: breadcrumbItems }}
+      showHomeIcon={false}
     >
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <Card>

--- a/app/(withSidebar)/settings/forms/[id]/edit/page.tsx
+++ b/app/(withSidebar)/settings/forms/[id]/edit/page.tsx
@@ -27,6 +27,12 @@ export default function EditFormPage() {
   const [formData, setFormData] = useState<FormData | null>(null)
   const [loading, setLoading] = useState(true)
 
+  const breadcrumbItems = [
+    { label: 'Settings', href: '/settings' },
+    { label: 'Forms & Surveys', href: '/settings/forms' },
+    { label: formData ? `Edit: ${formData.name}` : 'Edit Form', isCurrentPage: true }
+  ]
+
   useEffect(() => {
     if (!formId) return // ✅ Prevent fetch if formId is missing
 
@@ -85,7 +91,12 @@ export default function EditFormPage() {
 
   if (!formId) {
     return (
-      <PageShell title="Invalid Form" description="Missing or invalid form ID">
+      <PageShell
+        title="Invalid Form"
+        description="Missing or invalid form ID"
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
         <div className="text-center py-8">
           <p className="text-gray-500">The form ID is missing or invalid.</p>
         </div>
@@ -95,7 +106,12 @@ export default function EditFormPage() {
 
   if (loading) {
     return (
-      <PageShell title="Edit Form" description="Loading form data...">
+      <PageShell
+        title="Edit Form"
+        description="Loading form data..."
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
         <div className="flex items-center justify-center h-64">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
         </div>
@@ -105,7 +121,12 @@ export default function EditFormPage() {
 
   if (!formData) {
     return (
-      <PageShell title="Form Not Found" description="The requested form could not be found">
+      <PageShell
+        title="Form Not Found"
+        description="The requested form could not be found"
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
         <div className="text-center py-8">
           <p className="text-gray-500">Form not found or you don't have permission to edit it.</p>
         </div>
@@ -117,6 +138,8 @@ export default function EditFormPage() {
     <PageShell
       title={`Edit: ${formData.name}`}
       description="Modify the form using the builder below"
+      breadcrumbs={{ items: breadcrumbItems }}
+      showHomeIcon={false}
     >
       <FormBuilder
         onSave={handleSave}

--- a/app/(withSidebar)/settings/forms/exit-interview/new/page.tsx
+++ b/app/(withSidebar)/settings/forms/exit-interview/new/page.tsx
@@ -31,6 +31,13 @@ export default function NewExitInterviewTemplatePage() {
   })
   const [fields, setFields] = useState<FormField[]>([])
 
+  const breadcrumbItems = [
+    { label: 'Settings', href: '/settings' },
+    { label: 'Forms & Surveys', href: '/settings/forms' },
+    { label: 'Exit Interview Forms', href: '/settings/forms/exit-interview' },
+    { label: 'New Template', isCurrentPage: true }
+  ]
+
   const addField = () => {
     const newField: FormField = {
       id: `field_${Date.now()}`,
@@ -143,7 +150,12 @@ export default function NewExitInterviewTemplatePage() {
   }
 
   return (
-    <PageShell title="New Exit Interview Template" description="Create a new exit interview form template">
+    <PageShell
+      title="New Exit Interview Template"
+      description="Create a new exit interview form template"
+      breadcrumbs={{ items: breadcrumbItems }}
+      showHomeIcon={false}
+    >
       <form onSubmit={handleSubmit} className="space-y-6">
         <Card>
           <CardHeader>

--- a/app/(withSidebar)/settings/forms/exit-interview/page.tsx
+++ b/app/(withSidebar)/settings/forms/exit-interview/page.tsx
@@ -27,6 +27,12 @@ export default function ExitInterviewFormsPage() {
   const [templates, setTemplates] = useState<FormTemplate[]>([])
   const [loading, setLoading] = useState(true)
 
+  const breadcrumbItems = [
+    { label: 'Settings', href: '/settings' },
+    { label: 'Forms & Surveys', href: '/settings/forms' },
+    { label: 'Exit Interview Forms', isCurrentPage: true }
+  ]
+
   useEffect(() => {
     fetchTemplates()
   }, [])
@@ -104,7 +110,12 @@ export default function ExitInterviewFormsPage() {
 
   if (loading) {
     return (
-      <PageShell title="Exit Interview Forms" description="Manage exit interview form templates">
+      <PageShell
+        title="Exit Interview Forms"
+        description="Manage exit interview form templates"
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
         <div className="flex items-center justify-center h-64">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
         </div>
@@ -113,7 +124,12 @@ export default function ExitInterviewFormsPage() {
   }
 
   return (
-    <PageShell title="Exit Interview Forms" description="Manage exit interview form templates">
+    <PageShell
+      title="Exit Interview Forms"
+      description="Manage exit interview form templates"
+      breadcrumbs={{ items: breadcrumbItems }}
+      showHomeIcon={false}
+    >
       <div className="flex justify-between items-center mb-6">
         <div className="text-sm text-gray-600">
           {templates.length} template{templates.length !== 1 ? 's' : ''} total

--- a/app/(withSidebar)/settings/forms/new/page.tsx
+++ b/app/(withSidebar)/settings/forms/new/page.tsx
@@ -8,6 +8,12 @@ import { toast } from 'sonner'
 export default function NewFormPage() {
   const router = useRouter()
 
+  const breadcrumbItems = [
+    { label: 'Settings', href: '/settings' },
+    { label: 'Forms & Surveys', href: '/settings/forms' },
+    { label: 'Create Form', isCurrentPage: true }
+  ]
+
   const handleSave = async (data: {
     name: string
     slug: string
@@ -34,7 +40,12 @@ export default function NewFormPage() {
   }
 
   return (
-    <PageShell title="Create Form" description="Build a new form using the builder">
+    <PageShell
+      title="Create Form"
+      description="Build a new form using the builder"
+      breadcrumbs={{ items: breadcrumbItems }}
+      showHomeIcon={false}
+    >
       <FormBuilder onSave={handleSave} />
     </PageShell>
   )

--- a/app/(withSidebar)/settings/forms/page.tsx
+++ b/app/(withSidebar)/settings/forms/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import { PageShell } from '@/components/ui/PageShell'
+import { breadcrumbConfigs } from '@/components/ui/Breadcrumb'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
@@ -81,7 +82,12 @@ export default function FormsPage() {
 
   if (loading) {
     return (
-      <PageShell title="Forms & Surveys" description="Manage and create forms">
+      <PageShell
+        title="Forms & Surveys"
+        description="Manage and create forms"
+        breadcrumbs={breadcrumbConfigs.settingsSection('Forms & Surveys')}
+        showHomeIcon={false}
+      >
         <div className="flex items-center justify-center h-64">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
         </div>
@@ -90,7 +96,12 @@ export default function FormsPage() {
   }
 
   return (
-    <PageShell title="Forms & Surveys" description="Manage and create forms">
+    <PageShell
+      title="Forms & Surveys"
+      description="Manage and create forms"
+      breadcrumbs={breadcrumbConfigs.settingsSection('Forms & Surveys')}
+      showHomeIcon={false}
+    >
       {/* Search & Filters */}
       <div className="mb-4 grid grid-cols-1 md:grid-cols-4 gap-2">
         <div className="flex items-center gap-2">

--- a/app/(withSidebar)/settings/page.tsx
+++ b/app/(withSidebar)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { PageShell } from '@/components/ui/PageShell'
+import { breadcrumbConfigs } from '@/components/ui/Breadcrumb'
 import { Card, CardContent } from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import {
@@ -106,7 +107,13 @@ function SettingSection({
 
 export default function SettingsIndexPage() {
   return (
-    <PageShell title="Settings" description="Configure and manage your system settings across all modules" icon={<Cog className="w-6 h-6" />}>
+    <PageShell
+      title="Settings"
+      description="Configure and manage your system settings across all modules"
+      icon={<Cog className="w-6 h-6" />}
+      breadcrumbs={breadcrumbConfigs.settings}
+      showHomeIcon={false}
+    >
       <Accordion type="multiple" className="space-y-4" defaultValue={['holidays', 'system']}>
         <SettingSection
           id="holidays"

--- a/app/(withSidebar)/settings/system/audit-log/page.tsx
+++ b/app/(withSidebar)/settings/system/audit-log/page.tsx
@@ -272,6 +272,7 @@ export default function AuditLogPage() {
       title="Global Audit Log"
       description="Track all changes to system configuration and settings"
       breadcrumbs={breadcrumbConfigs.settingsSection("System Audit Log")}
+      showHomeIcon={false}
       action={
         <div className="flex gap-2">
           <Button variant="outline" onClick={exportLogs}>

--- a/app/(withSidebar)/settings/system/notifications/page.tsx
+++ b/app/(withSidebar)/settings/system/notifications/page.tsx
@@ -335,6 +335,7 @@ export default function NotificationSettingsPage() {
       title="Notification Settings"
       description="Configure notification channels, digests, and email templates"
       breadcrumbs={breadcrumbConfigs.settingsSection("Notification Settings")}
+      showHomeIcon={false}
     >
       <div className="space-y-6">
         <Tabs defaultValue="channels" className="w-full">

--- a/app/components/ui/PageShell.tsx
+++ b/app/components/ui/PageShell.tsx
@@ -11,6 +11,7 @@ interface PageShellProps {
   className?: string;
   action?: React.ReactNode;
   breadcrumbs?: BreadcrumbConfig; // Added for breadcrumb support
+  showHomeIcon?: boolean;
 }
 
 export function PageShell({
@@ -21,6 +22,7 @@ export function PageShell({
   className,
   action,
   breadcrumbs,
+  showHomeIcon = true,
 }: PageShellProps) {
   return (
     <div className={clsx("w-full min-h-screen bg-content-panel", className)}>
@@ -30,7 +32,7 @@ export function PageShell({
           {/* Breadcrumbs */}
           {breadcrumbs && (
             <div className="mb-4">
-              <Breadcrumb items={breadcrumbs.items} />
+              <Breadcrumb items={breadcrumbs.items} showHomeIcon={showHomeIcon} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- add showHomeIcon prop to PageShell and forward to Breadcrumb
- hide home icon on settings pages and supply breadcrumb configs
- provide custom breadcrumb arrays for nested settings pages

## Testing
- `npm test` *(fails: AutomationJobQueue subtest)*

------
https://chatgpt.com/codex/tasks/task_e_68c32066f2ac83319d446d420f77c3a7