### PR TITLE
Implement dynamic form analytics view and tests

### DIFF
--- a/app/(withSidebar)/settings/forms/[id]/analytics/page.tsx
+++ b/app/(withSidebar)/settings/forms/[id]/analytics/page.tsx
@@ -1,33 +1,464 @@
 "use client";
+
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { PageShell } from "@/components/ui/PageShell";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
-import { BarChart3, Users, FileText, TrendingUp } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Activity, FileText, TrendingUp, Users } from "lucide-react";
+
+export interface FormAnalyticsSummary {
+  form: {
+    id: string;
+    name: string;
+    type: string | null;
+    isActive: boolean;
+    createdAt: string;
+  };
+  metrics: {
+    totalSubmissions: number;
+    uniqueSubmitters: number;
+    completionRate: number | null;
+    totalAssignments: number;
+    overdueAssignments: number;
+    recentSubmissions: number;
+  };
+  trends: {
+    submissionsByDate: Record<string, number>;
+    last30Days: number;
+  };
+  breakdowns: {
+    byDepartment: { name: string; count: number }[];
+    byJobRole: { name: string; count: number }[];
+  };
+  recentActivity: {
+    id: string;
+    submitterName: string;
+    submitterEmail?: string | null;
+    department?: string | null;
+    jobRole?: string | null;
+    submittedAt: string;
+  }[];
+  generatedAt: string;
+}
+
+type FetchAnalyticsSummary = (
+  formId: string,
+  signal: AbortSignal,
+) => Promise<FormAnalyticsSummary>;
+
+const fetchFormAnalyticsSummary: FetchAnalyticsSummary = async (
+  formId,
+  signal,
+) => {
+  const response = await fetch(`/api/forms/${formId}/analytics/summary`, {
+    signal,
+  });
+  const payload = await response.json();
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : "Failed to load form analytics.";
+    throw new Error(message);
+  }
+
+  return payload as FormAnalyticsSummary;
+};
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function FormAnalyticsContent({
+  formId,
+  fetchAnalytics = fetchFormAnalyticsSummary,
+}: {
+  formId: string;
+  fetchAnalytics?: FetchAnalyticsSummary;
+}) {
+  const [summary, setSummary] = useState<FormAnalyticsSummary | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!formId) {
+      setSummary(null);
+      setIsLoading(false);
+      setError("Invalid form identifier.");
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    setIsLoading(true);
+    setError(null);
+
+    fetchAnalytics(formId, controller.signal)
+      .then((data) => {
+        if (cancelled) return;
+        setSummary(data);
+      })
+      .catch((err: Error) => {
+        if (cancelled || err.name === "AbortError") return;
+        setSummary(null);
+        setError(err.message || "Failed to load form analytics.");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [formId, fetchAnalytics]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-24">
+        <LoadingSpinner size="lg" showText text="Loading analytics" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="max-w-xl mx-auto">
+        <CardHeader>
+          <CardTitle>Unable to load analytics</CardTitle>
+          <CardDescription>{error}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Please refresh the page to try again. If the problem persists, contact
+            your administrator.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  return <FormAnalyticsView summary={summary} />;
+}
+
+export function FormAnalyticsView({
+  summary,
+}: {
+  summary: FormAnalyticsSummary;
+}) {
+  const { metrics, breakdowns, recentActivity, trends, form, generatedAt } =
+    summary;
+
+  const trendEntries = useMemo(
+    () =>
+      Object.entries(trends.submissionsByDate).sort(
+        ([a], [b]) => new Date(a).getTime() - new Date(b).getTime(),
+      ),
+    [trends.submissionsByDate],
+  );
+
+  const summaryCards = useMemo(
+    () =>
+      [
+        {
+          title: "Total Submissions",
+          icon: FileText,
+          value: formatNumber(metrics.totalSubmissions),
+          description:
+            metrics.totalSubmissions === 0
+              ? "No submissions yet"
+              : `${formatNumber(metrics.recentSubmissions)} in the last 30 days`,
+          testId: "analytics-card-total-submissions",
+        },
+        {
+          title: "Unique Submitters",
+          icon: Users,
+          value: formatNumber(metrics.uniqueSubmitters),
+          description:
+            metrics.uniqueSubmitters === 0
+              ? "No unique submitters yet"
+              : "Distinct employees have responded",
+          testId: "analytics-card-unique-submitters",
+        },
+        {
+          title: "Completion Rate",
+          icon: TrendingUp,
+          value:
+            metrics.completionRate === null
+              ? "—"
+              : `${metrics.completionRate.toFixed(0)}%`,
+          description:
+            metrics.totalAssignments === 0
+              ? "No assignments tracked"
+              : `${formatNumber(metrics.overdueAssignments)} overdue of ${formatNumber(metrics.totalAssignments)}`,
+          testId: "analytics-card-completion-rate",
+        },
+        {
+          title: "Recent Submissions (30d)",
+          icon: Activity,
+          value: formatNumber(trends.last30Days),
+          description:
+            trends.last30Days === 0
+              ? "No submissions this month yet"
+              : "In the last 30 days",
+          testId: "analytics-card-recent-submissions",
+        },
+      ] as const,
+    [
+      metrics.totalSubmissions,
+      metrics.recentSubmissions,
+      metrics.uniqueSubmitters,
+      metrics.completionRate,
+      metrics.totalAssignments,
+      metrics.overdueAssignments,
+      trends.last30Days,
+    ],
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <p className="text-sm text-muted-foreground">
+          Analytics generated {formatDateTime(generatedAt)}
+        </p>
+        <h2 className="text-2xl font-semibold text-foreground">
+          {form.name || "Form"}
+        </h2>
+        {form.type && (
+          <p className="text-sm text-muted-foreground">
+            Form type: {form.type}
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map(({ icon: Icon, title, value, description, testId }) => (
+          <div
+            key={title}
+            data-testid={testId}
+            className="glass rounded-3xl shadow-glass h-full transition-glass hover-glass hover-lift"
+          >
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">{title}</CardTitle>
+              <Icon className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{value}</div>
+              <p className="text-xs text-muted-foreground">{description}</p>
+            </CardContent>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Submission trend (last 30 days)</CardTitle>
+            <CardDescription>
+              {trends.last30Days === 0
+                ? "We haven’t seen any submissions in the past 30 days."
+                : `${formatNumber(trends.last30Days)} submissions in the last 30 days.`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {trendEntries.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Submissions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {trendEntries.map(([date, count]) => (
+                    <TableRow key={date}>
+                      <TableCell>{formatDateTime(date)}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatNumber(count)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No submission trend data available yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent activity</CardTitle>
+            <CardDescription>Latest ten submissions</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {recentActivity.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Submitter</TableHead>
+                    <TableHead>Department</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead className="text-right">Submitted</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {recentActivity.map((activity) => (
+                    <TableRow key={activity.id}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-foreground">
+                            {activity.submitterName || "Unknown"}
+                          </span>
+                          {activity.submitterEmail && (
+                            <span className="text-xs text-muted-foreground">
+                              {activity.submitterEmail}
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>{activity.department || "—"}</TableCell>
+                      <TableCell>{activity.jobRole || "—"}</TableCell>
+                      <TableCell className="text-right">
+                        {formatDateTime(activity.submittedAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No recent activity to show yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Department breakdown</CardTitle>
+            <CardDescription>
+              {breakdowns.byDepartment.length === 0
+                ? "Departments will appear once submissions are received."
+                : "Submission counts grouped by department."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {breakdowns.byDepartment.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Department</TableHead>
+                    <TableHead className="text-right">Submissions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {breakdowns.byDepartment.map((item) => (
+                    <TableRow key={item.name}>
+                      <TableCell>{item.name}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatNumber(item.count)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No department insights yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Role breakdown</CardTitle>
+            <CardDescription>
+              {breakdowns.byJobRole.length === 0
+                ? "Roles will display here after submissions are collected."
+                : "Submission counts grouped by job role."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {breakdowns.byJobRole.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Role</TableHead>
+                    <TableHead className="text-right">Submissions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {breakdowns.byJobRole.map((item) => (
+                    <TableRow key={item.name}>
+                      <TableCell>{item.name}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatNumber(item.count)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No role insights yet.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
 
 export default function FormAnalyticsPage() {
   const params = useParams();
   const formId = params?.id ? String(params.id) : "";
 
   const breadcrumbItems = [
-    { label: 'Settings', href: '/settings' },
-    { label: 'Forms & Surveys', href: '/settings/forms' },
-    { label: 'Form Analytics', isCurrentPage: true }
+    { label: "Settings", href: "/settings" },
+    { label: "Forms & Surveys", href: "/settings/forms" },
+    { label: "Form Analytics", isCurrentPage: true },
   ];
-
-  if (!formId) {
-    return (
-      <PageShell
-        title="Form Analytics"
-        description="View submission statistics and insights"
-        breadcrumbs={{ items: breadcrumbItems }}
-        showHomeIcon={false}
-      >
-        <div className="flex items-center justify-center h-64 text-gray-500">
-          Invalid form ID.
-        </div>
-      </PageShell>
-    );
-  }
 
   return (
     <PageShell
@@ -36,74 +467,21 @@ export default function FormAnalyticsPage() {
       breadcrumbs={{ items: breadcrumbItems }}
       showHomeIcon={false}
     >
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Total Submissions
-            </CardTitle>
-            <FileText className="h-4 w-4 text-muted-foreground" />
+      {formId ? (
+        <FormAnalyticsContent formId={formId} />
+      ) : (
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>Form not found</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
-            <p className="text-xs text-muted-foreground">No submissions yet</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Unique Users</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">0</div>
-            <p className="text-xs text-muted-foreground">No users yet</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Completion Rate
-            </CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">0%</div>
-            <p className="text-xs text-muted-foreground">No data available</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Avg. Time</CardTitle>
-            <BarChart3 className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">--</div>
-            <p className="text-xs text-muted-foreground">No data available</p>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Analytics Coming Soon</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center py-8">
-            <BarChart3 className="h-16 w-16 mx-auto text-gray-400 mb-4" />
-            <h3 className="text-lg font-semibold mb-2">Analytics Dashboard</h3>
-            <p className="text-gray-600 mb-4">
-              Detailed form analytics and insights will be available here soon.
+            <p className="text-sm text-muted-foreground">
+              We couldn&apos;t determine which form you wanted to inspect.
+              Please return to the forms list and try again.
             </p>
-            <p className="text-sm text-gray-500">
-              Features will include submission trends, completion rates, user
-              engagement metrics, and more.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
     </PageShell>
   );
 }

--- a/tests/formAnalyticsPage.test.tsx
+++ b/tests/formAnalyticsPage.test.tsx
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import type { FormAnalyticsSummary } from "../app/(withSidebar)/settings/forms/[id]/analytics/page";
+import { FormAnalyticsView } from "../app/(withSidebar)/settings/forms/[id]/analytics/page";
+
+test("renders analytics metrics from summary response", () => {
+  const summary: FormAnalyticsSummary = {
+    form: {
+      id: "form-123",
+      name: "Onboarding Survey",
+      type: "survey",
+      isActive: true,
+      createdAt: new Date("2024-01-01T12:00:00Z").toISOString(),
+    },
+    metrics: {
+      totalSubmissions: 24,
+      uniqueSubmitters: 17,
+      completionRate: 75,
+      totalAssignments: 30,
+      overdueAssignments: 2,
+      recentSubmissions: 5,
+    },
+    trends: {
+      submissionsByDate: {
+        "2024-01-03": 2,
+        "2024-01-05": 3,
+      },
+      last30Days: 5,
+    },
+    breakdowns: {
+      byDepartment: [
+        { name: "Engineering", count: 12 },
+        { name: "HR", count: 6 },
+      ],
+      byJobRole: [
+        { name: "Developer", count: 10 },
+        { name: "Manager", count: 4 },
+      ],
+    },
+    recentActivity: [
+      {
+        id: "sub-1",
+        submitterName: "Alice Example",
+        submitterEmail: "alice@example.com",
+        department: "Engineering",
+        jobRole: "Developer",
+        submittedAt: new Date("2024-01-05T15:30:00Z").toISOString(),
+      },
+    ],
+    generatedAt: new Date("2024-01-06T10:00:00Z").toISOString(),
+  };
+
+  const html = renderToString(<FormAnalyticsView summary={summary} />);
+
+  assert.ok(html.includes("Total Submissions"));
+  assert.ok(html.includes("<div class=\"text-2xl font-bold\">24</div>"));
+  assert.ok(html.includes("Unique Submitters"));
+  assert.ok(html.includes("<div class=\"text-2xl font-bold\">17</div>"));
+  assert.ok(html.includes("75%"));
+  assert.ok(html.includes("2 overdue of 30"));
+  assert.ok(html.includes("Engineering"));
+  assert.ok(html.includes("Alice Example"));
+});
+
+test("degrades gracefully when analytics are empty", () => {
+  const summary: FormAnalyticsSummary = {
+    form: {
+      id: "form-000",
+      name: "Pulse Check",
+      type: null,
+      isActive: false,
+      createdAt: new Date("2024-02-01T12:00:00Z").toISOString(),
+    },
+    metrics: {
+      totalSubmissions: 0,
+      uniqueSubmitters: 0,
+      completionRate: null,
+      totalAssignments: 0,
+      overdueAssignments: 0,
+      recentSubmissions: 0,
+    },
+    trends: {
+      submissionsByDate: {},
+      last30Days: 0,
+    },
+    breakdowns: {
+      byDepartment: [],
+      byJobRole: [],
+    },
+    recentActivity: [],
+    generatedAt: new Date("2024-02-02T09:00:00Z").toISOString(),
+  };
+
+  const html = renderToString(<FormAnalyticsView summary={summary} />);
+
+  assert.ok(html.includes("No submissions yet"));
+  assert.ok(html.includes("No unique submitters yet"));
+  assert.ok(html.includes("No assignments tracked"));
+  assert.ok(html.includes("No submissions this month yet"));
+  assert.ok(html.includes("No submission trend data available yet."));
+  assert.ok(html.includes("No recent activity to show yet."));
+  assert.ok(html.includes("No department insights yet."));
+  assert.ok(html.includes("No role insights yet."));
+});

--- a/tests/forms/logicEvaluator.test.ts
+++ b/tests/forms/logicEvaluator.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import test from "node:test";
+import assert from "node:assert/strict";
 
 // Minimal replica of the condition evaluation used in EnhancedFormRenderer
 function evaluateCondition(left: any, operator: string, right: any) {
@@ -8,9 +9,13 @@ function evaluateCondition(left: any, operator: string, right: any) {
     case "notEquals":
       return left !== right;
     case "contains":
-      return Array.isArray(left) ? left.includes(right) : String(left || "").includes(String(right ?? ""));
+      return Array.isArray(left)
+        ? left.includes(right)
+        : String(left || "").includes(String(right ?? ""));
     case "notContains":
-      return Array.isArray(left) ? !left.includes(right) : !String(left || "").includes(String(right ?? ""));
+      return Array.isArray(left)
+        ? !left.includes(right)
+        : !String(left || "").includes(String(right ?? ""));
     case "greaterThan":
       return Number(left) > Number(right);
     case "greaterOrEqual":
@@ -20,26 +25,34 @@ function evaluateCondition(left: any, operator: string, right: any) {
     case "lessOrEqual":
       return Number(left) <= Number(right);
     case "isEmpty":
-      return left === undefined || left === null || left === "" || (Array.isArray(left) && left.length === 0);
+      return (
+        left === undefined ||
+        left === null ||
+        left === "" ||
+        (Array.isArray(left) && left.length === 0)
+      );
     case "isNotEmpty":
-      return !(left === undefined || left === null || left === "" || (Array.isArray(left) && left.length === 0));
+      return !(
+        left === undefined ||
+        left === null ||
+        left === "" ||
+        (Array.isArray(left) && left.length === 0)
+      );
     default:
       return true;
   }
 }
 
-describe("logic evaluator", () => {
-  it("compares primitives", () => {
-    expect(evaluateCondition(5, "greaterThan", 3)).toBe(true);
-    expect(evaluateCondition(3, "lessOrEqual", 3)).toBe(true);
-    expect(evaluateCondition("abc", "contains", "b")).toBe(true);
-  });
+test("logic evaluator compares primitives", () => {
+  assert.equal(evaluateCondition(5, "greaterThan", 3), true);
+  assert.equal(evaluateCondition(3, "lessOrEqual", 3), true);
+  assert.equal(evaluateCondition("abc", "contains", "b"), true);
+});
 
-  it("handles emptiness", () => {
-    expect(evaluateCondition([], "isEmpty", null)).toBe(true);
-    expect(evaluateCondition([1], "isNotEmpty", null)).toBe(true);
-    expect(evaluateCondition("", "isEmpty", null)).toBe(true);
-  });
+test("logic evaluator handles emptiness", () => {
+  assert.equal(evaluateCondition([], "isEmpty", null), true);
+  assert.equal(evaluateCondition([1], "isNotEmpty", null), true);
+  assert.equal(evaluateCondition("", "isEmpty", null), true);
 });
 
 

--- a/tests/forms/schemaHelpers.test.ts
+++ b/tests/forms/schemaHelpers.test.ts
@@ -1,38 +1,43 @@
-import { describe, it, expect } from "vitest";
-import { isLegacySchema, upgradeLegacySchema, normalizeToPages, FormField, FormSchemaV2 } from "@/api/forms/[id]/types";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isLegacySchema,
+  upgradeLegacySchema,
+  normalizeToPages,
+  FormField,
+  FormSchemaV2,
+} from "@/api/forms/[id]/types";
 
-describe("schema helpers", () => {
-  it("detects legacy schema as array of fields", () => {
-    const legacy: FormField[] = [
-      { id: "a", type: "text", label: "A", required: false },
-    ];
-    expect(isLegacySchema(legacy)).toBe(true);
-  });
+test("detects legacy schema as array of fields", () => {
+  const legacy: FormField[] = [
+    { id: "a", type: "text", label: "A", required: false },
+  ];
+  assert.equal(isLegacySchema(legacy), true);
+});
 
-  it("wraps legacy schema into a default section and page", () => {
-    const legacy: FormField[] = [
-      { id: "a", type: "text", label: "A", required: false },
-      { id: "b", type: "number", label: "B", required: false },
-    ];
-    const v2 = upgradeLegacySchema(legacy);
-    expect(v2.version).toBe(2);
-    expect(v2.sections?.[0]?.fields?.length).toBe(2);
-    const pages = normalizeToPages(legacy);
-    expect(pages.length).toBe(1);
-    expect(pages[0].sections[0].fields.length).toBe(2);
-  });
+test("wraps legacy schema into a default section and page", () => {
+  const legacy: FormField[] = [
+    { id: "a", type: "text", label: "A", required: false },
+    { id: "b", type: "number", label: "B", required: false },
+  ];
+  const v2 = upgradeLegacySchema(legacy);
+  assert.equal(v2.version, 2);
+  assert.equal(v2.sections?.[0]?.fields?.length, 2);
+  const pages = normalizeToPages(legacy);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].sections[0].fields.length, 2);
+});
 
-  it("normalizes sections-only V2 schema into pages", () => {
-    const v2: FormSchemaV2 = {
-      version: 2,
-      sections: [
-        { id: "s1", columns: 2, layout: "two-column", hidden: false, fields: [] },
-      ],
-    };
-    const pages = normalizeToPages(v2);
-    expect(pages.length).toBe(1);
-    expect(pages[0].sections.length).toBe(1);
-  });
+test("normalizes sections-only V2 schema into pages", () => {
+  const v2: FormSchemaV2 = {
+    version: 2,
+    sections: [
+      { id: "s1", columns: 2, layout: "two-column", hidden: false, fields: [] },
+    ],
+  };
+  const pages = normalizeToPages(v2);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].sections.length, 1);
 });
 
 


### PR DESCRIPTION
## Summary
- fetch the form analytics summary client-side and display metrics, trends, breakdowns, and recent activity with graceful fallbacks
- reuse a shared FormAnalyticsView for rendering and update the page to handle loading and invalid form states
- rewrite legacy vitest-based specs to node:test and add coverage for the analytics view scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdaab97ad0833196369c0100b057e3