### PR TITLE
refactor: load resend key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ This update introduces a basic exit interview workflow for employee offboarding.
 
 ### Environment
 
-- No new environment variables are required.
+- Set `RESEND_API_KEY` with your Resend API key to use the email testing script:
+
+```bash
+export RESEND_API_KEY=your_api_key
+```
 
 ### Testing locally
 

--- a/scripts/resendTest.ts
+++ b/scripts/resendTest.ts
@@ -1,6 +1,11 @@
 import { Resend } from "resend";
 
-const resend = new Resend("re_Gic3qrtA_6KuAigMGZ8h2YGKZfMHAoG8E");
+const apiKey = process.env.RESEND_API_KEY;
+if (!apiKey) {
+  throw new Error("RESEND_API_KEY environment variable is not set");
+}
+
+const resend = new Resend(apiKey);
 
 async function testSend() {
   try {


### PR DESCRIPTION
## Summary
- remove hard-coded Resend API key and read from RESEND_API_KEY env var
- document setting RESEND_API_KEY in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6778d0ebc83318a97c775527691b2