### PR TITLE
Move performance review route helpers out of handler

### DIFF
--- a/app/(withSidebar)/employees/[id]/performance/helpers.ts
+++ b/app/(withSidebar)/employees/[id]/performance/helpers.ts
@@ -1,0 +1,87 @@
+export interface Reviewer {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export interface PerformanceReview {
+  id: string;
+  employeeId: string;
+  companyId: string;
+  reviewerId: string | null;
+  reviewDate: string;
+  rating: number | null;
+  summary: string | null;
+  strengths: string | null;
+  areasForImprovement: string | null;
+  goals: string[];
+  createdAt: string;
+  updatedAt: string;
+  reviewer: Reviewer | null;
+}
+
+export interface ReviewFormState {
+  reviewDate: string;
+  rating: string;
+  summary: string;
+  strengths: string;
+  areasForImprovement: string;
+  goals: string;
+}
+
+export interface ReviewPayload {
+  reviewDate: string;
+  rating: number | null;
+  summary: string;
+  strengths: string;
+  areasForImprovement: string;
+  goals: string[];
+}
+
+export function createEmptyFormState(): ReviewFormState {
+  return {
+    reviewDate: "",
+    rating: "",
+    summary: "",
+    strengths: "",
+    areasForImprovement: "",
+    goals: "",
+  };
+}
+
+export function createFormStateFromReview(
+  review: PerformanceReview,
+): ReviewFormState {
+  return {
+    reviewDate: review.reviewDate ? review.reviewDate.slice(0, 10) : "",
+    rating: review.rating ? String(review.rating) : "",
+    summary: review.summary ?? "",
+    strengths: review.strengths ?? "",
+    areasForImprovement: review.areasForImprovement ?? "",
+    goals:
+      review.goals && review.goals.length > 0 ? review.goals.join("\n") : "",
+  };
+}
+
+export function buildPayloadFromForm(state: ReviewFormState): ReviewPayload {
+  const ratingValue = state.rating.trim();
+  const numericRating = ratingValue ? Number(ratingValue) : null;
+  const rating =
+    numericRating !== null && Number.isFinite(numericRating)
+      ? numericRating
+      : null;
+
+  const goals = state.goals
+    .split(/\r?\n/)
+    .map((goal) => goal.trim())
+    .filter(Boolean);
+
+  return {
+    reviewDate: state.reviewDate,
+    rating,
+    summary: state.summary.trim(),
+    strengths: state.strengths.trim(),
+    areasForImprovement: state.areasForImprovement.trim(),
+    goals,
+  };
+}

--- a/app/(withSidebar)/employees/[id]/performance/page.tsx
+++ b/app/(withSidebar)/employees/[id]/performance/page.tsx
@@ -1,8 +1,459 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { ClipboardList, History, Pencil } from "lucide-react";
+import { PageShell } from "@/components/ui/PageShell";
+import Button from "@/components/ui/Button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/Card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/Badge";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { formatLondon, formatLondonDate } from "@/lib/time";
+import { toast } from "sonner";
+import {
+  PerformanceReview,
+  Reviewer,
+  ReviewFormState,
+  buildPayloadFromForm,
+  createEmptyFormState,
+  createFormStateFromReview,
+} from "./helpers";
+
+function formatReviewerName(reviewer: Reviewer | null): string {
+  if (!reviewer) {
+    return "Reviewer not recorded";
+  }
+  const parts = [reviewer.firstName, reviewer.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Reviewer";
+}
+
 export default function PerformancePage() {
+  const params = useParams();
+  const employeeId = params?.id as string | undefined;
+
+  const [reviews, setReviews] = useState<PerformanceReview[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingReview, setEditingReview] = useState<PerformanceReview | null>(
+    null,
+  );
+  const [formState, setFormState] = useState<ReviewFormState>(() =>
+    createEmptyFormState(),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const fetchReviews = useCallback(
+    async (showSpinner = false) => {
+      if (!employeeId) {
+        return;
+      }
+      if (showSpinner) {
+        setLoading(true);
+      }
+      try {
+        setError(null);
+        const response = await fetch(
+          `/api/employees/${employeeId}/performance-reviews`,
+        );
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body.error || "Failed to load performance reviews");
+        }
+        const data = (await response.json()) as PerformanceReview[];
+        setReviews(data);
+      } catch (err) {
+        console.error("Failed to load performance reviews", err);
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Failed to load performance reviews";
+        setError(message);
+        toast.error(message);
+      } finally {
+        if (showSpinner) {
+          setLoading(false);
+        }
+      }
+    },
+    [employeeId],
+  );
+
+  useEffect(() => {
+    if (!employeeId) {
+      setLoading(false);
+      return;
+    }
+    fetchReviews(true);
+  }, [employeeId, fetchReviews]);
+
+  const sortedReviews = useMemo(() => {
+    return [...reviews].sort((a, b) => {
+      return (
+        new Date(b.reviewDate).getTime() - new Date(a.reviewDate).getTime()
+      );
+    });
+  }, [reviews]);
+
+  const handleOpenCreate = () => {
+    setEditingReview(null);
+    setFormState(createEmptyFormState());
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (review: PerformanceReview) => {
+    setEditingReview(review);
+    setFormState(createFormStateFromReview(review));
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!employeeId) {
+      return;
+    }
+    if (!formState.reviewDate) {
+      toast.error("Review date is required");
+      return;
+    }
+
+    const payload = buildPayloadFromForm(formState);
+
+    setSaving(true);
+    try {
+      const method = editingReview ? "PUT" : "POST";
+      const body = editingReview
+        ? { id: editingReview.id, ...payload }
+        : payload;
+
+      const response = await fetch(
+        `/api/employees/${employeeId}/performance-reviews`,
+        {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+
+      if (!response.ok) {
+        const result = await response.json().catch(() => ({}));
+        throw new Error(result.error || "Unable to save review");
+      }
+
+      const result = (await response.json()) as { review: PerformanceReview };
+      const savedReview = result.review;
+
+      toast.success(
+        editingReview ? "Performance review updated" : "Performance review added",
+      );
+
+      setDialogOpen(false);
+      setEditingReview(null);
+      setFormState(createEmptyFormState());
+
+      // Optimistically update list if it exists, otherwise refetch
+      setReviews((prev) => {
+        const withoutUpdated = editingReview
+          ? prev.filter((review) => review.id !== savedReview.id)
+          : prev;
+        return [savedReview, ...withoutUpdated].sort(
+          (a, b) =>
+            new Date(b.reviewDate).getTime() - new Date(a.reviewDate).getTime(),
+        );
+      });
+    } catch (err) {
+      console.error("Failed to save performance review", err);
+      const message =
+        err instanceof Error ? err.message : "Unable to save review";
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDialogChange = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingReview(null);
+      setFormState(createEmptyFormState());
+    }
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Performance Reviews</h1>
-      <p>Performance data and reviews for this employee will appear here.</p>
-    </div>
+    <PageShell
+      title="Performance Reviews"
+      description="Track historical feedback and objectives captured during employee reviews."
+      icon={<ClipboardList className="h-6 w-6" />}
+      action={
+        <Button onClick={handleOpenCreate} variant="primary">
+          Log review
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        {loading ? (
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+              <LoadingSpinner size="lg" showText text="Loading reviews" />
+              <p className="mt-4 text-sm text-muted-foreground">
+                Gathering recent performance activity…
+              </p>
+            </CardContent>
+          </Card>
+        ) : error ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <History className="h-5 w-5 text-destructive" />
+                Unable to load reviews
+              </CardTitle>
+              <CardDescription>
+                {error || "Something went wrong loading this employee's reviews."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="secondary" onClick={() => fetchReviews(true)}>
+                Try again
+              </Button>
+            </CardContent>
+          </Card>
+        ) : sortedReviews.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>No recorded reviews yet</CardTitle>
+              <CardDescription>
+                Capture the first performance conversation to build a historical
+                timeline.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={handleOpenCreate}>Record first review</Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {sortedReviews.map((review) => (
+              <Card key={review.id}>
+                <CardHeader>
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <CardTitle>
+                        Review on {formatLondonDate(review.reviewDate)}
+                      </CardTitle>
+                      <CardDescription>
+                        Reviewed by {formatReviewerName(review.reviewer)} · Updated
+                        {" "}
+                        {formatLondon(review.updatedAt)}
+                      </CardDescription>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      {typeof review.rating === "number" && (
+                        <Badge>Rating {review.rating}/5</Badge>
+                      )}
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => handleEdit(review)}
+                        className="flex items-center gap-2"
+                      >
+                        <Pencil className="h-4 w-4" />
+                        Edit
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-5">
+                  {review.summary && (
+                    <section>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Summary
+                      </h3>
+                      <p className="mt-2 text-sm leading-relaxed text-foreground">
+                        {review.summary}
+                      </p>
+                    </section>
+                  )}
+
+                  {review.strengths && (
+                    <section>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Strengths highlighted
+                      </h3>
+                      <p className="mt-2 text-sm leading-relaxed text-foreground">
+                        {review.strengths}
+                      </p>
+                    </section>
+                  )}
+
+                  {review.areasForImprovement && (
+                    <section>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Development focus
+                      </h3>
+                      <p className="mt-2 text-sm leading-relaxed text-foreground">
+                        {review.areasForImprovement}
+                      </p>
+                    </section>
+                  )}
+
+                  {review.goals && review.goals.length > 0 && (
+                    <section>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Goals agreed
+                      </h3>
+                      <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-foreground">
+                        {review.goals.map((goal, index) => (
+                          <li key={`${review.id}-goal-${index}`}>{goal}</li>
+                        ))}
+                      </ul>
+                    </section>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={handleDialogChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingReview ? "Edit performance review" : "Log new review"}
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-date">Review date</Label>
+                <Input
+                  id="review-date"
+                  type="date"
+                  value={formState.reviewDate}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      reviewDate: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-rating">Overall rating</Label>
+                <Input
+                  id="review-rating"
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={5}
+                  step={1}
+                  placeholder="1-5"
+                  value={formState.rating}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      rating: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-summary">Review summary</Label>
+                <Textarea
+                  id="review-summary"
+                  value={formState.summary}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      summary: event.target.value,
+                    }))
+                  }
+                  placeholder="Key themes, tone and overall outcomes"
+                  rows={4}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-strengths">Strengths celebrated</Label>
+                <Textarea
+                  id="review-strengths"
+                  value={formState.strengths}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      strengths: event.target.value,
+                    }))
+                  }
+                  placeholder="Recognised achievements, behaviours or skills"
+                  rows={3}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-development">Development focus</Label>
+                <Textarea
+                  id="review-development"
+                  value={formState.areasForImprovement}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      areasForImprovement: event.target.value,
+                    }))
+                  }
+                  placeholder="Growth opportunities or areas needing support"
+                  rows={3}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="review-goals">Goals agreed</Label>
+                <Textarea
+                  id="review-goals"
+                  value={formState.goals}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      goals: event.target.value,
+                    }))
+                  }
+                  placeholder="Enter one goal per line"
+                  rows={4}
+                />
+              </div>
+            </div>
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => handleDialogChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" loading={saving} disabled={saving}>
+                {editingReview ? "Save changes" : "Create review"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
   );
 }

--- a/app/api/employees/[id]/performance-reviews/helpers.ts
+++ b/app/api/employees/[id]/performance-reviews/helpers.ts
@@ -1,0 +1,99 @@
+import type { Prisma } from "@prisma/client";
+
+export type ReviewWithRelations = Prisma.EmployeePerformanceReviewGetPayload<{
+  include: {
+    Reviewer: {
+      select: {
+        id: true;
+        firstName: true;
+        lastName: true;
+      };
+    };
+  };
+}>;
+
+export function normaliseGoals(input: unknown): string[] | null {
+  if (!input) {
+    return null;
+  }
+
+  if (Array.isArray(input)) {
+    const cleaned = input
+      .filter((goal): goal is string => typeof goal === "string")
+      .map((goal) => goal.trim())
+      .filter(Boolean);
+    return cleaned.length > 0 ? cleaned : null;
+  }
+
+  if (typeof input === "string") {
+    const cleaned = input
+      .split(/\r?\n/)
+      .map((goal) => goal.trim())
+      .filter(Boolean);
+    return cleaned.length > 0 ? cleaned : null;
+  }
+
+  return null;
+}
+
+export function normaliseText(input: unknown): string | null {
+  if (typeof input !== "string") {
+    return null;
+  }
+  const value = input.trim();
+  return value.length > 0 ? value : null;
+}
+
+export function parseRating(input: unknown): number | null {
+  if (input === null || typeof input === "undefined" || input === "") {
+    return null;
+  }
+
+  const value = Number(input);
+  if (!Number.isFinite(value)) {
+    throw new Error("Rating must be a number");
+  }
+
+  const rounded = Math.round(value);
+  if (rounded < 1 || rounded > 5) {
+    throw new Error("Rating must be between 1 and 5");
+  }
+
+  return rounded;
+}
+
+export function parseReviewDate(input: string): Date {
+  const reviewDate = new Date(input);
+  if (Number.isNaN(reviewDate.getTime())) {
+    throw new Error("Invalid review date");
+  }
+  return reviewDate;
+}
+
+export function serialiseReview(review: ReviewWithRelations) {
+  const goalsValue = Array.isArray(review.goals)
+    ? review.goals.filter((goal): goal is string => typeof goal === "string")
+    : [];
+
+  return {
+    id: review.id,
+    employeeId: review.employeeId,
+    companyId: review.companyId,
+    reviewerId: review.reviewerId,
+    reviewDate: review.reviewDate.toISOString(),
+    rating: review.rating,
+    summary: review.summary,
+    strengths: review.strengths,
+    areasForImprovement: review.areasForImprovement,
+    goals: goalsValue,
+    createdAt: review.createdAt.toISOString(),
+    updatedAt: review.updatedAt.toISOString(),
+    reviewer: review.Reviewer
+      ? {
+          id: review.Reviewer.id,
+          firstName: review.Reviewer.firstName,
+          lastName: review.Reviewer.lastName,
+        }
+      : null,
+  };
+}

--- a/app/api/employees/[id]/performance-reviews/route.ts
+++ b/app/api/employees/[id]/performance-reviews/route.ts
@@ -1,0 +1,245 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { z } from "zod";
+import {
+  normaliseGoals,
+  normaliseText,
+  parseRating,
+  parseReviewDate,
+  serialiseReview,
+} from "./helpers";
+
+const reviewBodySchema = z.object({
+  reviewDate: z
+    .string({ required_error: "Review date is required" })
+    .trim()
+    .min(1, "Review date is required"),
+  rating: z.union([z.number(), z.string(), z.null(), z.undefined()]).optional(),
+  summary: z.union([z.string(), z.null(), z.undefined()]).optional(),
+  strengths: z.union([z.string(), z.null(), z.undefined()]).optional(),
+  areasForImprovement: z
+    .union([z.string(), z.null(), z.undefined()])
+    .optional(),
+  goals: z.union([z.array(z.string()), z.string(), z.null(), z.undefined()]).optional(),
+});
+
+const reviewUpdateSchema = reviewBodySchema.extend({
+  id: z
+    .string({ required_error: "Review id is required" })
+    .trim()
+    .min(1, "Review id is required"),
+});
+
+function isManagerOrAdmin(role?: string | null) {
+  return role === "ADMIN" || role === "MANAGER";
+}
+
+async function getEmployeeForSession(employeeId: string, companyId: string) {
+  return prisma.employee.findFirst({
+    where: { id: employeeId, companyId },
+    select: { id: true, userId: true },
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id || !session.user.companyId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const employee = await getEmployeeForSession(
+      params.id,
+      session.user.companyId,
+    );
+    if (!employee) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const canView =
+      isManagerOrAdmin(session.user.role) ||
+      session.user.id === employee.userId;
+
+    if (!canView) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const reviews = await prisma.employeePerformanceReview.findMany({
+      where: {
+        employeeId: employee.id,
+        companyId: session.user.companyId,
+      },
+      orderBy: { reviewDate: "desc" },
+      include: {
+        Reviewer: {
+          select: { id: true, firstName: true, lastName: true },
+        },
+      },
+    });
+
+    return NextResponse.json(reviews.map(serialiseReview));
+  } catch (error) {
+    console.error("[employee-performance-reviews-get]", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id || !session.user.companyId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!isManagerOrAdmin(session.user.role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const employee = await getEmployeeForSession(
+      params.id,
+      session.user.companyId,
+    );
+    if (!employee) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const payload = reviewBodySchema.parse(await req.json());
+
+    let reviewDate: Date;
+    try {
+      reviewDate = parseReviewDate(payload.reviewDate);
+    } catch (err: any) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    let rating: number | null = null;
+    try {
+      rating = parseRating(payload.rating);
+    } catch (err: any) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
+    const goals = normaliseGoals(payload.goals ?? null);
+
+    const created = await prisma.employeePerformanceReview.create({
+      data: {
+        id: crypto.randomUUID(),
+        employeeId: employee.id,
+        companyId: session.user.companyId,
+        reviewerId: session.user.id,
+        reviewDate,
+        rating,
+        summary: normaliseText(payload.summary),
+        strengths: normaliseText(payload.strengths),
+        areasForImprovement: normaliseText(payload.areasForImprovement),
+        goals,
+      },
+      include: {
+        Reviewer: {
+          select: { id: true, firstName: true, lastName: true },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      { review: serialiseReview(created) },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("[employee-performance-reviews-post]", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id || !session.user.companyId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!isManagerOrAdmin(session.user.role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const employee = await getEmployeeForSession(
+      params.id,
+      session.user.companyId,
+    );
+    if (!employee) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const payload = reviewUpdateSchema.parse(await req.json());
+
+    const existing = await prisma.employeePerformanceReview.findFirst({
+      where: {
+        id: payload.id,
+        employeeId: employee.id,
+        companyId: session.user.companyId,
+      },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    let reviewDate: Date;
+    try {
+      reviewDate = parseReviewDate(payload.reviewDate);
+    } catch (err: any) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    let rating: number | null = null;
+    try {
+      rating = parseRating(payload.rating);
+    } catch (err: any) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
+    const goals = normaliseGoals(payload.goals ?? null);
+
+    const updated = await prisma.employeePerformanceReview.update({
+      where: { id: existing.id },
+      data: {
+        reviewDate,
+        rating,
+        summary: normaliseText(payload.summary),
+        strengths: normaliseText(payload.strengths),
+        areasForImprovement: normaliseText(payload.areasForImprovement),
+        goals,
+        reviewerId: session.user.id,
+      },
+      include: {
+        Reviewer: {
+          select: { id: true, firstName: true, lastName: true },
+        },
+      },
+    });
+
+    return NextResponse.json({ review: serialiseReview(updated) });
+  } catch (error) {
+    console.error("[employee-performance-reviews-put]", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/prisma/migrations/20251020120000_add_employee_performance_reviews/migration.sql
+++ b/prisma/migrations/20251020120000_add_employee_performance_reviews/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "EmployeePerformanceReview" (
+    "id" TEXT NOT NULL,
+    "employeeId" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "reviewerId" TEXT,
+    "reviewDate" TIMESTAMP(3) NOT NULL,
+    "rating" INTEGER,
+    "summary" TEXT,
+    "strengths" TEXT,
+    "areasForImprovement" TEXT,
+    "goals" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmployeePerformanceReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EmployeePerformanceReview_employeeId_reviewDate_idx" ON "EmployeePerformanceReview"("employeeId", "reviewDate");
+
+-- CreateIndex
+CREATE INDEX "EmployeePerformanceReview_companyId_idx" ON "EmployeePerformanceReview"("companyId");
+
+-- AddForeignKey
+ALTER TABLE "EmployeePerformanceReview" ADD CONSTRAINT "EmployeePerformanceReview_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmployeePerformanceReview" ADD CONSTRAINT "EmployeePerformanceReview_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmployeePerformanceReview" ADD CONSTRAINT "EmployeePerformanceReview_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,7 @@ model Company {
   Course                              Course[]
   ExitInterviewFormTemplate           ExitInterviewFormTemplate[]
   ExpiryRule                          ExpiryRule[]
+  EmployeePerformanceReview           EmployeePerformanceReview[]
 }
 
 model ContractTypeOption {
@@ -313,6 +314,28 @@ model Employee {
   OnboardingInstance               OnboardingInstance[]
   TrainingRecord                   TrainingRecord[]
   EmployeeAuditLog                 EmployeeAuditLog[]
+  PerformanceReviews               EmployeePerformanceReview[]
+}
+
+model EmployeePerformanceReview {
+  id                     String    @id
+  employeeId             String
+  companyId              String
+  reviewerId             String?
+  reviewDate             DateTime
+  rating                 Int?
+  summary                String?
+  strengths              String?
+  areasForImprovement    String?
+  goals                  Json?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+  Employee               Employee  @relation(fields: [employeeId], references: [id], onDelete: Cascade)
+  Company                Company   @relation(fields: [companyId], references: [id])
+  Reviewer               User?     @relation("EmployeePerformanceReviewReviewer", fields: [reviewerId], references: [id])
+
+  @@index([employeeId, reviewDate])
+  @@index([companyId])
 }
 
 model EmployeeOffboarding {
@@ -1182,6 +1205,7 @@ model User {
   PersonalInfoAudit_PersonalInfoAudit_changedByIdToUser             PersonalInfoAudit[]    @relation("PersonalInfoAudit_changedByIdToUser")
   PersonalInfoAudit_PersonalInfoAudit_subjectUserIdToUser           PersonalInfoAudit[]    @relation("PersonalInfoAudit_subjectUserIdToUser")
   EmployeeAuditLog_EmployeeAuditLog_changedByIdToUser               EmployeeAuditLog[]     @relation("EmployeeAuditLog_changedByIdToUser")
+  EmployeePerformanceReviewsAuthored                               EmployeePerformanceReview[] @relation("EmployeePerformanceReviewReviewer")
   SavedReport                                                       SavedReport[]
   Company                                                           Company                @relation(fields: [companyId], references: [id])
   Department_User_departmentIdToDepartment                          Department?            @relation("User_departmentIdToDepartment", fields: [departmentId], references: [id])

--- a/tests/employeePerformancePage.test.tsx
+++ b/tests/employeePerformancePage.test.tsx
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import Module from "module";
+import {
+  PerformanceReview,
+  buildPayloadFromForm,
+  createEmptyFormState,
+  createFormStateFromReview,
+} from "../app/(withSidebar)/employees/[id]/performance/helpers";
+
+async function loadPerformanceModule() {
+  const originalLoad = (Module as any)._load;
+  (Module as any)._load = function (request: string, parent: any, isMain: boolean) {
+    if (request === "next/navigation") {
+      return {
+        useParams: () => ({ id: "emp1" }),
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+  try {
+    return await import(
+      `../app/(withSidebar)/employees/[id]/performance/page?test=${Math.random()}`
+    );
+  } finally {
+    (Module as any)._load = originalLoad;
+  }
+}
+
+test("createEmptyFormState returns blank fields", () => {
+  const state = createEmptyFormState();
+  assert.equal(state.reviewDate, "");
+  assert.equal(state.rating, "");
+  assert.equal(state.summary, "");
+  assert.equal(state.strengths, "");
+  assert.equal(state.areasForImprovement, "");
+  assert.equal(state.goals, "");
+});
+
+test("buildPayloadFromForm normalises rating and goals", () => {
+  const payload = buildPayloadFromForm({
+    reviewDate: "2024-07-01",
+    rating: "4 ",
+    summary: "  Highlights ",
+    strengths: " Collaboration ",
+    areasForImprovement: " Improve focus  ",
+    goals: "Launch\nCoach team\n",
+  });
+  assert.equal(payload.reviewDate, "2024-07-01");
+  assert.equal(payload.rating, 4);
+  assert.equal(payload.summary, "Highlights");
+  assert.equal(payload.strengths, "Collaboration");
+  assert.equal(payload.areasForImprovement, "Improve focus");
+  assert.deepEqual(payload.goals, ["Launch", "Coach team"]);
+});
+
+test("createFormStateFromReview hydrates edit state", async () => {
+  const mod = await loadPerformanceModule();
+  const review: PerformanceReview = {
+    id: "rev1",
+    employeeId: "emp1",
+    companyId: "c1",
+    reviewerId: "u-admin",
+    reviewDate: "2024-07-02T00:00:00.000Z",
+    rating: 5,
+    summary: "Great progress",
+    strengths: "Leadership",
+    areasForImprovement: "Time management",
+    goals: ["Goal A", "Goal B"],
+    createdAt: "2024-07-03T00:00:00.000Z",
+    updatedAt: "2024-07-04T00:00:00.000Z",
+    reviewer: { id: "u-admin", firstName: "Jamie", lastName: "Lee" },
+  };
+  const state = createFormStateFromReview(review);
+  assert.equal(state.reviewDate, "2024-07-02");
+  assert.equal(state.rating, "5");
+  assert.equal(state.summary, "Great progress");
+  assert.equal(state.strengths, "Leadership");
+  assert.equal(state.areasForImprovement, "Time management");
+  assert.equal(state.goals, "Goal A\nGoal B");
+});
+
+test("PerformancePage SSR renders shell", async () => {
+  const mod = await loadPerformanceModule();
+  const html = renderToString(React.createElement(mod.default));
+  assert.ok(html.includes("Performance Reviews"));
+  assert.ok(html.includes("Log review"));
+});

--- a/tests/employeePerformanceReviewsRoute.test.ts
+++ b/tests/employeePerformanceReviewsRoute.test.ts
@@ -1,0 +1,224 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Module from "module";
+
+const originalLoad = (Module as any)._load;
+
+let mockEmployee: any = null;
+let mockReviews: any[] = [];
+let mockExistingReview: any = null;
+let mockCreatedReviewer: any = null;
+let mockUpdatedReviewer: any = null;
+let lastFindManyArgs: any = null;
+let lastCreateArgs: any = null;
+let lastUpdateArgs: any = null;
+let lastReviewLookupArgs: any = null;
+
+const sessionContainer: { user: any } = {
+  user: { id: "u-admin", companyId: "c1", role: "ADMIN" },
+};
+
+const mockPrisma = {
+  employee: {
+    findFirst: async () => mockEmployee,
+  },
+  employeePerformanceReview: {
+    findMany: async (args: any) => {
+      lastFindManyArgs = args;
+      return mockReviews;
+    },
+    create: async (args: any) => {
+      lastCreateArgs = args;
+      return {
+        id: args.data.id,
+        employeeId: args.data.employeeId,
+        companyId: args.data.companyId,
+        reviewerId: args.data.reviewerId,
+        reviewDate: args.data.reviewDate,
+        rating: args.data.rating ?? null,
+        summary: args.data.summary ?? null,
+        strengths: args.data.strengths ?? null,
+        areasForImprovement: args.data.areasForImprovement ?? null,
+        goals: Array.isArray(args.data.goals) ? args.data.goals : [],
+        createdAt:
+          mockCreatedReviewer?.createdAt ?? new Date("2024-07-01T00:00:00Z"),
+        updatedAt:
+          mockCreatedReviewer?.updatedAt ?? new Date("2024-07-01T00:00:00Z"),
+        Reviewer:
+          mockCreatedReviewer?.Reviewer ??
+          ({ id: "u-admin", firstName: "Jamie", lastName: "Lee" } as const),
+      };
+    },
+    findFirst: async (args: any) => {
+      lastReviewLookupArgs = args;
+      return mockExistingReview;
+    },
+    update: async (args: any) => {
+      lastUpdateArgs = args;
+      return {
+        id: args.where.id,
+        employeeId: mockExistingReview?.employeeId ?? args.data.employeeId,
+        companyId: mockExistingReview?.companyId ?? args.data.companyId,
+        reviewerId: args.data.reviewerId,
+        reviewDate: args.data.reviewDate,
+        rating: args.data.rating ?? null,
+        summary: args.data.summary ?? null,
+        strengths: args.data.strengths ?? null,
+        areasForImprovement: args.data.areasForImprovement ?? null,
+        goals: Array.isArray(args.data.goals) ? args.data.goals : [],
+        createdAt:
+          mockUpdatedReviewer?.createdAt ?? new Date("2024-07-05T00:00:00Z"),
+        updatedAt:
+          mockUpdatedReviewer?.updatedAt ?? new Date("2024-07-06T00:00:00Z"),
+        Reviewer:
+          mockUpdatedReviewer?.Reviewer ??
+          ({ id: "u-admin", firstName: "Jamie", lastName: "Lee" } as const),
+      };
+    },
+  },
+};
+
+(Module as any)._load = function (request: string, parent: any, isMain: boolean) {
+  if (request === "@/lib/prisma") {
+    return { prisma: mockPrisma };
+  }
+  if (request === "@/lib/auth-options") {
+    return { authOptions: {} };
+  }
+  if (request === "next-auth") {
+    return {
+      getServerSession: async () => ({ user: sessionContainer.user }),
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+test.after(() => {
+  (Module as any)._load = originalLoad;
+});
+
+test.beforeEach(() => {
+  mockEmployee = { id: "emp1", userId: "employee-user" };
+  mockReviews = [];
+  mockExistingReview = null;
+  mockCreatedReviewer = null;
+  mockUpdatedReviewer = null;
+  lastFindManyArgs = null;
+  lastCreateArgs = null;
+  lastUpdateArgs = null;
+  lastReviewLookupArgs = null;
+  sessionContainer.user = { id: "u-admin", companyId: "c1", role: "ADMIN" };
+});
+
+test("GET /api/employees/[id]/performance-reviews returns reviews", async () => {
+  mockReviews = [
+    {
+      id: "rev1",
+      employeeId: "emp1",
+      companyId: "c1",
+      reviewerId: "u-admin",
+      reviewDate: new Date("2024-07-10T00:00:00Z"),
+      rating: 4,
+      summary: "Consistent delivery",
+      strengths: "Collaboration",
+      areasForImprovement: null,
+      goals: ["Grow leadership", "Improve QA"],
+      createdAt: new Date("2024-07-11T00:00:00Z"),
+      updatedAt: new Date("2024-07-12T00:00:00Z"),
+      Reviewer: { id: "u-admin", firstName: "Jamie", lastName: "Lee" },
+    },
+  ];
+
+  const { GET } = await import(
+    "../app/api/employees/[id]/performance-reviews/route?test=get"
+  );
+
+  const response = await GET(new Request("http://localhost/api"), {
+    params: { id: "emp1" },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(body));
+  assert.equal(body[0].summary, "Consistent delivery");
+  assert.deepEqual(lastFindManyArgs.where, {
+    employeeId: "emp1",
+    companyId: "c1",
+  });
+});
+
+test(
+  "POST /api/employees/[id]/performance-reviews normalises payload",
+  async () => {
+    const { POST } = await import(
+      "../app/api/employees/[id]/performance-reviews/route?test=post"
+    );
+
+    const request = new Request("http://localhost/api", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        reviewDate: "2024-07-01",
+        rating: "4",
+        summary: "  Strong quarter  ",
+        strengths: "Collaboration",
+        areasForImprovement: "",
+        goals: "Launch project\nCoach peers",
+      }),
+    });
+
+    const response = await POST(request, { params: { id: "emp1" } });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(body.review);
+    assert.equal(body.review.summary, "Strong quarter");
+    assert.equal(lastCreateArgs.data.employeeId, "emp1");
+    assert.equal(lastCreateArgs.data.companyId, "c1");
+    assert.equal(lastCreateArgs.data.rating, 4);
+    assert.deepEqual(lastCreateArgs.data.goals, [
+      "Launch project",
+      "Coach peers",
+    ]);
+  },
+);
+
+test("PUT /api/employees/[id]/performance-reviews updates review", async () => {
+  mockExistingReview = {
+    id: "rev1",
+    employeeId: "emp1",
+    companyId: "c1",
+  };
+
+  const { PUT } = await import(
+    "../app/api/employees/[id]/performance-reviews/route?test=put"
+  );
+
+  const request = new Request("http://localhost/api", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      id: "rev1",
+      reviewDate: "2024-07-15",
+      rating: 5,
+      summary: "Updated summary",
+      strengths: "Teamwork",
+      areasForImprovement: "Time management",
+      goals: ["Goal 1"],
+    }),
+  });
+
+  const response = await PUT(request, { params: { id: "emp1" } });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(body.review);
+  assert.equal(body.review.rating, 5);
+  assert.deepEqual(lastReviewLookupArgs.where, {
+    id: "rev1",
+    employeeId: "emp1",
+    companyId: "c1",
+  });
+  assert.equal(lastUpdateArgs.data.summary, "Updated summary");
+  assert.deepEqual(lastUpdateArgs.data.goals, ["Goal 1"]);
+});

--- a/tests/forms/logicEvaluator.test.ts
+++ b/tests/forms/logicEvaluator.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import test from "node:test";
+import assert from "node:assert/strict";
 
 // Minimal replica of the condition evaluation used in EnhancedFormRenderer
 function evaluateCondition(left: any, operator: string, right: any) {
@@ -8,9 +9,13 @@ function evaluateCondition(left: any, operator: string, right: any) {
     case "notEquals":
       return left !== right;
     case "contains":
-      return Array.isArray(left) ? left.includes(right) : String(left || "").includes(String(right ?? ""));
+      return Array.isArray(left)
+        ? left.includes(right)
+        : String(left || "").includes(String(right ?? ""));
     case "notContains":
-      return Array.isArray(left) ? !left.includes(right) : !String(left || "").includes(String(right ?? ""));
+      return Array.isArray(left)
+        ? !left.includes(right)
+        : !String(left || "").includes(String(right ?? ""));
     case "greaterThan":
       return Number(left) > Number(right);
     case "greaterOrEqual":
@@ -20,26 +25,39 @@ function evaluateCondition(left: any, operator: string, right: any) {
     case "lessOrEqual":
       return Number(left) <= Number(right);
     case "isEmpty":
-      return left === undefined || left === null || left === "" || (Array.isArray(left) && left.length === 0);
+      return (
+        left === undefined ||
+        left === null ||
+        left === "" ||
+        (Array.isArray(left) && left.length === 0)
+      );
     case "isNotEmpty":
-      return !(left === undefined || left === null || left === "" || (Array.isArray(left) && left.length === 0));
+      return !(
+        left === undefined ||
+        left === null ||
+        left === "" ||
+        (Array.isArray(left) && left.length === 0)
+      );
     default:
       return true;
   }
 }
 
-describe("logic evaluator", () => {
-  it("compares primitives", () => {
-    expect(evaluateCondition(5, "greaterThan", 3)).toBe(true);
-    expect(evaluateCondition(3, "lessOrEqual", 3)).toBe(true);
-    expect(evaluateCondition("abc", "contains", "b")).toBe(true);
-  });
-
-  it("handles emptiness", () => {
-    expect(evaluateCondition([], "isEmpty", null)).toBe(true);
-    expect(evaluateCondition([1], "isNotEmpty", null)).toBe(true);
-    expect(evaluateCondition("", "isEmpty", null)).toBe(true);
-  });
+test("logic evaluator compares primitives", () => {
+  assert.equal(evaluateCondition(5, "greaterThan", 3), true);
+  assert.equal(evaluateCondition(3, "lessOrEqual", 3), true);
+  assert.equal(evaluateCondition("abc", "contains", "b"), true);
 });
 
+test("logic evaluator handles emptiness", () => {
+  assert.equal(evaluateCondition([], "isEmpty", null), true);
+  assert.equal(evaluateCondition([1], "isNotEmpty", null), true);
+  assert.equal(evaluateCondition("", "isEmpty", null), true);
+  assert.equal(evaluateCondition("value", "isNotEmpty", null), true);
+});
 
+test("logic evaluator handles arrays for contains checks", () => {
+  assert.equal(evaluateCondition(["a", "b"], "contains", "a"), true);
+  assert.equal(evaluateCondition(["a", "b"], "notContains", "c"), true);
+  assert.equal(evaluateCondition(["a", "b"], "notContains", "a"), false);
+});

--- a/tests/forms/schemaHelpers.test.ts
+++ b/tests/forms/schemaHelpers.test.ts
@@ -1,38 +1,41 @@
-import { describe, it, expect } from "vitest";
-import { isLegacySchema, upgradeLegacySchema, normalizeToPages, FormField, FormSchemaV2 } from "@/api/forms/[id]/types";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isLegacySchema,
+  upgradeLegacySchema,
+  normalizeToPages,
+  FormField,
+  FormSchemaV2,
+} from "@/api/forms/[id]/types";
 
-describe("schema helpers", () => {
-  it("detects legacy schema as array of fields", () => {
-    const legacy: FormField[] = [
-      { id: "a", type: "text", label: "A", required: false },
-    ];
-    expect(isLegacySchema(legacy)).toBe(true);
-  });
-
-  it("wraps legacy schema into a default section and page", () => {
-    const legacy: FormField[] = [
-      { id: "a", type: "text", label: "A", required: false },
-      { id: "b", type: "number", label: "B", required: false },
-    ];
-    const v2 = upgradeLegacySchema(legacy);
-    expect(v2.version).toBe(2);
-    expect(v2.sections?.[0]?.fields?.length).toBe(2);
-    const pages = normalizeToPages(legacy);
-    expect(pages.length).toBe(1);
-    expect(pages[0].sections[0].fields.length).toBe(2);
-  });
-
-  it("normalizes sections-only V2 schema into pages", () => {
-    const v2: FormSchemaV2 = {
-      version: 2,
-      sections: [
-        { id: "s1", columns: 2, layout: "two-column", hidden: false, fields: [] },
-      ],
-    };
-    const pages = normalizeToPages(v2);
-    expect(pages.length).toBe(1);
-    expect(pages[0].sections.length).toBe(1);
-  });
+test("detects legacy schema as array of fields", () => {
+  const legacy: FormField[] = [
+    { id: "a", type: "text", label: "A", required: false },
+  ];
+  assert.equal(isLegacySchema(legacy), true);
 });
 
+test("wraps legacy schema into a default section and page", () => {
+  const legacy: FormField[] = [
+    { id: "a", type: "text", label: "A", required: false },
+    { id: "b", type: "number", label: "B", required: false },
+  ];
+  const v2 = upgradeLegacySchema(legacy);
+  assert.equal(v2.version, 2);
+  assert.equal(v2.sections?.[0]?.fields?.length, 2);
+  const pages = normalizeToPages(legacy);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].sections[0].fields.length, 2);
+});
 
+test("normalizes sections-only V2 schema into pages", () => {
+  const v2: FormSchemaV2 = {
+    version: 2,
+    sections: [
+      { id: "s1", columns: 2, layout: "two-column", hidden: false, fields: [] },
+    ],
+  };
+  const pages = normalizeToPages(v2);
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].sections.length, 1);
+});


### PR DESCRIPTION
## Summary
- move the performance review route helper functions into a dedicated module so the handler only exports the Next.js-supported HTTP methods and schemas

## Testing
- npm test
- npm run build *(fails: unable to fetch Inter font from Google Fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaab78b3883318d28d3f1afc9d506