### PR TITLE
Add security headers to Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,22 @@
         {
           "key": "X-XSS-Protection",
           "value": "1; mode=block"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self' https://*.supabase.co https://api.resend.com; connect-src 'self' https://*.supabase.co https://api.resend.com; img-src 'self' data:; script-src 'self'; style-src 'self'; frame-ancestors 'none'"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=(), interest-cohort=()"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- enforce HTTPS with HSTS
- add strict CSP for self, Supabase, and Resend
- add Referrer-Policy and disable sensitive APIs via Permissions-Policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c745b8adf083319a6aef0e3c9fb35a