### PR TITLE
Add Google and Azure AD login buttons

### DIFF
--- a/app/login/LoginClient.tsx
+++ b/app/login/LoginClient.tsx
@@ -95,6 +95,14 @@ export default function LoginClient() {
             Sign In
           </Button>
         </form>
+        <div className="mt-4 space-y-2">
+          <Button className="w-full" onClick={() => signIn("google")}>
+            Sign in with Google
+          </Button>
+          <Button className="w-full" onClick={() => signIn("azure-ad")}>
+            Sign in with Azure AD
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add Google and Azure AD sign-in buttons to login page

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b89280cc83318baee524e45ff1b6