### PR TITLE
Ensure Supabase documents are removed with document deletions

### DIFF
--- a/app/api/documents/delete/route.ts
+++ b/app/api/documents/delete/route.ts
@@ -32,7 +32,16 @@ export async function DELETE(req: Request) {
       );
 
     // Delete file from Supabase using `path`
-    await supabase.storage.from("documents").remove([doc.path]);
+    const { error: storageError } = await supabase.storage
+      .from("documents")
+      .remove([doc.path]);
+    if (storageError) {
+      console.error("Supabase remove error:", storageError);
+      return NextResponse.json(
+        { error: "Failed to delete document file" },
+        { status: 500 },
+      );
+    }
 
     // Delete DB record (scoped)
     await prisma.document.delete({ where: { id: doc.id } });

--- a/app/api/employees/[id]/route.ts
+++ b/app/api/employees/[id]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { canAccessEmployee } from "@/lib/permissions";
+import supabase from "@/lib/supabase-admin";
 
 // ✅ GET employee profile by Employee.id (not User.id)
 export async function GET(
@@ -116,7 +117,9 @@ export async function DELETE(
     const companyId =
       employee.companyId ?? employee.user?.companyId ?? undefined;
 
-    const result = await prisma.$transaction(async (tx) => {
+    const transactionResult = await prisma.$transaction(async (tx) => {
+      const pathsToRemove: string[] = [];
+
       // Onboarding instances and nested data
       await tx.onboardingStepResponse.deleteMany({
         where: {
@@ -155,6 +158,13 @@ export async function DELETE(
       await tx.employeeOffboarding.deleteMany({ where: { employeeId } });
 
       // Documents: delete only those attached to this employee
+      const employeeDocs = await tx.document.findMany({
+        where: { employeeId },
+        select: { path: true },
+      });
+      if (employeeDocs.length) {
+        pathsToRemove.push(...employeeDocs.map((doc) => doc.path));
+      }
       await tx.document.deleteMany({ where: { employeeId } });
 
       // Onboarding assignments for this user
@@ -179,11 +189,25 @@ export async function DELETE(
             data: { uploaderId: fallbackAdmin.id },
           });
         } else {
+          const companyDocs = await tx.document.findMany({
+            where: { uploaderId: userId, employeeId: null },
+            select: { path: true },
+          });
+          if (companyDocs.length) {
+            pathsToRemove.push(...companyDocs.map((doc) => doc.path));
+          }
           await tx.document.deleteMany({
             where: { uploaderId: userId, employeeId: null },
           });
         }
       } else {
+        const companyDocs = await tx.document.findMany({
+          where: { uploaderId: userId, employeeId: null },
+          select: { path: true },
+        });
+        if (companyDocs.length) {
+          pathsToRemove.push(...companyDocs.map((doc) => doc.path));
+        }
         await tx.document.deleteMany({
           where: { uploaderId: userId, employeeId: null },
         });
@@ -198,8 +222,29 @@ export async function DELETE(
       await tx.employee.delete({ where: { id: employeeId } });
       await tx.user.delete({ where: { id: userId } });
 
-      return { deleted: true };
+      return { deleted: true, pathsToRemove };
     });
+
+    const { pathsToRemove, ...result } = transactionResult;
+    const uniquePaths = Array.from(
+      new Set(pathsToRemove.filter((path): path is string => Boolean(path))),
+    );
+
+    if (uniquePaths.length) {
+      const { error: storageError } = await supabase.storage
+        .from("documents")
+        .remove(uniquePaths);
+      if (storageError) {
+        console.error("Supabase remove error:", storageError);
+        return NextResponse.json(
+          {
+            success: false,
+            error: "Failed to delete associated document files.",
+          },
+          { status: 500 },
+        );
+      }
+    }
 
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/tests/documentsDeleteRoute.test.ts
+++ b/tests/documentsDeleteRoute.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Module from "module";
+
+test("DELETE /api/documents/delete removes Supabase object before deleting DB row", async () => {
+  const originalLoad = (Module as any)._load;
+  const removeCalls: string[][] = [];
+  const deleteCalls: any[] = [];
+  const supabaseState: { error: any } = { error: null };
+
+  (Module as any)._load = function (
+    request: string,
+    parent: any,
+    isMain: boolean,
+  ) {
+    if (request === "@/lib/prisma") {
+      return {
+        prisma: {
+          document: {
+            findFirst: async (args: any) => {
+              if (args?.where?.id === "missing") return null;
+              return {
+                id: "doc-1",
+                path: "documents/test.pdf",
+                companyId: "company-1",
+              };
+            },
+            delete: async (args: any) => {
+              deleteCalls.push(args);
+              return { id: args?.where?.id };
+            },
+          },
+        },
+      };
+    }
+    if (request === "@/lib/supabase-admin") {
+      return {
+        default: {
+          storage: {
+            from: () => ({
+              remove: async (paths: string[]) => {
+                removeCalls.push(paths);
+                return { data: null, error: supabaseState.error };
+              },
+            }),
+          },
+        },
+      };
+    }
+    if (request === "@/lib/auth-options") {
+      return { authOptions: {} };
+    }
+    if (request === "next-auth") {
+      return {
+        getServerSession: async () => ({
+          user: { companyId: "company-1", role: "ADMIN" },
+        }),
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    const { DELETE } = await import("../app/api/documents/delete/route");
+
+    supabaseState.error = null;
+    const req = { json: async () => ({ documentId: "doc-1" }) } as Request;
+    const res = await DELETE(req);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { success: true });
+    assert.deepEqual(removeCalls.at(0), ["documents/test.pdf"]);
+    assert.equal(deleteCalls.length, 1);
+    assert.deepEqual(deleteCalls[0], { where: { id: "doc-1" } });
+
+    supabaseState.error = { message: "storage failure" };
+    const reqError = { json: async () => ({ documentId: "doc-1" }) } as Request;
+    const resError = await DELETE(reqError);
+    assert.equal(resError.status, 500);
+    const errorBody = await resError.json();
+    assert.equal(errorBody.error, "Failed to delete document file");
+    assert.equal(deleteCalls.length, 1);
+    assert.equal(removeCalls.length, 2);
+  } finally {
+    (Module as any)._load = originalLoad;
+  }
+});

--- a/tests/employeeDeleteRoute.test.ts
+++ b/tests/employeeDeleteRoute.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Module from "module";
+
+test("DELETE /api/employees/[id] removes Supabase files for related documents", async () => {
+  const originalLoad = (Module as any)._load;
+  const supabaseRemoveCalls: string[][] = [];
+  const deleteManyCalls: any[] = [];
+  const employeeDocPaths = ["employee/doc.pdf"];
+  const companyDocPaths = ["company/doc.pdf"];
+
+  (Module as any)._load = function (
+    request: string,
+    parent: any,
+    isMain: boolean,
+  ) {
+    if (request === "@/lib/prisma") {
+      return {
+        prisma: {
+          employee: {
+            findUnique: async (args: any) => ({
+              id: args.where.id,
+              userId: "user-1",
+              companyId: "company-1",
+              user: { companyId: "company-1" },
+            }),
+          },
+          $transaction: async (callback: any) => {
+            const tx: any = {
+              onboardingStepResponse: { deleteMany: async () => ({}) },
+              onboardingStepInstance: { deleteMany: async () => ({}) },
+              onboardingInstance: { deleteMany: async () => ({}) },
+              formDataRecord: { deleteMany: async () => ({}) },
+              formSubmission: { deleteMany: async () => ({}) },
+              formAssignment: { deleteMany: async () => ({}) },
+              documentAcknowledgement: { deleteMany: async () => ({}) },
+              employmentCheck: { deleteMany: async () => ({}) },
+              driverLicence: { deleteMany: async () => ({}) },
+              trainingRecord: { deleteMany: async () => ({}) },
+              leaveEntitlement: { deleteMany: async () => ({}) },
+              leaveRequest: { deleteMany: async () => ({}) },
+              employeeOffboarding: { deleteMany: async () => ({}) },
+              document: {
+                findMany: async (args: any) => {
+                  if (args?.where?.employeeId) {
+                    return employeeDocPaths.map((path) => ({ path }));
+                  }
+                  if (args?.where?.uploaderId) {
+                    return companyDocPaths.map((path) => ({ path }));
+                  }
+                  return [];
+                },
+                deleteMany: async (args: any) => {
+                  deleteManyCalls.push(args);
+                  return { count: 1 };
+                },
+                updateMany: async () => ({ count: 0 }),
+              },
+              user: {
+                findFirst: async () => null,
+                delete: async () => ({}),
+              },
+              onboardingAssignment: { deleteMany: async () => ({}) },
+              activationToken: { deleteMany: async () => ({}) },
+              savedReport: { deleteMany: async () => ({}) },
+              newsPost: { deleteMany: async () => ({}) },
+              employeeWorkingPatternAssignment: { deleteMany: async () => ({}) },
+              employee: { delete: async () => ({}) },
+            };
+
+            return callback(tx);
+          },
+        },
+      };
+    }
+    if (request === "@/lib/supabase-admin") {
+      return {
+        default: {
+          storage: {
+            from: () => ({
+              remove: async (paths: string[]) => {
+                supabaseRemoveCalls.push(paths);
+                return { data: null, error: null };
+              },
+            }),
+          },
+        },
+      };
+    }
+    if (request === "next-auth") {
+      return {
+        getServerSession: async () => ({
+          user: { id: "admin-1", companyId: "company-1", role: "ADMIN" },
+        }),
+      };
+    }
+    if (request === "@/lib/auth-options") {
+      return { authOptions: {} };
+    }
+    if (request === "@/lib/permissions") {
+      return { canAccessEmployee: async () => true };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    const { DELETE } = await import("../app/api/employees/[id]/route");
+    const res = await DELETE({} as Request, { params: { id: "emp-1" } });
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { success: true, deleted: true });
+
+    assert.equal(supabaseRemoveCalls.length, 1);
+    const removed = new Set(supabaseRemoveCalls[0]);
+    assert.equal(removed.has("employee/doc.pdf"), true);
+    assert.equal(removed.has("company/doc.pdf"), true);
+    assert.equal(deleteManyCalls.length, 2);
+  } finally {
+    (Module as any)._load = originalLoad;
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the document delete API aborts when Supabase file removal fails
- gather document paths during employee deletion and remove the files from Supabase once the transaction completes
- add regression tests covering both delete flows and Supabase removal handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87c1b4f8c833182ebb1fe8a74c37f