### PR TITLE
Use signed URLs for Supabase documents

### DIFF
--- a/app/api/calendar-events/route.ts
+++ b/app/api/calendar-events/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
+import supabase from "@/lib/supabase-admin";
 
 export const dynamic = "force-dynamic";
 
@@ -52,28 +53,38 @@ export async function GET(req: Request) {
       orderBy: { startDate: "desc" },
     });
 
-    const events = leaveRequests.map((req) => {
-      const user = req.employee.user;
-      const displayName =
-        user.name ||
-        `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
-        "Unknown";
+    const events = await Promise.all(
+      leaveRequests.map(async (req) => {
+        const user = req.employee.user;
+        const displayName =
+          user.name ||
+          `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
+          "Unknown";
 
-      return {
-        id: req.id,
-        title: `${req.eventCategory.name} - ${displayName}`,
-        start: req.startDate,
-        end: req.endDate,
-        allDay: true,
-        reason: req.reason ?? null,
-        employee: {
-          id: req.employee.id,
-          name: displayName,
-          department: req.employee.department?.name ?? null,
-          profileImageUrl: user.profileImageUrl ?? null,
-        },
-      };
-    });
+        let profileImageUrl: string | null = null;
+        if (user.profileImageUrl) {
+          const { data: signed } = await supabase.storage
+            .from("documents")
+            .createSignedUrl(user.profileImageUrl, 60 * 5);
+          profileImageUrl = signed?.signedUrl ?? null;
+        }
+
+        return {
+          id: req.id,
+          title: `${req.eventCategory.name} - ${displayName}`,
+          start: req.startDate,
+          end: req.endDate,
+          allDay: true,
+          reason: req.reason ?? null,
+          employee: {
+            id: req.employee.id,
+            name: displayName,
+            department: req.employee.department?.name ?? null,
+            profileImageUrl,
+          },
+        };
+      }),
+    );
 
     return NextResponse.json(events);
   } catch (error) {

--- a/app/api/documents/list-company/route.ts
+++ b/app/api/documents/list-company/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
+import supabase from "@/lib/supabase-admin";
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions);
@@ -52,5 +53,14 @@ export async function GET(req: Request) {
     orderBy: { createdAt: "desc" },
   });
 
-  return NextResponse.json(documents);
+  const withUrls = await Promise.all(
+    documents.map(async (doc) => {
+      const { data: signed } = await supabase.storage
+        .from("documents")
+        .createSignedUrl(doc.path, 60 * 5);
+      return { ...doc, url: signed?.signedUrl ?? null };
+    }),
+  );
+
+  return NextResponse.json(withUrls);
 }

--- a/app/api/documents/list-employee/route.ts
+++ b/app/api/documents/list-employee/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import supabase from "@/lib/supabase-admin";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -52,5 +53,14 @@ export async function GET(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(documents);
+  const withUrls = await Promise.all(
+    documents.map(async (doc) => {
+      const { data: signed } = await supabase.storage
+        .from("documents")
+        .createSignedUrl(doc.path, 60 * 5);
+      return { ...doc, url: signed?.signedUrl ?? null };
+    }),
+  );
+
+  return NextResponse.json(withUrls);
 }

--- a/app/api/documents/list/route.ts
+++ b/app/api/documents/list/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { Prisma } from "@prisma/client";
 import { hasPermission } from "@/lib/permissions";
+import supabase from "@/lib/supabase-admin";
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions);
@@ -51,13 +52,15 @@ export async function GET(req: Request) {
       orderBy: { createdAt: "desc" },
     });
 
-    // ✅ Include requiresAck explicitly
-    return NextResponse.json(
-      adminDocs.map((doc) => ({
-        ...doc,
-        requiresAck: doc.requiresAck,
-      })),
+    const withUrls = await Promise.all(
+      adminDocs.map(async (doc) => {
+        const { data: signed } = await supabase.storage
+          .from("documents")
+          .createSignedUrl(doc.path, 60 * 5);
+        return { ...doc, url: signed?.signedUrl ?? null, requiresAck: doc.requiresAck };
+      }),
     );
+    return NextResponse.json(withUrls);
   }
 
   // ✅ Role flag - fallback to basic access if no admin permissions
@@ -96,11 +99,13 @@ export async function GET(req: Request) {
     orderBy: { createdAt: "desc" },
   });
 
-  // ✅ Include requiresAck explicitly
-  return NextResponse.json(
-    documents.map((doc) => ({
-      ...doc,
-      requiresAck: doc.requiresAck,
-    })),
+  const withUrls = await Promise.all(
+    documents.map(async (doc) => {
+      const { data: signed } = await supabase.storage
+        .from("documents")
+        .createSignedUrl(doc.path, 60 * 5);
+      return { ...doc, url: signed?.signedUrl ?? null, requiresAck: doc.requiresAck };
+    }),
   );
+  return NextResponse.json(withUrls);
 }

--- a/app/api/documents/upload-employee/route.ts
+++ b/app/api/documents/upload-employee/route.ts
@@ -100,11 +100,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: uploadError.message }, { status: 500 });
   }
 
-  // ✅ Retrieve public URL after upload
-  const { data: urlData } = supabase.storage
+  const { data: signed, error: signErr } = await supabase.storage
     .from("documents")
-    .getPublicUrl(path);
-  const fileUrl = urlData.publicUrl;
+    .createSignedUrl(path, 60 * 5);
+  if (signErr) {
+    return NextResponse.json({ error: signErr.message }, { status: 500 });
+  }
+  const fileUrl = signed?.signedUrl ?? null;
 
   // ✅ Create document record in Prisma with access flags
   const document = await prisma.document.create({
@@ -112,7 +114,7 @@ export async function POST(req: NextRequest) {
       name,
       category,
       path,
-      url: fileUrl,
+      url: path,
       size: file.size,
       type: file.type,
       uploaderId: uploaderId,
@@ -172,7 +174,7 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({
     document: {
       id: document.id,
-      url: document.url,
+      url: fileUrl,
       name: document.name,
       category: document.category,
       size: document.size,

--- a/app/api/documents/upload/route.ts
+++ b/app/api/documents/upload/route.ts
@@ -69,14 +69,12 @@ export async function POST(req: Request) {
       );
     }
 
-    // ✅ Generate public URL
-    const { data: publicUrlData } = supabase.storage
+    const { data: signedUrlData, error: signErr } = await supabase.storage
       .from("documents")
-      .getPublicUrl(data.path);
-    const publicUrl = publicUrlData?.publicUrl;
-    if (!publicUrl) {
+      .createSignedUrl(data.path, 60 * 5);
+    if (signErr) {
       return NextResponse.json(
-        { error: "Failed to generate public URL" },
+        { error: signErr.message },
         { status: 500 },
       );
     }
@@ -89,7 +87,7 @@ export async function POST(req: Request) {
         path: data.path,
         size: file.size,
         type: file.type,
-        url: publicUrl,
+        url: data.path,
         uploaderId: session.user.id,
         companyId: session.user.companyId,
         employeeId: type === "employee" && employeeId ? employeeId : null,
@@ -243,7 +241,10 @@ export async function POST(req: Request) {
     // --- END: Send Resend emails for company docs with requiresAck ---
 
     console.log("✅ Document uploaded:", document);
-    return NextResponse.json(document);
+    return NextResponse.json({
+      ...document,
+      url: signedUrlData?.signedUrl ?? null,
+    });
   } catch (error) {
     console.error("❌ Document upload error:", error);
     return NextResponse.json(

--- a/app/api/employment-checks/[id]/route.ts
+++ b/app/api/employment-checks/[id]/route.ts
@@ -24,6 +24,7 @@ export async function PATCH(
   const file = formData.get("file") as File | null;
 
   let documentUrl: string | undefined = undefined;
+  let signedUrl: string | undefined = undefined;
 
   if (file) {
     const fileExt = file.name.split(".").pop();
@@ -37,10 +38,11 @@ export async function PATCH(
       console.error(error);
       return NextResponse.json({ error: "Upload failed" }, { status: 500 });
     }
-    const { data: urlData } = supabase.storage
+    documentUrl = data.path;
+    const { data: signed } = await supabase.storage
       .from("documents")
-      .getPublicUrl(data.path);
-    documentUrl = urlData.publicUrl;
+      .createSignedUrl(data.path, 60 * 5);
+    signedUrl = signed?.signedUrl;
   }
 
   const updated = await prisma.employmentCheck.update({
@@ -54,5 +56,12 @@ export async function PATCH(
     },
   });
 
-  return NextResponse.json(updated);
+  if (!signedUrl && updated.documentUrl) {
+    const { data: signedExisting } = await supabase.storage
+      .from("documents")
+      .createSignedUrl(updated.documentUrl, 60 * 5);
+    signedUrl = signedExisting?.signedUrl;
+  }
+
+  return NextResponse.json({ ...updated, documentUrl: signedUrl ?? null });
 }

--- a/app/api/employment-checks/create/route.ts
+++ b/app/api/employment-checks/create/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: NextRequest) {
   let documentSize: number | null = null;
   let documentType: string | null = null;
   let documentPath: string | null = null;
+  let documentSignedUrl: string | null = null;
 
   try {
     if (file) {
@@ -48,14 +49,16 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Upload failed" }, { status: 500 });
       }
 
-      const { data: urlData } = supabase.storage
-        .from("documents")
-        .getPublicUrl(data.path);
-      documentUrl = urlData.publicUrl;
+      documentUrl = data.path;
       documentName = file.name;
       documentSize = file.size;
       documentType = file.type;
       documentPath = data.path;
+
+      const { data: signed } = await supabase.storage
+        .from("documents")
+        .createSignedUrl(data.path, 60 * 5);
+      documentSignedUrl = signed?.signedUrl ?? null;
     }
 
     const employmentCheck = await prisma.employmentCheck.create({
@@ -75,7 +78,7 @@ export async function POST(req: NextRequest) {
         data: {
           name: documentName,
           path: documentPath,
-          url: documentUrl,
+          url: documentPath,
           size: documentSize ?? 0,
           type: documentType ?? "",
           category: "Employment Checks",
@@ -86,7 +89,10 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    return NextResponse.json(employmentCheck);
+    return NextResponse.json({
+      ...employmentCheck,
+      documentUrl: documentSignedUrl,
+    });
   } catch (error) {
     console.error("Employment Check creation error:", error);
     return NextResponse.json(

--- a/app/api/employment-checks/list/route.ts
+++ b/app/api/employment-checks/list/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
+import supabase from "@/lib/supabase-admin";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -21,7 +22,17 @@ export async function GET(req: NextRequest) {
       orderBy: { createdAt: "desc" },
     });
 
-    return NextResponse.json(checks);
+    const withUrls = await Promise.all(
+      checks.map(async (c) => {
+        if (!c.documentUrl) return c;
+        const { data: signed } = await supabase.storage
+          .from("documents")
+          .createSignedUrl(c.documentUrl, 60 * 5);
+        return { ...c, documentUrl: signed?.signedUrl ?? null };
+      }),
+    );
+
+    return NextResponse.json(withUrls);
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/app/api/onboarding/instances/[employeeId]/route.ts
+++ b/app/api/onboarding/instances/[employeeId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import supabase from "@/lib/supabase-admin";
 
 const mapStepType = (type: string) => {
   switch (type) {
@@ -53,28 +54,37 @@ export async function GET(
     }
 
     // ✅ Merge template steps with instance step info
-    const mergedSteps = instance.template.steps.map((tStep) => {
-      const instStep = instance.steps.find((i) => i.stepId === tStep.id);
-      return {
-        id: tStep.id, // template step ID
-        instanceStepId: instStep?.id || null, // ✅ onboardingStepInstance ID
-        type: mapStepType(tStep.type),
-        label: tStep.label,
-        instruction: tStep.instruction ?? undefined,
-        uploadType: tStep.uploadType ?? undefined,
-        documentId: tStep.documentId ?? undefined,
-        document: tStep.document
-          ? {
-              id: tStep.document.id,
-              name: tStep.document.name,
-              url: tStep.document.url,
-            }
-          : undefined,
-        formId: tStep.formId ?? undefined,
-        order: tStep.order,
-        status: instStep?.status || "pending",
-      };
-    });
+    const mergedSteps = await Promise.all(
+      instance.template.steps.map(async (tStep) => {
+        const instStep = instance.steps.find((i) => i.stepId === tStep.id);
+        let url: string | null = null;
+        if (tStep.document?.url) {
+          const { data: signed } = await supabase.storage
+            .from("documents")
+            .createSignedUrl(tStep.document.url, 60 * 5);
+          url = signed?.signedUrl ?? null;
+        }
+        return {
+          id: tStep.id, // template step ID
+          instanceStepId: instStep?.id || null, // ✅ onboardingStepInstance ID
+          type: mapStepType(tStep.type),
+          label: tStep.label,
+          instruction: tStep.instruction ?? undefined,
+          uploadType: tStep.uploadType ?? undefined,
+          documentId: tStep.documentId ?? undefined,
+          document: tStep.document
+            ? {
+                id: tStep.document.id,
+                name: tStep.document.name,
+                url,
+              }
+            : undefined,
+          formId: tStep.formId ?? undefined,
+          order: tStep.order,
+          status: instStep?.status || "pending",
+        };
+      }),
+    );
 
     const normalized = {
       id: instance.id,

--- a/app/api/users/[id]/profile-image/route.ts
+++ b/app/api/users/[id]/profile-image/route.ts
@@ -16,21 +16,21 @@ export async function PATCH(
 
     const userId = params.id;
     const body = await req.json();
-    let url: string | undefined =
-      typeof body?.url === "string" ? body.url : undefined;
     const path: string | undefined =
       typeof body?.path === "string" ? body.path : undefined;
 
-    if (!url && path) {
-      const { data } = supabase.storage.from("documents").getPublicUrl(path);
-      url = data?.publicUrl;
-    }
-
-    if (!url) {
+    if (!path) {
       return NextResponse.json(
-        { error: "Invalid url or path" },
+        { error: "Invalid path" },
         { status: 400 },
       );
+    }
+
+    const { data: signed, error: signErr } = await supabase.storage
+      .from("documents")
+      .createSignedUrl(path, 60 * 5);
+    if (signErr) {
+      return NextResponse.json({ error: signErr.message }, { status: 500 });
     }
 
     // Allow self-update or admin
@@ -40,11 +40,14 @@ export async function PATCH(
 
     const updated = await prisma.user.update({
       where: { id: userId },
-      data: { profileImageUrl: url },
+      data: { profileImageUrl: path },
       select: { id: true, profileImageUrl: true },
     });
 
-    return NextResponse.json(updated);
+    return NextResponse.json({
+      id: updated.id,
+      profileImageUrl: signed?.signedUrl ?? null,
+    });
   } catch (e: any) {
     return NextResponse.json(
       { error: e?.message || "Server error" },

--- a/app/api/users/[id]/profile-image/upload/route.ts
+++ b/app/api/users/[id]/profile-image/upload/route.ts
@@ -34,28 +34,18 @@ export async function POST(
     if (uploadError)
       return NextResponse.json({ error: uploadError.message }, { status: 400 });
 
-    // Try public URL first
-    const { data: pub } = supabase.storage
+    const { data: signed, error: signErr } = await supabase.storage
       .from("documents")
-      .getPublicUrl(objectPath);
-    let url = pub?.publicUrl;
-
-    // If not public, create a long-lived signed URL
-    if (!url) {
-      const { data: signed, error: signErr } = await supabase.storage
-        .from("documents")
-        .createSignedUrl(objectPath, 60 * 60 * 24 * 365 * 10); // ~10 years
-      if (signErr)
-        return NextResponse.json({ error: signErr.message }, { status: 500 });
-      url = signed?.signedUrl;
-    }
+      .createSignedUrl(objectPath, 60 * 5);
+    if (signErr)
+      return NextResponse.json({ error: signErr.message }, { status: 500 });
 
     await prisma.user.update({
       where: { id: userId },
-      data: { profileImageUrl: url || null },
+      data: { profileImageUrl: objectPath },
     });
 
-    return NextResponse.json({ url });
+    return NextResponse.json({ url: signed?.signedUrl ?? null, path: objectPath });
   } catch (e: any) {
     return NextResponse.json(
       { error: e?.message || "Server error" },

--- a/app/lib/news/uploadFileToSupabase.ts
+++ b/app/lib/news/uploadFileToSupabase.ts
@@ -16,16 +16,16 @@ export async function uploadFileToSupabase(file: File) {
 
   if (error) throw new Error(error.message);
 
-  const publicUrlResponse = supabase.storage
+  const { data: signed, error: signErr } = await supabase.storage
     .from("documents")
-    .getPublicUrl(filePath);
+    .createSignedUrl(filePath, 60 * 5);
 
-  if (!publicUrlResponse.data?.publicUrl) {
-    throw new Error("Failed to get public URL from Supabase");
+  if (signErr || !signed?.signedUrl) {
+    throw new Error("Failed to get signed URL from Supabase");
   }
 
   return {
-    url: publicUrlResponse.data.publicUrl,
+    url: signed.signedUrl,
     path: filePath,
   };
 }

--- a/app/lib/supabase.ts
+++ b/app/lib/supabase.ts
@@ -16,16 +16,16 @@ export async function uploadToSupabase(file: File) {
 
   if (error) throw new Error(error.message);
 
-  const publicUrlResponse = supabase.storage
+  const { data: signed, error: signErr } = await supabase.storage
     .from("documents")
-    .getPublicUrl(filePath);
+    .createSignedUrl(filePath, 60 * 5);
 
-  if (!publicUrlResponse.data?.publicUrl) {
-    throw new Error("Failed to get public URL from Supabase");
+  if (signErr || !signed?.signedUrl) {
+    throw new Error("Failed to get signed URL from Supabase");
   }
 
   return {
-    url: publicUrlResponse.data.publicUrl,
+    url: signed.signedUrl,
     path: filePath,
   };
 }


### PR DESCRIPTION
## Summary
- replace `getPublicUrl` usages with short-lived `createSignedUrl`
- persist only object path for documents and profile images
- generate signed URLs when returning documents and user images

## Testing
- `npm test`
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c7375a94308331821f2a309ce6ba4b