### PR TITLE
Document auth env variables in example env file

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,13 @@
+# Google OAuth credentials from Google Cloud Console
+GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+
+# Azure AD app registration credentials from Azure Portal
+AZURE_AD_CLIENT_ID=YOUR_AZURE_AD_CLIENT_ID
+AZURE_AD_CLIENT_SECRET=YOUR_AZURE_AD_CLIENT_SECRET
+AZURE_AD_TENANT_ID=YOUR_AZURE_AD_TENANT_ID
+
+# Secret for NextAuth.js - generate with `openssl rand -base64 32`
+NEXTAUTH_SECRET=YOUR_NEXTAUTH_SECRET
+# Base URL of your application for NextAuth.js
+NEXTAUTH_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- add Google and Azure AD OAuth env placeholders
- note NextAuth secret and URL in env example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c29050a48331a896710398158f17