### PR TITLE
feat: add per-IP rate limiting middleware

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,10 @@ GOOGLE_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET
 NEXTAUTH_URL=https://your-domain.com
 NEXTAUTH_SECRET=CHANGE_ME
 FROM_EMAIL=noreply@peoplecore.co.nz
+RATE_LIMIT_MAX=120
+RATE_LIMIT_WINDOW_MS=60000
+# Optional Vercel KV or Upstash Redis credentials
+# KV_REST_API_URL=https://example.upstash.io
+# KV_REST_API_TOKEN=your_kv_token
+# UPSTASH_REDIS_REST_URL=https://example.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your_upstash_token

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ export RESEND_API_KEY=your_api_key
 - **Assets to return** – tick any items the leaver must return. Each item is tracked as a task during offboarding.
 - **Start Offboarding Process** – submits the form, creates the offboarding record, and seeds default tasks (including any above selections).
 - **Cancel** – closes the modal without saving.
+
+## Rate limiting
+
+To keep APIs responsive in a multi-tenant environment:
+
+- Set `RATE_LIMIT_MAX` and `RATE_LIMIT_WINDOW_MS` in your environment.
+- To share limits across Vercel instances, add `KV_REST_API_URL` and `KV_REST_API_TOKEN` (or Upstash equivalents).
+- Send an `x-company-id` header with each request so limits are tracked per tenant.
+- Restart the server after changing these variables or installing `@vercel/kv`.
+

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -7,7 +7,10 @@ const instance = axios.create({
 instance.interceptors.request.use((config) => {
   const token =
     typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  const companyId =
+    typeof window !== "undefined" ? localStorage.getItem("companyId") : null;
   if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (companyId) config.headers["x-company-id"] = companyId;
   return config;
 });
 

--- a/app/lib/rate-limit.ts
+++ b/app/lib/rate-limit.ts
@@ -1,0 +1,67 @@
+// Simple in-memory rate limiter with optional Vercel KV backing.
+// Returns true if the provided key has exceeded the rate limit.
+
+export interface RateLimitOptions {
+  /** maximum number of requests */
+  limit: number;
+  /** time window in milliseconds */
+  windowMs: number;
+}
+
+interface Entry {
+  count: number;
+  expires: number;
+}
+
+const memoryStore = new Map<string, Entry>();
+let kvClient:
+  | {
+      incr(key: string): Promise<number>;
+      expire(key: string, ttl: number): Promise<void>;
+    }
+  | null = null;
+
+async function getKV() {
+  if (kvClient) return kvClient;
+
+  const url =
+    process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const token =
+    process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    // @ts-ignore - optional dependency
+    const { createClient } = await import("@vercel/kv");
+    kvClient = createClient({ url, token });
+  } catch {
+    kvClient = null;
+  }
+  return kvClient;
+}
+
+export async function rateLimit(
+  key: string,
+  { limit, windowMs }: RateLimitOptions,
+): Promise<boolean> {
+  const kv = await getKV();
+  if (kv) {
+    const count = await kv.incr(key);
+    if (count === 1) {
+      await kv.expire(key, Math.ceil(windowMs / 1000));
+    }
+    return count > limit;
+  }
+
+  const now = Date.now();
+  const entry = memoryStore.get(key);
+  if (!entry || entry.expires < now) {
+    memoryStore.set(key, { count: 1, expires: now + windowMs });
+    return false;
+  }
+  if (entry.count >= limit) {
+    return true;
+  }
+  entry.count += 1;
+  return false;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,54 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
 import { isAllowedOrigin } from "./app/lib/origin";
+import { rateLimit } from "./app/lib/rate-limit";
 
 const RESTRICTED_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
-export function middleware(request: NextRequest) {
+const RATE_LIMIT_PATHS = [
+  "/api/auth",
+  "/api/email",
+  "/api/upload",
+  "/api/report",
+  "/api/employees",
+  "/api/documents",
+  "/api/news",
+];
+
+export async function middleware(request: NextRequest) {
   if (RESTRICTED_METHODS.includes(request.method)) {
     const origin = request.headers.get("origin");
     if (!isAllowedOrigin(origin)) {
       return NextResponse.json({ error: "Origin not allowed" }, { status: 403 });
     }
   }
-  return NextResponse.next();
+
+  const requestHeaders = new Headers(request.headers);
+  if (!requestHeaders.has("x-company-id")) {
+    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+    if (token?.companyId) {
+      requestHeaders.set("x-company-id", String(token.companyId));
+    }
+  }
+
+  const path = request.nextUrl.pathname;
+  if (RATE_LIMIT_PATHS.some((p) => path.startsWith(p))) {
+    const ip = request.ip || requestHeaders.get("x-forwarded-for") || "unknown";
+    const tenantId = requestHeaders.get("x-company-id") || "public";
+    const key = `${tenantId}:${ip}`;
+    const limit = Number(process.env.RATE_LIMIT_MAX ?? "120");
+    const windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS ?? "60000");
+    const limited = await rateLimit(key, { limit, windowMs });
+    if (limited) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        { status: 429 },
+      );
+    }
+  }
+
+  return NextResponse.next({ request: { headers: requestHeaders } });
 }
 
 export const config = {

--- a/types/vercel-kv.d.ts
+++ b/types/vercel-kv.d.ts
@@ -1,0 +1,14 @@
+declare module "@vercel/kv" {
+  export const kv: {
+    incr(key: string): Promise<number>;
+    expire(key: string, ttlSeconds: number): Promise<void>;
+  };
+  export function createClient(config: {
+    url: string;
+    token: string;
+  }): {
+    incr(key: string): Promise<number>;
+    expire(key: string, ttlSeconds: number): Promise<void>;
+  };
+}
+


### PR DESCRIPTION
## Summary
- add simple in-memory/optional KV rate limiter utility
- enforce per-tenant, per-IP limits on auth, email, upload, report and key API resources
- expose rate limit options via environment variables
- allow rate limiter to use Upstash Redis credentials
- document rate limiting setup in README
- automatically attach `x-company-id` header from session token in middleware
- send `x-company-id` on Axios requests when stored in `localStorage`

## Testing
- `npm test` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bf100a688331991cdfe45aa19516