### PR TITLE
Fix EmployeeOverviewPage JSX structure

### DIFF
--- a/app/(withSidebar)/employees/[id]/overview/page.tsx
+++ b/app/(withSidebar)/employees/[id]/overview/page.tsx
@@ -3,7 +3,6 @@ import LeaveBalancePanel from "@/components/LeaveBalancePanel";
 import Link from "next/link";
 import AddLeaveRequestDialog from "@/components/AddLeaveRequestDialog";
 import { PageShell } from "@/components/ui/PageShell";
-import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
 import { User } from "lucide-react";
 import {
   Dialog,
@@ -184,6 +183,7 @@ export default async function EmployeeOverviewPage({ params }: PageProps) {
           </div>
         </Card>
       </div>
-    </PageShell>
+    </div>
+  </PageShell>
   );
 }


### PR DESCRIPTION
## Summary
- fix JSX structure in EmployeeOverviewPage and drop unused breadcrumbs hook

## Testing
- `npm run lint` *(fails: Invalid Options: useEslintrc, extensions, etc.)*
- `npm test`
- `RESEND_API_KEY=dummy SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c665c72b408331b0b9de8996aba70e