### PR TITLE
Add onboarding notifications for kickoff and step updates

### DIFF
--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { resend } from "@/lib/resend";
+import { sendOnboardingKickoffNotifications } from "@/lib/onboarding-notifications";
 
 async function findBestOnboardingTemplate(employee: any, companyId: string) {
   // 1. By Job Role
@@ -161,7 +162,6 @@ export async function POST(req: NextRequest) {
           process.env.NEXT_PUBLIC_APP_URL ||
           process.env.NEXT_PUBLIC_BASE_URL ||
           "";
-        const onboardingLink = `${baseUrl}/${employee.id}/onboarding`;
         const loginWithNext = `${baseUrl}/login?next=/${employee.id}/onboarding`;
         await resend.emails.send({
           from: "PeopleCore Notifications <noreply@peoplecore.co.nz>",
@@ -178,6 +178,20 @@ export async function POST(req: NextRequest) {
         console.error("Failed to send onboarding email:", e);
         // continue without failing the request
       }
+    }
+
+    try {
+      await sendOnboardingKickoffNotifications({
+        employee,
+        template,
+        onboardingInstanceId: result.onboardingInstance.id,
+        companyId: session.user.companyId,
+      });
+    } catch (notificationError) {
+      console.error(
+        "Failed to send onboarding kickoff notifications:",
+        notificationError,
+      );
     }
 
     return NextResponse.json(result, { status: 201 });

--- a/app/api/onboarding/step/[stepId]/complete/route.ts
+++ b/app/api/onboarding/step/[stepId]/complete/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { sendOnboardingStepStatusNotification } from "@/lib/onboarding-notifications";
 
 // Util: Parse JSON body (works for Next.js App Router POST)
 async function parseBody(request: NextRequest) {
@@ -34,6 +35,12 @@ export async function POST(
                 User: true, // This gets you employee.user.companyId
               },
             },
+            OnboardingTemplate: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
           },
         },
         OnboardingStep: true,
@@ -48,11 +55,20 @@ export async function POST(
     // e.g. check session.user.id === stepInstance.OnboardingInstance.Employee.User.id
 
     // 2. Mark step as completed
+    const nextStatus =
+      typeof body.status === "string" && body.status.trim().length > 0
+        ? body.status.trim()
+        : "completed";
+
+    const shouldNotify =
+      stepInstance.status !== nextStatus ||
+      (nextStatus === "completed" && !stepInstance.completedAt);
+
     await prisma.onboardingStepInstance.update({
       where: { id: stepId },
       data: {
-        status: "completed",
-        completedAt: new Date(),
+        status: nextStatus,
+        completedAt: nextStatus === "completed" ? new Date() : null,
       },
     });
 
@@ -96,6 +112,29 @@ export async function POST(
     }
 
     // 5. (Optional) Log to audit table here
+
+    if (shouldNotify) {
+      try {
+        const onboardingTemplate =
+          stepInstance.OnboardingInstance.OnboardingTemplate || {
+            id: stepInstance.OnboardingInstance.templateId,
+            name: "Onboarding",
+          };
+
+        await sendOnboardingStepStatusNotification({
+          employee: stepInstance.OnboardingInstance.Employee,
+          template: onboardingTemplate,
+          step: stepInstance.OnboardingStep,
+          status: nextStatus,
+          companyId: stepInstance.OnboardingInstance.Employee.companyId,
+        });
+      } catch (notificationError) {
+        console.error(
+          "Failed to send onboarding step status notification:",
+          notificationError,
+        );
+      }
+    }
 
     return NextResponse.json({ ok: true });
   } catch (err: any) {

--- a/app/api/onboarding/templates/actions.ts
+++ b/app/api/onboarding/templates/actions.ts
@@ -1,5 +1,141 @@
 import { prisma } from "@/lib/prisma";
 import { mapSteps } from "./stepMapper";
+import { OnboardingNotificationType } from "@prisma/client";
+import {
+  ONBOARDING_NOTIFICATION_DEFAULTS,
+  resolveOnboardingNotificationSettings,
+} from "@/lib/onboarding-notifications";
+
+const NOTIFICATION_KEYS = [
+  "notifyManagers",
+  "notifyTaskOwners",
+  "notifyHiringManagers",
+  "notifyEmployee",
+  "notifyAdmins",
+] as const;
+
+type NotificationPreferenceKey = (typeof NOTIFICATION_KEYS)[number];
+
+export type TemplateNotificationPreferenceOverrides = Partial<
+  Record<NotificationPreferenceKey, boolean>
+>;
+
+export interface TemplateNotificationPreferencesInput {
+  kickoff?: TemplateNotificationPreferenceOverrides | null;
+  stepUpdate?: TemplateNotificationPreferenceOverrides | null;
+}
+
+function sanitizeOverrides(
+  overrides: TemplateNotificationPreferenceOverrides | null | undefined,
+): Partial<Record<NotificationPreferenceKey, boolean>> {
+  const sanitized: Partial<Record<NotificationPreferenceKey, boolean>> = {};
+  if (!overrides) {
+    return sanitized;
+  }
+  for (const key of NOTIFICATION_KEYS) {
+    if (typeof overrides[key] === "boolean") {
+      sanitized[key] = overrides[key] as boolean;
+    }
+  }
+  return sanitized;
+}
+
+async function applyTemplateNotificationPreferences({
+  companyId,
+  templateId,
+  preferences,
+  prismaClient = prisma,
+}: {
+  companyId: string;
+  templateId: string;
+  preferences?: TemplateNotificationPreferencesInput | null;
+  prismaClient?: typeof prisma;
+}) {
+  if (!preferences) {
+    return;
+  }
+
+  const entries: Array<{
+    type: OnboardingNotificationType;
+    overrides: TemplateNotificationPreferenceOverrides | null | undefined;
+  }> = [
+    {
+      type: OnboardingNotificationType.KICKOFF,
+      overrides: preferences.kickoff,
+    },
+    {
+      type: OnboardingNotificationType.STEP_UPDATE,
+      overrides: preferences.stepUpdate,
+    },
+  ];
+
+  for (const { type, overrides } of entries) {
+    if (overrides === undefined) {
+      continue;
+    }
+
+    if (overrides === null) {
+      await prismaClient.onboardingNotificationPreference
+        .delete({
+          where: {
+            companyId_templateId_notificationType: {
+              companyId,
+              templateId,
+              notificationType: type,
+            },
+          },
+        })
+        .catch(() => {});
+      continue;
+    }
+
+    const sanitized = sanitizeOverrides(overrides);
+    if (!Object.keys(sanitized).length) {
+      continue;
+    }
+
+    await prismaClient.onboardingNotificationPreference.upsert({
+      where: {
+        companyId_templateId_notificationType: {
+          companyId,
+          templateId,
+          notificationType: type,
+        },
+      },
+      update: sanitized,
+      create: {
+        companyId,
+        templateId,
+        notificationType: type,
+        ...ONBOARDING_NOTIFICATION_DEFAULTS[type],
+        ...sanitized,
+      },
+    });
+  }
+}
+
+export async function getTemplateNotificationPreferences(
+  companyId: string,
+  templateId: string,
+) {
+  const [kickoff, stepUpdate] = await Promise.all([
+    resolveOnboardingNotificationSettings({
+      companyId,
+      templateId,
+      notificationType: OnboardingNotificationType.KICKOFF,
+    }),
+    resolveOnboardingNotificationSettings({
+      companyId,
+      templateId,
+      notificationType: OnboardingNotificationType.STEP_UPDATE,
+    }),
+  ]);
+
+  return {
+    kickoff,
+    stepUpdate,
+  };
+}
 
 export async function createTemplate(
   session: any,
@@ -13,9 +149,10 @@ export async function createTemplate(
     jobRoles = [],
     steps = [],
     isActive = false,
+    notificationPreferences = null,
   } = body;
   const filteredSteps = mapSteps(steps);
-  return prismaClient.onboardingTemplate.create({
+  const template = await prismaClient.onboardingTemplate.create({
     data: {
       id: `template_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
       name,
@@ -41,6 +178,20 @@ export async function createTemplate(
       User: { select: { id: true, name: true, email: true } },
     },
   });
+
+  await applyTemplateNotificationPreferences({
+    companyId: session.user.companyId,
+    templateId: template.id,
+    preferences: notificationPreferences,
+    prismaClient,
+  });
+
+  const preferences = await getTemplateNotificationPreferences(
+    session.user.companyId,
+    template.id,
+  );
+
+  return { ...template, notificationPreferences: preferences };
 }
 
 export async function updateTemplate(
@@ -56,6 +207,7 @@ export async function updateTemplate(
     jobRoles = [],
     steps = [],
     isActive,
+    notificationPreferences = undefined,
   } = body;
   const filteredSteps = mapSteps(steps);
 
@@ -68,7 +220,7 @@ export async function updateTemplate(
   });
   await prismaClient.onboardingStep.deleteMany({ where: { templateId: id } });
 
-  return prismaClient.onboardingTemplate.update({
+  const template = await prismaClient.onboardingTemplate.update({
     where: { id },
     data: {
       name,
@@ -96,5 +248,19 @@ export async function updateTemplate(
       User: { select: { id: true, name: true, email: true } },
     },
   });
+
+  await applyTemplateNotificationPreferences({
+    companyId: session.user.companyId,
+    templateId: id,
+    preferences: notificationPreferences,
+    prismaClient,
+  });
+
+  const preferences = await getTemplateNotificationPreferences(
+    session.user.companyId,
+    id,
+  );
+
+  return { ...template, notificationPreferences: preferences };
 }
 

--- a/app/api/onboarding/templates/route.ts
+++ b/app/api/onboarding/templates/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { createTemplate, updateTemplate } from "./actions";
+import {
+  createTemplate,
+  updateTemplate,
+  getTemplateNotificationPreferences,
+} from "./actions";
 import { hasPermission } from "@/lib/permissions";
 
 // ✅ GET - Fetch Templates
@@ -50,7 +54,17 @@ export async function GET(req: Request) {
     orderBy: { createdAt: "asc" },
   });
 
-  return NextResponse.json(templates);
+  const templatesWithPreferences = await Promise.all(
+    templates.map(async (template) => ({
+      ...template,
+      notificationPreferences: await getTemplateNotificationPreferences(
+        session.user.companyId,
+        template.id,
+      ),
+    })),
+  );
+
+  return NextResponse.json(templatesWithPreferences);
 }
 
 // ✅ POST - Create Template

--- a/app/lib/onboarding-notifications.ts
+++ b/app/lib/onboarding-notifications.ts
@@ -1,0 +1,608 @@
+import { resend } from "@/lib/resend";
+import { prisma } from "@/lib/prisma";
+import {
+  Employee,
+  OnboardingNotificationType,
+  OnboardingStep,
+  OnboardingTemplate,
+  Prisma,
+  User,
+} from "@prisma/client";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@peoplecore.co.nz";
+const APP_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_BASE_URL ||
+  "";
+
+type MinimalUser = Pick<User, "id" | "email" | "firstName" | "lastName" | "name">;
+
+type NotificationFlags = {
+  notifyManagers: boolean;
+  notifyTaskOwners: boolean;
+  notifyHiringManagers: boolean;
+  notifyEmployee: boolean;
+  notifyAdmins: boolean;
+};
+
+export const ONBOARDING_NOTIFICATION_DEFAULTS: Record<
+  OnboardingNotificationType,
+  NotificationFlags
+> = {
+  [OnboardingNotificationType.KICKOFF]: {
+    notifyManagers: true,
+    notifyTaskOwners: true,
+    notifyHiringManagers: false,
+    notifyEmployee: false,
+    notifyAdmins: false,
+  },
+  [OnboardingNotificationType.STEP_UPDATE]: {
+    notifyManagers: false,
+    notifyTaskOwners: true,
+    notifyHiringManagers: false,
+    notifyEmployee: false,
+    notifyAdmins: false,
+  },
+};
+
+type RecipientRole =
+  | "manager"
+  | "hiring_manager"
+  | "task_owner"
+  | "admin"
+  | "employee";
+
+const ROLE_LABELS: Record<RecipientRole, string> = {
+  manager: "People Manager",
+  hiring_manager: "Hiring Manager",
+  task_owner: "Onboarding Task Owner",
+  admin: "Company Admin",
+  employee: "Employee",
+};
+
+type StepSummary = Pick<
+  OnboardingStep,
+  "id" | "label" | "order" | "taskOwnerId" | "type"
+>;
+
+type RecipientRecord = {
+  user: MinimalUser;
+  roles: Set<RecipientRole>;
+  steps: StepSummary[];
+};
+
+function formatUserName(user?: MinimalUser | null): string {
+  if (!user) return "";
+  if (user.firstName || user.lastName) {
+    return `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
+  }
+  return user.name || user.email || "";
+}
+
+function extractHiringManagerId(
+  onboardingStatus: Prisma.JsonValue | null | undefined,
+): string | null {
+  if (!onboardingStatus || typeof onboardingStatus !== "object") {
+    return null;
+  }
+  const status = onboardingStatus as Record<string, unknown>;
+  const value = status?.hiringManagerId;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function ensureRecipient(
+  recipients: Map<string, RecipientRecord>,
+  user: MinimalUser,
+): RecipientRecord {
+  const existing = recipients.get(user.id);
+  if (existing) {
+    return existing;
+  }
+  const record: RecipientRecord = {
+    user,
+    roles: new Set<RecipientRole>(),
+    steps: [],
+  };
+  recipients.set(user.id, record);
+  return record;
+}
+
+function rolesToSentence(roles: Set<RecipientRole>): string {
+  const parts = Array.from(roles).map((role) => ROLE_LABELS[role]);
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return parts[0];
+  const last = parts.pop();
+  return `${parts.join(", ")} and ${last}`;
+}
+
+function buildStepListHtml(steps: StepSummary[], ownerName: string): string {
+  if (!steps.length) {
+    return `
+      <p>You have been included for visibility as ${ownerName}.</p>
+    `;
+  }
+
+  const items = steps
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map(
+      (step) => `
+        <li>
+          <strong>${step.label}</strong>
+          <span style="color:#6b7280;"> (Step ${(step.order ?? 0) + 1})</span>
+        </li>
+      `,
+    )
+    .join("");
+
+  return `
+    <p>The following onboarding tasks are allocated to you:</p>
+    <ul style="padding-left:20px;">${items}</ul>
+  `;
+}
+
+function buildStepListText(steps: StepSummary[]): string {
+  if (!steps.length) {
+    return "No direct tasks assigned.";
+  }
+  return steps
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((step, index) => `${index + 1}. ${step.label}`)
+    .join("\n");
+}
+
+export async function resolveOnboardingNotificationSettings({
+  companyId,
+  templateId,
+  notificationType,
+}: {
+  companyId: string;
+  templateId?: string;
+  notificationType: OnboardingNotificationType;
+}): Promise<NotificationFlags> {
+  const defaults = ONBOARDING_NOTIFICATION_DEFAULTS[notificationType];
+
+  const [companyPreference, templatePreference] = await Promise.all([
+    prisma.onboardingNotificationPreference.findFirst({
+      where: {
+        companyId,
+        notificationType,
+        templateId: null,
+      },
+    }),
+    templateId
+      ? prisma.onboardingNotificationPreference.findFirst({
+          where: {
+            companyId,
+            notificationType,
+            templateId,
+          },
+        })
+      : Promise.resolve(null),
+  ]);
+
+  return {
+    notifyManagers:
+      templatePreference?.notifyManagers ??
+      companyPreference?.notifyManagers ??
+      defaults.notifyManagers,
+    notifyTaskOwners:
+      templatePreference?.notifyTaskOwners ??
+      companyPreference?.notifyTaskOwners ??
+      defaults.notifyTaskOwners,
+    notifyHiringManagers:
+      templatePreference?.notifyHiringManagers ??
+      companyPreference?.notifyHiringManagers ??
+      defaults.notifyHiringManagers,
+    notifyEmployee:
+      templatePreference?.notifyEmployee ??
+      companyPreference?.notifyEmployee ??
+      defaults.notifyEmployee,
+    notifyAdmins:
+      templatePreference?.notifyAdmins ??
+      companyPreference?.notifyAdmins ??
+      defaults.notifyAdmins,
+  };
+}
+
+export async function sendOnboardingKickoffNotifications({
+  employee,
+  template,
+  onboardingInstanceId,
+  companyId,
+}: {
+  employee: Employee & { User: MinimalUser | null; onboardingStatus?: Prisma.JsonValue };
+  template: OnboardingTemplate & { OnboardingStep: StepSummary[] };
+  onboardingInstanceId: string;
+  companyId: string;
+}): Promise<void> {
+  const preferences = await resolveOnboardingNotificationSettings({
+    companyId,
+    templateId: template.id,
+    notificationType: OnboardingNotificationType.KICKOFF,
+  });
+
+  if (
+    !preferences.notifyAdmins &&
+    !preferences.notifyEmployee &&
+    !preferences.notifyManagers &&
+    !preferences.notifyTaskOwners &&
+    !preferences.notifyHiringManagers
+  ) {
+    return;
+  }
+
+  const sortedSteps = [...template.OnboardingStep].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0),
+  );
+  const stepsByOwner = new Map<string, StepSummary[]>();
+  if (preferences.notifyTaskOwners) {
+    for (const step of sortedSteps) {
+      if (!step.taskOwnerId) continue;
+      const list = stepsByOwner.get(step.taskOwnerId) ?? [];
+      list.push(step);
+      stepsByOwner.set(step.taskOwnerId, list);
+    }
+  }
+
+  const targetIds = new Set<string>();
+  for (const ownerId of stepsByOwner.keys()) {
+    targetIds.add(ownerId);
+  }
+  const managerId = preferences.notifyManagers
+    ? employee.User?.managerId ?? null
+    : null;
+  if (managerId) targetIds.add(managerId);
+
+  const hiringManagerId = preferences.notifyHiringManagers
+    ? extractHiringManagerId(employee.onboardingStatus ?? null)
+    : null;
+  if (hiringManagerId) targetIds.add(hiringManagerId);
+
+  const [targetUsers, adminUsers] = await Promise.all([
+    targetIds.size
+      ? prisma.user.findMany({
+          where: { id: { in: Array.from(targetIds) } },
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            name: true,
+          },
+        })
+      : Promise.resolve([] as MinimalUser[]),
+    preferences.notifyAdmins
+      ? prisma.user.findMany({
+          where: { companyId, role: "ADMIN" },
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            name: true,
+          },
+        })
+      : Promise.resolve([] as MinimalUser[]),
+  ]);
+
+  const knownUsers = new Map<string, MinimalUser>();
+  for (const user of targetUsers) {
+    knownUsers.set(user.id, user);
+  }
+  for (const admin of adminUsers) {
+    knownUsers.set(admin.id, admin);
+  }
+  if (employee.User) {
+    knownUsers.set(employee.User.id, employee.User);
+  }
+
+  const recipients = new Map<string, RecipientRecord>();
+
+  if (preferences.notifyTaskOwners) {
+    for (const [ownerId, ownerSteps] of stepsByOwner.entries()) {
+      const owner = knownUsers.get(ownerId);
+      if (!owner?.email) continue;
+      const record = ensureRecipient(recipients, owner);
+      record.roles.add("task_owner");
+      record.steps.push(...ownerSteps);
+    }
+  }
+
+  if (preferences.notifyManagers && managerId) {
+    const manager = knownUsers.get(managerId);
+    if (manager?.email) {
+      const record = ensureRecipient(recipients, manager);
+      record.roles.add("manager");
+    }
+  }
+
+  if (preferences.notifyHiringManagers && hiringManagerId) {
+    const hiringManager = knownUsers.get(hiringManagerId);
+    if (hiringManager?.email) {
+      const record = ensureRecipient(recipients, hiringManager);
+      record.roles.add("hiring_manager");
+    }
+  }
+
+  if (preferences.notifyAdmins) {
+    for (const admin of adminUsers) {
+      if (!admin.email) continue;
+      const record = ensureRecipient(recipients, admin);
+      record.roles.add("admin");
+    }
+  }
+
+  if (preferences.notifyEmployee && employee.User?.email) {
+    const record = ensureRecipient(recipients, employee.User);
+    record.roles.add("employee");
+  }
+
+  if (!recipients.size) {
+    return;
+  }
+
+  const employeeName = formatUserName(employee.User) || "the new employee";
+  const planUrl = APP_URL
+    ? `${APP_URL}/employees/${employee.id}/onboarding`
+    : "";
+
+  const generalRows = sortedSteps
+    .map((step, index) => {
+      const owner = step.taskOwnerId
+        ? formatUserName(knownUsers.get(step.taskOwnerId)) || "Unassigned"
+        : "Unassigned";
+      return `
+        <tr>
+          <td style="padding:8px;border:1px solid #e5e7eb;">${index + 1}</td>
+          <td style="padding:8px;border:1px solid #e5e7eb;">${step.label}</td>
+          <td style="padding:8px;border:1px solid #e5e7eb;">${owner}</td>
+          <td style="padding:8px;border:1px solid #e5e7eb; text-transform:capitalize;">${step.type.toLowerCase().replace(/_/g, " ")}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  const generalTable = `
+    <table style="width:100%;border-collapse:collapse;margin-top:16px;font-size:14px;">
+      <thead>
+        <tr style="background-color:#f3f4f6;color:#111827;">
+          <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">#</th>
+          <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Step</th>
+          <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Owner</th>
+          <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Type</th>
+        </tr>
+      </thead>
+      <tbody>${generalRows}</tbody>
+    </table>
+  `;
+
+  await Promise.all(
+    Array.from(recipients.values()).map(async (recipient) => {
+      try {
+        if (!recipient.user.email) {
+          return;
+        }
+        const name = formatUserName(recipient.user) || recipient.user.email;
+        const rolesSentence = rolesToSentence(recipient.roles);
+        const assignedStepsHtml = buildStepListHtml(
+          recipient.steps,
+          rolesSentence || "your role",
+        );
+        const assignedStepsText = buildStepListText(recipient.steps);
+
+        const intro = rolesSentence
+          ? `You are receiving this because you are the ${rolesSentence.toLowerCase()} for ${employeeName}'s onboarding.`
+          : `${employeeName}'s onboarding has started.`;
+
+        const html = `
+          <div style="font-family:Arial, sans-serif; color:#111827; max-width:640px; margin:0 auto;">
+            <h2 style="color:#1d4ed8;">Onboarding kickoff for ${employeeName}</h2>
+            <p>Hi ${name},</p>
+            <p>${intro}</p>
+            ${assignedStepsHtml}
+            <p style="margin-top:16px;">Full onboarding plan:</p>
+            ${generalTable}
+            ${
+              planUrl
+                ? `<p style="margin-top:16px;"><a href="${planUrl}" style="background:#1d4ed8;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open onboarding workspace</a></p>`
+                : ""
+            }
+            <p style="margin-top:16px;color:#6b7280;font-size:12px;">Onboarding instance ID: ${onboardingInstanceId}</p>
+          </div>
+        `;
+
+        const text = `Onboarding kickoff for ${employeeName}\n\n${intro}\n\nTasks assigned to you:\n${assignedStepsText}\n\n${planUrl ? `View onboarding workspace: ${planUrl}\n` : ""}Onboarding instance: ${onboardingInstanceId}`;
+
+        await resend.emails.send({
+          from: FROM_EMAIL,
+          to: recipient.user.email,
+          subject: `Onboarding kickoff: ${employeeName}`,
+          html,
+          text,
+        });
+      } catch (error) {
+        console.error(
+          "Failed to send onboarding kickoff notification",
+          recipient.user.id,
+          error,
+        );
+      }
+    }),
+  );
+}
+
+export async function sendOnboardingStepStatusNotification({
+  employee,
+  template,
+  step,
+  status,
+  companyId,
+}: {
+  employee: Employee & { User: MinimalUser | null; onboardingStatus?: Prisma.JsonValue };
+  template: Pick<OnboardingTemplate, "id" | "name">;
+  step: StepSummary;
+  status: string;
+  companyId: string;
+}): Promise<void> {
+  const preferences = await resolveOnboardingNotificationSettings({
+    companyId,
+    templateId: template.id,
+    notificationType: OnboardingNotificationType.STEP_UPDATE,
+  });
+
+  if (
+    !preferences.notifyAdmins &&
+    !preferences.notifyEmployee &&
+    !preferences.notifyManagers &&
+    !preferences.notifyTaskOwners &&
+    !preferences.notifyHiringManagers
+  ) {
+    return;
+  }
+
+  const managerId = preferences.notifyManagers
+    ? employee.User?.managerId ?? null
+    : null;
+  const hiringManagerId = preferences.notifyHiringManagers
+    ? extractHiringManagerId(employee.onboardingStatus ?? null)
+    : null;
+
+  const targetIds = new Set<string>();
+  if (preferences.notifyTaskOwners && step.taskOwnerId) {
+    targetIds.add(step.taskOwnerId);
+  }
+  if (managerId) targetIds.add(managerId);
+  if (hiringManagerId) targetIds.add(hiringManagerId);
+
+  const [targetUsers, adminUsers] = await Promise.all([
+    targetIds.size
+      ? prisma.user.findMany({
+          where: { id: { in: Array.from(targetIds) } },
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            name: true,
+          },
+        })
+      : Promise.resolve([] as MinimalUser[]),
+    preferences.notifyAdmins
+      ? prisma.user.findMany({
+          where: { companyId, role: "ADMIN" },
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            name: true,
+          },
+        })
+      : Promise.resolve([] as MinimalUser[]),
+  ]);
+
+  const knownUsers = new Map<string, MinimalUser>();
+  for (const user of targetUsers) {
+    knownUsers.set(user.id, user);
+  }
+  for (const admin of adminUsers) {
+    knownUsers.set(admin.id, admin);
+  }
+  if (employee.User) {
+    knownUsers.set(employee.User.id, employee.User);
+  }
+
+  const recipients = new Map<string, RecipientRecord>();
+
+  if (preferences.notifyTaskOwners && step.taskOwnerId) {
+    const owner = knownUsers.get(step.taskOwnerId);
+    if (owner?.email) {
+      const record = ensureRecipient(recipients, owner);
+      record.roles.add("task_owner");
+      record.steps.push(step);
+    }
+  }
+
+  if (preferences.notifyManagers && managerId) {
+    const manager = knownUsers.get(managerId);
+    if (manager?.email) {
+      const record = ensureRecipient(recipients, manager);
+      record.roles.add("manager");
+    }
+  }
+
+  if (preferences.notifyHiringManagers && hiringManagerId) {
+    const hiringManager = knownUsers.get(hiringManagerId);
+    if (hiringManager?.email) {
+      const record = ensureRecipient(recipients, hiringManager);
+      record.roles.add("hiring_manager");
+    }
+  }
+
+  if (preferences.notifyAdmins) {
+    for (const admin of adminUsers) {
+      if (!admin.email) continue;
+      const record = ensureRecipient(recipients, admin);
+      record.roles.add("admin");
+    }
+  }
+
+  if (preferences.notifyEmployee && employee.User?.email) {
+    const record = ensureRecipient(recipients, employee.User);
+    record.roles.add("employee");
+  }
+
+  if (!recipients.size) {
+    return;
+  }
+
+  const employeeName = formatUserName(employee.User) || "the employee";
+  const statusLabel = status.replace(/_/g, " ").toLowerCase();
+  const planUrl = APP_URL
+    ? `${APP_URL}/employees/${employee.id}/onboarding`
+    : "";
+
+  await Promise.all(
+    Array.from(recipients.values()).map(async (recipient) => {
+      try {
+        if (!recipient.user.email) return;
+        const name = formatUserName(recipient.user) || recipient.user.email;
+        const rolesSentence = rolesToSentence(recipient.roles);
+        const ownerMessage = recipient.roles.has("task_owner")
+          ? "Please review the task details and complete any follow-up actions."
+          : "This update is shared with you for visibility.";
+
+        const html = `
+          <div style="font-family:Arial, sans-serif; color:#111827; max-width:640px; margin:0 auto;">
+            <h2 style="color:#1d4ed8;">Onboarding step ${statusLabel}</h2>
+            <p>Hi ${name},</p>
+            <p>The onboarding step <strong>${step.label}</strong> for ${employeeName} (${template.name}) has been ${statusLabel}.</p>
+            ${rolesSentence ? `<p>Role: ${rolesSentence}</p>` : ""}
+            <p>${ownerMessage}</p>
+            ${
+              planUrl
+                ? `<p style="margin-top:16px;"><a href="${planUrl}" style="background:#1d4ed8;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open onboarding workspace</a></p>`
+                : ""
+            }
+          </div>
+        `;
+
+        const text = `Onboarding step ${statusLabel}\n\nStep: ${step.label}\nEmployee: ${employeeName}\nTemplate: ${template.name}\n${rolesSentence ? `Role: ${rolesSentence}\n` : ""}${ownerMessage}\n${planUrl ? `View onboarding workspace: ${planUrl}\n` : ""}`;
+
+        await resend.emails.send({
+          from: FROM_EMAIL,
+          to: recipient.user.email,
+          subject: `Onboarding step ${statusLabel}: ${step.label}`,
+          html,
+          text,
+        });
+      } catch (error) {
+        console.error(
+          "Failed to send onboarding step notification",
+          recipient.user.id,
+          error,
+        );
+      }
+    }),
+  );
+}

--- a/app/lib/onboarding-notifications.ts
+++ b/app/lib/onboarding-notifications.ts
@@ -15,7 +15,10 @@ const APP_URL =
   process.env.NEXT_PUBLIC_BASE_URL ||
   "";
 
-type MinimalUser = Pick<User, "id" | "email" | "firstName" | "lastName" | "name">;
+type MinimalUser = Pick<
+  User,
+  "id" | "email" | "firstName" | "lastName" | "name" | "managerId"
+>;
 
 type NotificationFlags = {
   notifyManagers: boolean;
@@ -268,6 +271,7 @@ export async function sendOnboardingKickoffNotifications({
             firstName: true,
             lastName: true,
             name: true,
+            managerId: true,
           },
         })
       : Promise.resolve([] as MinimalUser[]),
@@ -280,6 +284,7 @@ export async function sendOnboardingKickoffNotifications({
             firstName: true,
             lastName: true,
             name: true,
+            managerId: true,
           },
         })
       : Promise.resolve([] as MinimalUser[]),
@@ -484,6 +489,7 @@ export async function sendOnboardingStepStatusNotification({
             firstName: true,
             lastName: true,
             name: true,
+            managerId: true,
           },
         })
       : Promise.resolve([] as MinimalUser[]),
@@ -496,6 +502,7 @@ export async function sendOnboardingStepStatusNotification({
             firstName: true,
             lastName: true,
             name: true,
+            managerId: true,
           },
         })
       : Promise.resolve([] as MinimalUser[]),

--- a/prisma/migrations/20251030120000_add_onboarding_notification_preferences/migration.sql
+++ b/prisma/migrations/20251030120000_add_onboarding_notification_preferences/migration.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "OnboardingNotificationType" AS ENUM ('KICKOFF', 'STEP_UPDATE');
+
+CREATE TABLE "OnboardingNotificationPreference" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "templateId" TEXT,
+    "notificationType" "OnboardingNotificationType" NOT NULL,
+    "notifyManagers" BOOLEAN NOT NULL DEFAULT true,
+    "notifyTaskOwners" BOOLEAN NOT NULL DEFAULT true,
+    "notifyHiringManagers" BOOLEAN NOT NULL DEFAULT false,
+    "notifyEmployee" BOOLEAN NOT NULL DEFAULT false,
+    "notifyAdmins" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OnboardingNotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "OnboardingNotificationPreference_companyId_notificationType_idx" ON "OnboardingNotificationPreference"("companyId", "notificationType");
+CREATE INDEX "OnboardingNotificationPreference_companyId_templateId_idx" ON "OnboardingNotificationPreference"("companyId", "templateId");
+CREATE UNIQUE INDEX "OnboardingNotificationPreference_companyId_templateId_notificationType_key" ON "OnboardingNotificationPreference"("companyId", "templateId", "notificationType");
+
+ALTER TABLE "OnboardingNotificationPreference" ADD CONSTRAINT "OnboardingNotificationPreference_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OnboardingNotificationPreference" ADD CONSTRAINT "OnboardingNotificationPreference_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "OnboardingTemplate"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,7 @@ model Company {
   LeaveRequest                        LeaveRequest[]
   NotificationChannel                 NotificationChannel[]
   NotificationSettings                NotificationSettings?
+  OnboardingNotificationPreference    OnboardingNotificationPreference[]
   OnboardingTemplate                  OnboardingTemplate[]
   PermissionProfile                   PermissionProfile[]
   SCIMConfiguration                   SCIMConfiguration?
@@ -1011,12 +1012,34 @@ model OnboardingTemplate {
   OnboardingAssignment OnboardingAssignment[]
   OnboardingInstance   OnboardingInstance[]
   OnboardingStep       OnboardingStep[]
+  OnboardingNotificationPreference OnboardingNotificationPreference[]
   Company              Company                @relation(fields: [companyId], references: [id])
   User                 User?                  @relation(fields: [updatedById], references: [id])
   Department           Department[]           @relation("OnboardingTemplateDepartments")
   JobRole              JobRole[]              @relation("OnboardingTemplateJobRoles")
 
   @@unique([companyId, name])
+}
+
+model OnboardingNotificationPreference {
+  id                String                       @id @default(cuid())
+  companyId         String
+  templateId        String?
+  notificationType  OnboardingNotificationType
+  notifyManagers    Boolean                      @default(true)
+  notifyTaskOwners  Boolean                      @default(true)
+  notifyHiringManagers Boolean                   @default(false)
+  notifyEmployee    Boolean                      @default(false)
+  notifyAdmins      Boolean                      @default(false)
+  createdAt         DateTime                     @default(now())
+  updatedAt         DateTime                     @updatedAt
+
+  Company           Company                      @relation(fields: [companyId], references: [id])
+  OnboardingTemplate OnboardingTemplate?         @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, notificationType])
+  @@index([companyId, templateId])
+  @@unique([companyId, templateId, notificationType])
 }
 
 model PermissionAudit {
@@ -1539,6 +1562,11 @@ enum OnboardingUploadType {
   DRIVER_LICENSE
   TRAINING_CERTIFICATE
   OTHER
+}
+
+enum OnboardingNotificationType {
+  KICKOFF
+  STEP_UPDATE
 }
 
 enum PaidStatus {


### PR DESCRIPTION
## Summary
- add reusable onboarding notification helpers that resolve template preferences and send kickoff / step status emails
- persist notification preferences per template with Prisma schema changes and expose them via the onboarding template API
- trigger stakeholder emails when onboarding instances start or steps change status

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf31652da883318ba58e6443888fca