### PR TITLE
Store profile image path and add signed URL retrieval

### DIFF
--- a/app/api/users/[id]/profile-image/route.ts
+++ b/app/api/users/[id]/profile-image/route.ts
@@ -4,6 +4,41 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import supabase from "@/lib/supabase-admin";
 
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: params.id },
+      select: { profileImageUrl: true },
+    });
+
+    if (!user?.profileImageUrl) {
+      return NextResponse.json({ url: null });
+    }
+
+    const { data: signed, error: signErr } = await supabase.storage
+      .from("documents")
+      .createSignedUrl(user.profileImageUrl, 60 * 5);
+    if (signErr) {
+      return NextResponse.json({ error: signErr.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ url: signed?.signedUrl ?? null });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Server error" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function PATCH(
   req: Request,
   { params }: { params: { id: string } },
@@ -26,13 +61,6 @@ export async function PATCH(
       );
     }
 
-    const { data: signed, error: signErr } = await supabase.storage
-      .from("documents")
-      .createSignedUrl(path, 60 * 5);
-    if (signErr) {
-      return NextResponse.json({ error: signErr.message }, { status: 500 });
-    }
-
     // Allow self-update or admin
     if (session.user.id !== userId && session.user.role !== "ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
@@ -44,10 +72,7 @@ export async function PATCH(
       select: { id: true, profileImageUrl: true },
     });
 
-    return NextResponse.json({
-      id: updated.id,
-      profileImageUrl: signed?.signedUrl ?? null,
-    });
+    return NextResponse.json({ id: updated.id, path: updated.profileImageUrl });
   } catch (e: any) {
     return NextResponse.json(
       { error: e?.message || "Server error" },

--- a/app/api/users/[id]/profile-image/upload/route.ts
+++ b/app/api/users/[id]/profile-image/upload/route.ts
@@ -34,18 +34,11 @@ export async function POST(
     if (uploadError)
       return NextResponse.json({ error: uploadError.message }, { status: 400 });
 
-    const { data: signed, error: signErr } = await supabase.storage
-      .from("documents")
-      .createSignedUrl(objectPath, 60 * 5);
-    if (signErr)
-      return NextResponse.json({ error: signErr.message }, { status: 500 });
-
     await prisma.user.update({
       where: { id: userId },
       data: { profileImageUrl: objectPath },
     });
-
-    return NextResponse.json({ url: signed?.signedUrl ?? null, path: objectPath });
+    return NextResponse.json({ path: objectPath });
   } catch (e: any) {
     return NextResponse.json(
       { error: e?.message || "Server error" },


### PR DESCRIPTION
## Summary
- Store Supabase storage path for profile images instead of signed URL
- Return only the path on upload and update operations
- Add GET handler to retrieve a short-lived signed URL for a user's profile image

## Testing
- `npm test`
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c73c0ed4a8833192c5279d128b571a