### PR TITLE
Add middleware origin allowlist for unsafe methods

### DIFF
--- a/app/lib/origin.ts
+++ b/app/lib/origin.ts
@@ -1,0 +1,11 @@
+const originAllowList = (process.env.ORIGIN_ALLOWLIST || "")
+  .split(",")
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+export function isAllowedOrigin(origin: string | null) {
+  if (!origin) return true;
+  return originAllowList.includes(origin);
+}
+
+export { originAllowList };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { isAllowedOrigin } from "./app/lib/origin";
+
+const RESTRICTED_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
+
+export function middleware(request: NextRequest) {
+  if (RESTRICTED_METHODS.includes(request.method)) {
+    const origin = request.headers.get("origin");
+    if (!isAllowedOrigin(origin)) {
+      return NextResponse.json({ error: "Origin not allowed" }, { status: 403 });
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
## Summary
- add origin allowlist utility
- enforce allowed origins on mutating API requests with middleware

## Testing
- `npm test`
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c747dd3318833196868c5992ca0a99