### PR TITLE
Add IRD number and tax code validation for bank payroll

### DIFF
--- a/app/(withSidebar)/employees/[id]/bank-payroll/page.tsx
+++ b/app/(withSidebar)/employees/[id]/bank-payroll/page.tsx
@@ -6,25 +6,93 @@ import { Input } from "@/components/ui/Input";
 import Link from "next/link";
 import HeaderWithHistory from "@/components/audit/HeaderWithHistory";
 import EmployeeSaveButton from "@/components/employees/EmployeeSaveButton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import {
+  NZ_TAX_CODE_OPTIONS,
+  cn,
+  formatBankAccountNumber,
+  formatIrdNumber,
+  isValidIrdNumber,
+  isValidNzBankAccountNumber,
+  normalizeBankAccountNumber,
+  normalizeIrdNumber,
+} from "@/lib/utils";
+import type { NzTaxCodeValue } from "@/lib/utils";
+
+type TaxCodeFormValue = "" | NzTaxCodeValue;
+
+interface FormState {
+  bankAccountNumber: string;
+  irdNumber: string;
+  taxCode: TaxCodeFormValue;
+  kiwiSaverEnrolled: "" | "yes" | "no";
+  kiwiSaverContribution: string;
+}
+
+interface InitialValuesState {
+  bankAccountNumber: string | null;
+  irdNumber: string | null;
+  taxCode: NzTaxCodeValue | null;
+  kiwiSaverEnrolled: boolean | null;
+  kiwiSaverContribution: number | null;
+}
 
 export default function BankPayrollPage({ params }: { params: { id: string } }) {
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<FormState>({
     bankAccountNumber: "",
+    irdNumber: "",
     taxCode: "",
     kiwiSaverEnrolled: "",
     kiwiSaverContribution: "",
   });
-  const [initialValues, setInitialValues] = useState<{
-    bankAccountNumber: string | null;
-    taxCode: string | null;
-    kiwiSaverEnrolled: boolean | null;
-    kiwiSaverContribution: number | null;
-  }>({
+  const [initialValues, setInitialValues] = useState<InitialValuesState>({
     bankAccountNumber: null,
+    irdNumber: null,
     taxCode: null,
     kiwiSaverEnrolled: null,
     kiwiSaverContribution: null,
   });
+  const [errors, setErrors] = useState<{ bankAccountNumber?: string; irdNumber?: string }>({});
+  const [touched, setTouched] = useState<{ bankAccountNumber: boolean; irdNumber: boolean }>(
+    { bankAccountNumber: false, irdNumber: false },
+  );
+
+  const validateBankAccount = (value: string) => {
+    const normalized = normalizeBankAccountNumber(value);
+    if (!normalized) return undefined;
+    if (normalized.length < 15 || normalized.length > 16) {
+      return "Bank account numbers must be 15 or 16 digits.";
+    }
+    if (!isValidNzBankAccountNumber(normalized)) {
+      return "Enter a valid New Zealand bank account number.";
+    }
+    return undefined;
+  };
+
+  const validateIrd = (value: string) => {
+    const normalized = normalizeIrdNumber(value);
+    if (!normalized) return undefined;
+    if (normalized.length < 8 || normalized.length > 9) {
+      return "IRD numbers must be 8 or 9 digits.";
+    }
+    if (!isValidIrdNumber(normalized)) {
+      return "Enter a valid IRD number.";
+    }
+    return undefined;
+  };
 
   useEffect(() => {
     (async () => {
@@ -36,24 +104,92 @@ export default function BankPayrollPage({ params }: { params: { id: string } }) 
         // Store initial values for audit comparison
         setInitialValues({
           bankAccountNumber: data.bankAccountNumber,
+          irdNumber: data.irdNumber,
           taxCode: data.taxCode,
           kiwiSaverEnrolled: data.kiwiSaverEnrolled,
           kiwiSaverContribution: data.kiwiSaverContribution,
         });
         
         setForm({
-          bankAccountNumber: data.bankAccountNumber ?? "",
+          bankAccountNumber: formatBankAccountNumber(data.bankAccountNumber ?? ""),
+          irdNumber: formatIrdNumber(data.irdNumber ?? ""),
           taxCode: data.taxCode ?? "",
-          kiwiSaverEnrolled: data.kiwiSaverEnrolled ? "yes" : "no",
+          kiwiSaverEnrolled:
+            data.kiwiSaverEnrolled === true
+              ? "yes"
+              : data.kiwiSaverEnrolled === false
+              ? "no"
+              : "",
           kiwiSaverContribution: data.kiwiSaverContribution?.toString() ?? "",
         });
+        setErrors({});
+        setTouched({ bankAccountNumber: false, irdNumber: false });
       } catch {}
     })();
   }, [params.id]);
 
+  const handleBankAccountChange = (value: string) => {
+    const formatted = formatBankAccountNumber(value);
+    setForm((prev) => ({ ...prev, bankAccountNumber: formatted }));
+
+    const normalized = normalizeBankAccountNumber(formatted);
+    if (!normalized) {
+      setErrors((prev) => ({ ...prev, bankAccountNumber: undefined }));
+      return;
+    }
+
+    if (touched.bankAccountNumber || normalized.length >= 15) {
+      setErrors((prev) => ({
+        ...prev,
+        bankAccountNumber: validateBankAccount(formatted),
+      }));
+    }
+  };
+
+  const handleBankAccountBlur = () => {
+    setTouched((prev) => ({ ...prev, bankAccountNumber: true }));
+    setErrors((prev) => ({
+      ...prev,
+      bankAccountNumber: validateBankAccount(form.bankAccountNumber),
+    }));
+  };
+
+  const handleIrdChange = (value: string) => {
+    const formatted = formatIrdNumber(value);
+    setForm((prev) => ({ ...prev, irdNumber: formatted }));
+
+    const normalized = normalizeIrdNumber(formatted);
+    if (!normalized) {
+      setErrors((prev) => ({ ...prev, irdNumber: undefined }));
+      return;
+    }
+
+    if (touched.irdNumber || normalized.length >= 8) {
+      setErrors((prev) => ({
+        ...prev,
+        irdNumber: validateIrd(formatted),
+      }));
+    }
+  };
+
+  const handleIrdBlur = () => {
+    setTouched((prev) => ({ ...prev, irdNumber: true }));
+    setErrors((prev) => ({ ...prev, irdNumber: validateIrd(form.irdNumber) }));
+  };
+
+  const normalizedBankAccount = normalizeBankAccountNumber(form.bankAccountNumber);
+  const normalizedIrd = normalizeIrdNumber(form.irdNumber);
+  const isBankInvalid =
+    normalizedBankAccount.length > 0 && !isValidNzBankAccountNumber(normalizedBankAccount);
+  const isIrdInvalid = normalizedIrd.length > 0 && !isValidIrdNumber(normalizedIrd);
+  const disableSave = isBankInvalid || isIrdInvalid;
+
   // Convert form values to API format
   const getCurrentValues = () => ({
-    bankAccountNumber: form.bankAccountNumber || null,
+    bankAccountNumber: normalizedBankAccount
+      ? formatBankAccountNumber(normalizedBankAccount)
+      : null,
+    irdNumber: normalizedIrd ? normalizedIrd : null,
     taxCode: form.taxCode || null,
     kiwiSaverEnrolled:
       form.kiwiSaverEnrolled === "yes"
@@ -80,56 +216,174 @@ export default function BankPayrollPage({ params }: { params: { id: string } }) 
         section="bank-payroll" 
       />
 
-      <Card>
-        <div className="border-b p-4">
-          <h2 className="text-lg font-semibold">Payroll details</h2>
-        </div>
-        <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="md:col-span-2">
-            <label className="block text-sm font-medium mb-1">Bank account</label>
-            <Input
-              value={form.bankAccountNumber}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, bankAccountNumber: e.target.value }))
-              }
-            />
+      <TooltipProvider>
+        <Card>
+          <div className="border-b p-4">
+            <h2 className="text-lg font-semibold">Payroll details</h2>
           </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Tax code</label>
-            <Input
-              value={form.taxCode}
-              onChange={(e) => setForm((f) => ({ ...f, taxCode: e.target.value }))}
-            />
+          <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium mb-1" htmlFor="bankAccount">
+                Bank account
+              </label>
+              <Input
+                id="bankAccount"
+                value={form.bankAccountNumber}
+                onChange={(e) => handleBankAccountChange(e.target.value)}
+                onBlur={handleBankAccountBlur}
+                aria-invalid={Boolean(errors.bankAccountNumber)}
+                className={cn(
+                  errors.bankAccountNumber
+                    ? "border-destructive focus:border-destructive focus:ring-destructive/50"
+                    : "",
+                )}
+                placeholder="00-0000-0000000-000"
+                inputMode="numeric"
+              />
+              {errors.bankAccountNumber && (
+                <p className="mt-1 text-sm text-destructive">{errors.bankAccountNumber}</p>
+              )}
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <label className="block text-sm font-medium" htmlFor="irdNumber">
+                  IRD number
+                </label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground"
+                      aria-label="IRD number guidance"
+                    >
+                      <Info className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    IRD numbers include a check digit. We'll validate them against Inland Revenue rules.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Input
+                id="irdNumber"
+                value={form.irdNumber}
+                onChange={(e) => handleIrdChange(e.target.value)}
+                onBlur={handleIrdBlur}
+                aria-invalid={Boolean(errors.irdNumber)}
+                className={cn(
+                  errors.irdNumber
+                    ? "border-destructive focus:border-destructive focus:ring-destructive/50"
+                    : "",
+                )}
+                placeholder="123-456-789"
+                inputMode="numeric"
+                maxLength={11}
+              />
+              {errors.irdNumber && (
+                <p className="mt-1 text-sm text-destructive">{errors.irdNumber}</p>
+              )}
+              <p className="mt-1 text-xs text-muted-foreground">
+                Format: 12-345-678 or 123-456-789.{" "}
+                <a
+                  href="https://www.ird.govt.nz/tasks/find-your-ird-number"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Find IRD guidance
+                </a>
+                .
+              </p>
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <label className="block text-sm font-medium" htmlFor="taxCode">
+                  Tax code
+                </label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground"
+                      aria-label="Tax code guidance"
+                    >
+                      <Info className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Choose from the standard Inland Revenue tax codes.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Select
+                value={form.taxCode}
+                onValueChange={(value) =>
+                  setForm((prev) => ({ ...prev, taxCode: value as TaxCodeFormValue }))
+                }
+              >
+                <SelectTrigger id="taxCode">
+                  <SelectValue placeholder="Select tax code" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Not set</SelectItem>
+                  {NZ_TAX_CODE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                <a
+                  href="https://www.ird.govt.nz/employing-staff/paye-tax/tax-codes"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Inland Revenue explains each code
+                </a>
+                .
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="kiwiSaverEnrolled">
+                KiwiSaver enrolled
+              </label>
+              <select
+                id="kiwiSaverEnrolled"
+                className="block w-full border rounded-md h-9 px-3"
+                value={form.kiwiSaverEnrolled}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    kiwiSaverEnrolled: e.target.value as FormState["kiwiSaverEnrolled"],
+                  }))
+                }
+              >
+                <option value="">Select</option>
+                <option value="yes">Yes</option>
+                <option value="no">No</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="kiwiSaverContribution">
+                KiwiSaver contribution (%)
+              </label>
+              <Input
+                id="kiwiSaverContribution"
+                type="number"
+                min="0"
+                max="100"
+                step="1"
+                value={form.kiwiSaverContribution}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, kiwiSaverContribution: e.target.value }))
+                }
+              />
+            </div>
           </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">KiwiSaver enrolled</label>
-            <select
-              className="block w-full border rounded-md h-9 px-3"
-              value={form.kiwiSaverEnrolled}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, kiwiSaverEnrolled: e.target.value }))
-              }
-            >
-              <option value="">Select</option>
-              <option value="yes">Yes</option>
-              <option value="no">No</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">KiwiSaver contribution (%)</label>
-            <Input
-              type="number"
-              min="0"
-              max="100"
-              step="1"
-              value={form.kiwiSaverContribution}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, kiwiSaverContribution: e.target.value }))
-              }
-            />
-          </div>
-        </div>
-      </Card>
+        </Card>
+      </TooltipProvider>
 
       <div className="flex items-center justify-between">
         <Link
@@ -144,6 +398,7 @@ export default function BankPayrollPage({ params }: { params: { id: string } }) 
           initialValues={initialValues}
           currentValues={getCurrentValues()}
           onSaveSuccess={handleSaveSuccess}
+          disabled={disableSave}
         />
       </div>
     </div>

--- a/app/api/employees/[id]/bank-payroll/route.ts
+++ b/app/api/employees/[id]/bank-payroll/route.ts
@@ -3,6 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import {
+  formatBankAccountNumber,
+  isValidIrdNumber,
+  isValidNzBankAccountNumber,
+  normalizeBankAccountNumber,
+  normalizeIrdNumber,
+} from "@/lib/utils";
+import { TaxCode } from "@prisma/client";
 
 export async function PATCH(
   req: Request,
@@ -30,6 +38,7 @@ export async function PATCH(
     
     const allowed = [
       "bankAccountNumber",
+      "irdNumber",
       "taxCode",
       "kiwiSaverEnrolled",
       "kiwiSaverContribution",
@@ -39,6 +48,74 @@ export async function PATCH(
     for (const key of allowed) {
       if (Object.prototype.hasOwnProperty.call(updateFields, key)) {
         updates[key] = updateFields[key as string];
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, "bankAccountNumber")) {
+      const raw = updates.bankAccountNumber;
+      if (raw === null || raw === undefined) {
+        updates.bankAccountNumber = null;
+      } else if (typeof raw === "string") {
+        const normalized = normalizeBankAccountNumber(raw);
+        if (!normalized) {
+          updates.bankAccountNumber = null;
+        } else if (!isValidNzBankAccountNumber(normalized)) {
+          return NextResponse.json(
+            { error: "Invalid bank account number" },
+            { status: 400 },
+          );
+        } else {
+          updates.bankAccountNumber = formatBankAccountNumber(normalized);
+        }
+      } else {
+        return NextResponse.json(
+          { error: "Invalid bank account number" },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, "irdNumber")) {
+      const raw = updates.irdNumber;
+      if (raw === null || raw === undefined) {
+        updates.irdNumber = null;
+      } else if (typeof raw === "string") {
+        const normalized = normalizeIrdNumber(raw);
+        if (!normalized) {
+          updates.irdNumber = null;
+        } else if (!isValidIrdNumber(normalized)) {
+          return NextResponse.json(
+            { error: "Invalid IRD number" },
+            { status: 400 },
+          );
+        } else {
+          updates.irdNumber = normalized;
+        }
+      } else {
+        return NextResponse.json(
+          { error: "Invalid IRD number" },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, "taxCode")) {
+      const value = updates.taxCode;
+      if (value === null || value === undefined || value === "") {
+        updates.taxCode = null;
+      } else if (typeof value === "string") {
+        if (!Object.values(TaxCode).includes(value as TaxCode)) {
+          return NextResponse.json(
+            { error: "Invalid tax code" },
+            { status: 400 },
+          );
+        }
+        updates.taxCode = value as TaxCode;
+      } else {
+        return NextResponse.json(
+          { error: "Invalid tax code" },
+          { status: 400 },
+        );
       }
     }
 
@@ -108,6 +185,7 @@ export async function GET(
 
     return NextResponse.json({
       bankAccountNumber: employee.bankAccountNumber,
+      irdNumber: employee.irdNumber,
       taxCode: employee.taxCode,
       kiwiSaverEnrolled: employee.kiwiSaverEnrolled,
       kiwiSaverContribution: employee.kiwiSaverContribution,

--- a/app/components/audit/HistoryModal.tsx
+++ b/app/components/audit/HistoryModal.tsx
@@ -63,6 +63,7 @@ const fieldLabels: Record<string, string> = {
   pronouns: "Pronouns",
   genderOptionId: "Gender",
   bankAccountNumber: "Bank account number",
+  irdNumber: "IRD number",
   taxCode: "Tax code",
   kiwiSaverEnrolled: "KiwiSaver enrolled",
   kiwiSaverContribution: "KiwiSaver contribution",

--- a/app/lib/audit-field-labels.ts
+++ b/app/lib/audit-field-labels.ts
@@ -19,6 +19,7 @@ export const fieldLabels: Record<string, string> = {
   pronouns: "Pronouns",
   genderOptionId: "Gender",
   bankAccountNumber: "Bank account number",
+  irdNumber: "IRD number",
   taxCode: "Tax code",
   kiwiSaverEnrolled: "KiwiSaver enrolled",
   kiwiSaverContribution: "KiwiSaver contribution",

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -5,3 +5,131 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function normalizeIrdNumber(input: string): string {
+  return (input || "").replace(/\D/g, "").slice(0, 9);
+}
+
+function computeIrdCheckDigit(digits: number[], weights: number[]): number {
+  const sum = digits.reduce((total, digit, index) => total + digit * weights[index], 0);
+  const remainder = sum % 11;
+  if (remainder === 0) return 0;
+  const candidate = 11 - remainder;
+  return candidate === 11 ? 0 : candidate;
+}
+
+export function isValidIrdNumber(input: string): boolean {
+  const normalized = normalizeIrdNumber(input);
+  if (normalized.length < 8 || normalized.length > 9) {
+    return false;
+  }
+
+  const padded = normalized.padStart(9, "0");
+  const digits = padded.split("").map((char) => Number.parseInt(char, 10));
+  if (digits.some((digit) => Number.isNaN(digit))) {
+    return false;
+  }
+
+  const primaryWeights = [3, 2, 7, 6, 5, 4, 3, 2];
+  const secondaryWeights = [7, 4, 3, 2, 5, 2, 7, 6];
+
+  let checkDigit = computeIrdCheckDigit(digits.slice(0, 8), primaryWeights);
+  if (checkDigit === 10) {
+    checkDigit = computeIrdCheckDigit(digits.slice(0, 8), secondaryWeights);
+  }
+
+  if (checkDigit === 10) {
+    return false;
+  }
+
+  return checkDigit === digits[8];
+}
+
+export function formatIrdNumber(input: string): string {
+  const digits = normalizeIrdNumber(input);
+  if (!digits) return "";
+
+  if (digits.length <= 3) {
+    return digits;
+  }
+
+  if (digits.length <= 6) {
+    const head = digits.slice(0, digits.length - 3);
+    const tail = digits.slice(-3);
+    return head ? `${head}-${tail}` : tail;
+  }
+
+  const trimmed = digits.slice(0, 9);
+  const firstGroupLength = trimmed.length === 8 ? 2 : Math.min(3, trimmed.length - 6);
+  const firstGroup = trimmed.slice(0, firstGroupLength);
+  const secondGroup = trimmed.slice(firstGroupLength, firstGroupLength + 3);
+  const thirdGroup = trimmed.slice(firstGroupLength + 3);
+
+  const parts = [firstGroup, secondGroup, thirdGroup].filter((part) => Boolean(part));
+  return parts.join("-");
+}
+
+export function normalizeBankAccountNumber(input: string): string {
+  return (input || "").replace(/\D/g, "").slice(0, 16);
+}
+
+export function isValidNzBankAccountNumber(input: string): boolean {
+  const normalized = normalizeBankAccountNumber(input);
+  return normalized.length === 15 || normalized.length === 16;
+}
+
+export function formatBankAccountNumber(input: string): string {
+  const digits = normalizeBankAccountNumber(input);
+  if (!digits) return "";
+
+  const parts: string[] = [];
+  const bank = digits.slice(0, Math.min(2, digits.length));
+  if (bank) parts.push(bank);
+
+  if (digits.length > 2) {
+    const branch = digits.slice(2, Math.min(6, digits.length));
+    if (branch) parts.push(branch);
+  }
+
+  if (digits.length > 6) {
+    const account = digits.slice(6, Math.min(13, digits.length));
+    if (account) parts.push(account);
+  }
+
+  if (digits.length > 13) {
+    const suffix = digits.slice(13);
+    if (suffix) parts.push(suffix);
+  }
+
+  return parts.join("-");
+}
+
+export const NZ_TAX_CODE_OPTIONS = [
+  { value: "M", label: "M – Main income (no student loan)" },
+  { value: "ME", label: "ME – Main income (exclusive earners' levy)" },
+  { value: "M_SL", label: "M SL – Main income with student loan" },
+  { value: "ME_SL", label: "ME SL – Main income (exclusive earners' levy) with student loan" },
+  { value: "SB", label: "SB – Secondary income up to $14,000" },
+  { value: "SB_SL", label: "SB SL – Secondary income up to $14,000 with student loan" },
+  { value: "S", label: "S – Secondary income $14,001 to $48,000" },
+  { value: "S_SL", label: "S SL – Secondary income $14,001 to $48,000 with student loan" },
+  { value: "SH", label: "SH – Secondary income $48,001 to $70,000" },
+  { value: "SH_SL", label: "SH SL – Secondary income $48,001 to $70,000 with student loan" },
+  { value: "ST", label: "ST – Secondary income over $70,000" },
+  { value: "ST_SL", label: "ST SL – Secondary income over $70,000 with student loan" },
+  { value: "SA", label: "SA – Casual agricultural workers" },
+  { value: "SA_SL", label: "SA SL – Casual agricultural workers with student loan" },
+  { value: "SL", label: "SL – Student loan deductions only" },
+  { value: "SED", label: "SED – Election day workers" },
+  { value: "STC", label: "STC – Special tax code" },
+  { value: "CAE", label: "CAE – Casual agricultural (schedular)" },
+  { value: "EDW", label: "EDW – Election day workers (schedular)" },
+  { value: "ND", label: "ND – No tax code provided" },
+  { value: "NS", label: "NS – Non-resident seasonal workers" },
+  { value: "NC", label: "NC – Child support deductions" },
+  { value: "NCC", label: "NCC – Combined child support deductions" },
+  { value: "WT", label: "WT – Withholding tax" },
+  { value: "P", label: "P – Prescribed investor rate" },
+] as const;
+
+export type NzTaxCodeValue = (typeof NZ_TAX_CODE_OPTIONS)[number]["value"];
+

--- a/prisma/migrations/20251102090000_add_employee_ird_and_taxcode/migration.sql
+++ b/prisma/migrations/20251102090000_add_employee_ird_and_taxcode/migration.sql
@@ -1,0 +1,45 @@
+-- Create TaxCode enum and new IRD number field
+CREATE TYPE "TaxCode" AS ENUM (
+  'M',
+  'ME',
+  'M SL',
+  'ME SL',
+  'SB',
+  'SB SL',
+  'S',
+  'S SL',
+  'SH',
+  'SH SL',
+  'ST',
+  'ST SL',
+  'SA',
+  'SA SL',
+  'SL',
+  'SED',
+  'STC',
+  'CAE',
+  'EDW',
+  'ND',
+  'NS',
+  'NC',
+  'NCC',
+  'WT',
+  'P'
+);
+
+ALTER TABLE "Employee"
+  ADD COLUMN "irdNumber" TEXT,
+  ADD COLUMN IF NOT EXISTS "taxCode_tmp" "TaxCode";
+
+UPDATE "Employee"
+SET "taxCode_tmp" = CASE
+  WHEN "taxCode" IS NULL THEN NULL
+  WHEN replace("taxCode", '_', ' ') IN ('M', 'ME', 'M SL', 'ME SL', 'SB', 'SB SL', 'S', 'S SL', 'SH', 'SH SL', 'ST', 'ST SL', 'SA', 'SA SL', 'SL', 'SED', 'STC', 'CAE', 'EDW', 'ND', 'NS', 'NC', 'NCC', 'WT', 'P')
+    THEN replace("taxCode", '_', ' ')::"TaxCode"
+  ELSE NULL
+END;
+
+ALTER TABLE "Employee" DROP COLUMN "taxCode";
+ALTER TABLE "Employee" RENAME COLUMN "taxCode_tmp" TO "taxCode";
+
+CREATE UNIQUE INDEX "Employee_companyId_irdNumber_key" ON "Employee"("companyId", "irdNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -369,6 +369,7 @@ model Employee {
   locationId                       String?
   startDate                        DateTime?
   bankAccountNumber                String?
+  irdNumber                        String?
   contractType                     String?
   employmentType                   String?
   hourlyRate                       Decimal?                           @db.Decimal(10, 2)
@@ -376,7 +377,7 @@ model Employee {
   kiwiSaverEnrolled                Boolean?
   salaryAmount                     Decimal?                           @db.Decimal(10, 2)
   siteLocation                     String?
-  taxCode                          String?
+  taxCode                          TaxCode?
   Document                         Document[]
   DocumentAcknowledgement          DocumentAcknowledgement[]
   DriverLicence                    DriverLicence[]
@@ -402,6 +403,8 @@ model Employee {
   DocumentSignatureArtifact        DocumentSignatureArtifact[]
   DocumentSignatureEmployee        DocumentSignatureEmployee[]
   DocumentSignatureField           DocumentSignatureField[]
+
+  @@unique([companyId, irdNumber])
 }
 
 model EmployeePerformanceReview {
@@ -1662,6 +1665,34 @@ enum SSOProvider {
 enum StaffingDensityBehavior {
   DENY
   REQUIRE_APPROVAL
+}
+
+enum TaxCode {
+  M
+  ME
+  M_SL   @map("M SL")
+  ME_SL  @map("ME SL")
+  SB
+  SB_SL  @map("SB SL")
+  S
+  S_SL   @map("S SL")
+  SH
+  SH_SL  @map("SH SL")
+  ST
+  ST_SL  @map("ST SL")
+  SA
+  SA_SL  @map("SA SL")
+  SL
+  SED
+  STC
+  CAE
+  EDW
+  ND
+  NS
+  NC
+  NCC
+  WT
+  P
 }
 
 enum TaskCategory {

--- a/tests/auditLogsNotificationIntegration.test.ts
+++ b/tests/auditLogsNotificationIntegration.test.ts
@@ -327,6 +327,11 @@ describe("Audit Logs Notification Integration", () => {
           newValue: "****5678",
         },
         {
+          field: "irdNumber",
+          oldValue: "12345678",
+          newValue: "123456789",
+        },
+        {
           field: "taxCode",
           oldValue: "M",
           newValue: "ME",
@@ -335,11 +340,12 @@ describe("Audit Logs Notification Integration", () => {
 
       const reasons = {
         bankAccountNumber: "Changed bank",
+        irdNumber: "Validated with IRD",
         taxCode: "Updated for accuracy",
       };
 
       mockPrisma.employeeAuditLog.createMany.mock.mockImplementationOnce(
-        () => Promise.resolve({ count: 2 })
+        () => Promise.resolve({ count: 3 })
       );
 
       mockDispatchNotifications.mock.mockImplementationOnce(


### PR DESCRIPTION
## Summary
- add an `irdNumber` field and `TaxCode` enum to the Prisma employee model and ship a migration that maps existing tax code values and enforces uniqueness per company
- extend payroll API logic and shared utilities to normalise and validate IRD numbers, NZ bank accounts, and expose a curated Inland Revenue tax code list
- refresh the bank & payroll client screen with an IRD field, tax code select fed by approved codes, inline validation/error messaging, tooltips, and updated audit labelling/tests

## Testing
- ⚠️ `npx prisma migrate dev --name add-ird-tax-fields --create-only` *(fails: requires a running PostgreSQL instance in CI environment)*
- ✅ `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68d023558c9083318841ffbd223bfe3b