### PR TITLE
Guard NewsPost index drop in migration

### DIFF
--- a/prisma/migrations/20250921011555_esign/migration.sql
+++ b/prisma/migrations/20250921011555_esign/migration.sql
@@ -16,8 +16,7 @@ CREATE TYPE "public"."ApprovalStageMode" AS ENUM ('SEQUENTIAL', 'FIRST_RESPONDER
 -- DropIndex
 DROP INDEX "public"."Department_code_key";
 
--- DropIndex
-DROP INDEX "public"."NewsPost_companyId_idx";
+DROP INDEX IF EXISTS "public"."NewsPost_companyId_idx";
 
 -- AlterTable
 ALTER TABLE "public"."Course" ADD COLUMN     "companyId" TEXT;


### PR DESCRIPTION
## Summary
- guard the NewsPost company index drop so the migration succeeds even if the index is missing

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npx prisma migrate dev` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68d02aabed188331b3e4aa0ac1605f73