### PR TITLE
Add password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 This update introduces a basic exit interview workflow for employee offboarding. After initiating an offboarding you can optionally schedule an interview and assign an interviewer.
 
+## Password reset flow
+
+- End users can select **Forgot password?** from `/login` which opens `/forgot-password`.
+- The form posts to `POST /api/auth/password-reset`, which rate limits requests (defaults: 3 attempts per 15 minutes per email/IP pair – override with `PASSWORD_RESET_LIMIT` and `PASSWORD_RESET_WINDOW_MS`).
+- When an account is found, a new token is written to the existing `ActivationToken` table and an email is sent via Resend using the standard `FROM_EMAIL` identity.
+- Reset links point to `/activate?token=…` which reuses the current password set flow; tokens are single-use because they are replaced on every request.
+- Operations can pre-seed tokens during onboarding by inserting into `ActivationToken` with a generated UUID `id`, a random 64-character hex `token`, the `userId`, and `createdAt` timestamp. Example SQL:
+
+```sql
+insert into "ActivationToken" ("id", "token", "userId", "createdAt")
+values (
+  gen_random_uuid(),
+  encode(gen_random_bytes(32), 'hex'),
+  'USER_UUID_HERE',
+  now()
+)
+on conflict ("userId")
+do update set "token" = excluded."token", "createdAt" = now();
+```
+
+- Provide the resulting `token` to the employee (or let the API send the email) so they can complete `/activate?token=…` and choose a password.
+
 ### Environment
 
 - Set `RESEND_API_KEY` with your Resend API key to use the email testing script:

--- a/app/api/auth/password-reset/route.ts
+++ b/app/api/auth/password-reset/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes, randomUUID } from "crypto";
+import { prisma } from "@/lib/prisma";
+import { rateLimit } from "@/lib/rate-limit";
+import { resend } from "@/lib/resend";
+import { buildPasswordResetEmail } from "@/lib/email/password-reset";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@peoplecore.co.nz";
+const RATE_LIMIT_WINDOW = Number(process.env.PASSWORD_RESET_WINDOW_MS ?? 15 * 60 * 1000);
+const RATE_LIMIT_MAX = Number(process.env.PASSWORD_RESET_LIMIT ?? 3);
+
+function normaliseEmail(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+function isEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export async function POST(request: NextRequest) {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const emailInput = normaliseEmail(body?.email);
+  if (!emailInput || !isEmail(emailInput)) {
+    return NextResponse.json({ error: "A valid email address is required." }, { status: 400 });
+  }
+
+  const ip =
+    request.ip ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown";
+  const rateKey = `password-reset:${emailInput.toLowerCase()}:${ip}`;
+
+  try {
+    const limited = await rateLimit(rateKey, {
+      limit: RATE_LIMIT_MAX,
+      windowMs: RATE_LIMIT_WINDOW,
+    });
+
+    if (limited) {
+      return NextResponse.json(
+        { error: "Too many reset attempts. Try again later." },
+        { status: 429 },
+      );
+    }
+  } catch (error) {
+    console.warn("Password reset rate limit failed", error);
+    // Continue on soft failure to avoid blocking legitimate users
+  }
+
+  try {
+    const user = await prisma.user.findFirst({
+      where: {
+        email: { equals: emailInput, mode: "insensitive" } as any,
+      },
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        companyId: true,
+        Company: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!user || !user.companyId || !user.Company) {
+      // Avoid revealing whether the account exists for privacy reasons
+      return NextResponse.json({ success: true });
+    }
+
+    const token = randomBytes(32).toString("hex");
+    const now = new Date();
+
+    await prisma.activationToken.upsert({
+      where: { userId: user.id },
+      update: {
+        token,
+        createdAt: now,
+      },
+      create: {
+        id: randomUUID(),
+        token,
+        userId: user.id,
+        createdAt: now,
+      },
+    });
+
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      new URL(request.url).origin;
+    const resetUrl = `${appUrl}/activate?token=${token}`;
+
+    const fullName = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
+
+    const { subject, html, text } = buildPasswordResetEmail({
+      recipientName: fullName || null,
+      companyName: user.Company?.name,
+      resetUrl,
+    });
+
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: user.email,
+      subject,
+      html,
+      text,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Password reset request failed", error);
+    return NextResponse.json(
+      { error: "We couldn't send the reset email. Please try again." },
+      { status: 500 },
+    );
+  }
+}
+

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+import Button from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { toast } from "@/hooks/use-toast";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const trimmedEmail = email.trim();
+    if (!EMAIL_PATTERN.test(trimmedEmail)) {
+      setFormError("Enter a valid work email address.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch("/api/auth/password-reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmedEmail }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = data?.error || "We couldn't start a reset just now. Try again soon.";
+        setFormError(message);
+        toast({
+          title: "Couldn't send reset email",
+          description: message,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setSubmitted(true);
+      toast({
+        title: "Check your inbox",
+        description:
+          "If the email matches an account, you'll receive password reset instructions shortly.",
+      });
+    } catch (error) {
+      console.error("Forgot password request failed", error);
+      const message = "We couldn't reach the server. Please try again.";
+      setFormError(message);
+      toast({
+        title: "Network error",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface px-4 py-12 dark:bg-surface-dark">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-sm transition-colors dark:bg-surface-dark">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-primary">Reset your password</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            We'll email you a link to choose a new password.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="email">
+              Work email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              disabled={loading || submitted}
+            />
+          </div>
+
+          {formError && (
+            <p className="text-sm text-red-600" role="alert">
+              {formError}
+            </p>
+          )}
+
+          {submitted && !formError && (
+            <p className="text-sm text-green-600" role="status">
+              Check your inbox for a reset link. It may take a minute to arrive.
+            </p>
+          )}
+
+          <Button type="submit" className="w-full" loading={loading} disabled={submitted}>
+            Send reset link
+          </Button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <Link
+            href="/login"
+            className="text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-surface-dark"
+          >
+            Back to login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/app/lib/email/password-reset.ts
+++ b/app/lib/email/password-reset.ts
@@ -1,0 +1,71 @@
+interface PasswordResetEmailOptions {
+  recipientName?: string | null;
+  companyName?: string | null;
+  resetUrl: string;
+  supportEmail?: string | null;
+}
+
+const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL || "support@peoplecore.co.nz";
+
+export function buildPasswordResetEmail({
+  recipientName,
+  companyName,
+  resetUrl,
+  supportEmail = SUPPORT_EMAIL,
+}: PasswordResetEmailOptions): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const safeName = recipientName?.trim() || "there";
+  const tenantName = companyName?.trim();
+  const subject = tenantName
+    ? `${tenantName} | Reset your PeopleCore password`
+    : "Reset your PeopleCore password";
+
+  const introLine = tenantName
+    ? `${tenantName} uses PeopleCore to manage access. Use the button below to choose a new password.`
+    : "Use the button below to choose a new password.";
+
+  const html = `
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color:#f5f7fb;padding:32px 0;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;color:#1f2933;">
+      <tr>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 12px 32px rgba(15, 23, 42, 0.1);">
+            <tr>
+              <td style="padding:32px 40px 24px;border-bottom:1px solid #e5e9f2;background-color:#111827;">
+                <h1 style="margin:0;font-size:24px;color:#ffffff;font-weight:700;">PeopleCore</h1>
+                ${tenantName ? `<p style="margin:8px 0 0;color:#d1d5db;font-size:14px;">${tenantName}</p>` : ""}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px 40px;">
+                <p style="margin:0 0 16px;font-size:16px;">Hi ${safeName},</p>
+                <p style="margin:0 0 24px;font-size:16px;line-height:1.5;">${introLine}</p>
+                <table role="presentation" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td style="border-radius:8px;background:#111827;">
+                      <a href="${resetUrl}" style="display:inline-block;padding:14px 28px;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;border-radius:8px;">Choose a new password</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:#52616b;">This link will expire after it is used once. If you didn't request this, you can safely ignore this email and your password will stay the same.</p>
+                <p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:#52616b;">Need help? Contact us at <a href="mailto:${supportEmail}" style="color:#111827;text-decoration:underline;">${supportEmail}</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 40px;background:#f9fafb;border-top:1px solid #e5e9f2;text-align:center;font-size:12px;color:#94a3b8;">
+                <p style="margin:0;">© ${new Date().getFullYear()} PeopleCore. All rights reserved.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  `;
+
+  const text = [`Hi ${safeName},`, "", introLine, "", `Reset password: ${resetUrl}`, "", "This link can be used once. Ignore this email if you didn't request the reset.", "", `Need help? Email ${supportEmail}.`].join("\n");
+
+  return { subject, html, text };
+}
+

--- a/app/login/LoginClient.tsx
+++ b/app/login/LoginClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn } from "next-auth/react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, FormEvent } from "react";
 import { FcGoogle } from "react-icons/fc";
@@ -105,6 +106,15 @@ export default function LoginClient() {
             Sign In
           </Button>
         </form>
+
+        <div className="mt-4 text-center">
+          <Link
+            href="/forgot-password"
+            className="text-sm font-medium text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-surface-dark"
+          >
+            Forgot password?
+          </Link>
+        </div>
 
         <div className="my-6 flex items-center">
           <div className="h-px flex-1 bg-gray-200 dark:bg-gray-700" />


### PR DESCRIPTION
## Summary
- add a forgot-password screen linked from the login experience
- expose a password reset API that rate limits requests, issues activation tokens, and sends transactional email
- create a reset email template and document how operations can seed tokens during onboarding

## Testing
- npm run lint *(fails: repository currently violates existing lint rules unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d01bfcae9483318bdcd1ac8ffc1489