### PR TITLE
Add branded email template and refactor transactional senders

### DIFF
--- a/app/api/cron/send-expiry-alerts/route.ts
+++ b/app/api/cron/send-expiry-alerts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { resend } from "@/lib/resend"; // assumes Resend configured
+import { renderPeopleCoreEmail } from "@/lib/email/template";
 import { sendExitInterviewFormInvite } from "@/lib/email/send";
 import { isTodayInLondon } from "@/lib/time";
 
@@ -106,23 +107,38 @@ async function processCompany(companyId: string) {
       }
 
       for (const recipient of recipients) {
+        const { html, text } = renderPeopleCoreEmail({
+          preheader: `${item.type} for ${employeeName} expires soon`,
+          title: "Upcoming Expiry Alert",
+          intro: [
+            "Hello,",
+            "This is a reminder that the following item is expiring soon:",
+          ],
+          sections: [
+            {
+              title: "Expiry Details",
+              description: [
+                `Employee: ${employeeName}`,
+                `Type: ${item.type}`,
+                `Item: ${item.itemName}`,
+                `Expiry Date: ${item.expiryDate.toDateString()}`,
+                `Days Remaining: ${daysRemaining} day(s)`,
+              ],
+            },
+          ],
+          outro: [
+            "Please take action if required.",
+            "Regards,",
+            "PeopleCore HRIS",
+          ],
+        });
+
         await resend.emails.send({
           from: "noreply@peoplecore.co.nz",
           to: recipient,
           subject: `Expiry Alert: ${item.type} for ${employeeName}`,
-          html: `
-              <p>Hello,</p>
-              <p>This is a reminder that the following item is expiring soon:</p>
-              <ul>
-                <li><strong>Employee:</strong> ${employeeName}</li>
-                <li><strong>Type:</strong> ${item.type}</li>
-                <li><strong>Item:</strong> ${item.itemName}</li>
-                <li><strong>Expiry Date:</strong> ${item.expiryDate.toDateString()}</li>
-                <li><strong>Days Remaining:</strong> ${daysRemaining} day(s)</li>
-              </ul>
-              <p>Please take action if required.</p>
-              <p>Regards,<br/>PeopleCore HRIS</p>
-            `,
+          html,
+          text,
         });
         console.log(
           `✅ Sent expiry alert to ${recipient} for ${employeeName} (${item.type})`,

--- a/app/api/documents/signature-fields/[documentId]/route.ts
+++ b/app/api/documents/signature-fields/[documentId]/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl } from "@/lib/email/template";
+import { buildDocumentNotificationEmail } from "@/lib/email/documentNotifications";
 
 export async function GET(
   req: NextRequest,
@@ -120,7 +123,7 @@ export async function POST(
         select: { id: true, email: true, name: true },
       });
 
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+      const baseUrl = getAppBaseUrl();
       const link = document.employeeId
         ? `${baseUrl}/employees/${document.employeeId}/documents?open=${document.id}`
         : `${baseUrl}/documents?open=${document.id}`;
@@ -132,25 +135,22 @@ export async function POST(
         await Promise.all(
           chunk.map(async (u) => {
             try {
-              const resp = await fetch("https://api.resend.com/emails", {
-                method: "POST",
-                headers: {
-                  Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  from: "noreply@peoplecore.co.nz",
-                  to: u.email,
-                  subject: "Document Requires Your Signature",
-                  html: `
-                    <p>Hi ${u.name || "there"},</p>
-                    <p>The document <b>${document.name}</b> requires your signature.</p>
-                    ${document.signatureDueAt ? `<p>Due by: <b>${new Date(document.signatureDueAt).toLocaleString()}</b></p>` : ""}
-                    <p><a href="${link}">Open Document</a></p>
-                  `,
-                }),
+              const { subject, html, text } = buildDocumentNotificationEmail({
+                recipientName: u.name,
+                documentName: document.name,
+                category: document.category,
+                docLink: link,
+                requiresSignature: true,
+                signatureDueAt: document.signatureDueAt,
               });
-              await resp.json();
+
+              await resend.emails.send({
+                from: "noreply@peoplecore.co.nz",
+                to: u.email,
+                subject,
+                html,
+                text,
+              });
             } catch (err) {
               console.error("Resend (placement notify) error:", err);
             }

--- a/app/api/documents/update-access/route.ts
+++ b/app/api/documents/update-access/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl } from "@/lib/email/template";
+import { buildDocumentNotificationEmail } from "@/lib/email/documentNotifications";
 
 export async function PATCH(req: Request) {
   const session = await getServerSession(authOptions);
@@ -108,7 +111,7 @@ export async function PATCH(req: Request) {
           select: { id: true, email: true, name: true },
         });
 
-        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+        const baseUrl = getAppBaseUrl();
         const docLink = document.employeeId
           ? `${baseUrl}/employees/${document.employeeId}/documents`
           : `${baseUrl}/documents`;
@@ -121,24 +124,22 @@ export async function PATCH(req: Request) {
           await Promise.all(
             chunk.map(async (user) => {
               try {
-                const resendRes = await fetch("https://api.resend.com/emails", {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify({
-                    from: "noreply@peoplecore.co.nz",
-                    to: user.email,
-                    subject: "Document Requires Your Signature",
-                    html: `
-                      <p>Hi ${user.name || "there"},</p>
-                      <p>The document <b>${document.name}</b> requires your signature.</p>
-                      <p><a href="${docLink}">Open Document</a></p>
-                    `,
-                  }),
+                const { subject, html, text } = buildDocumentNotificationEmail({
+                  recipientName: user.name,
+                  documentName: document.name,
+                  category: document.category,
+                  docLink,
+                  requiresSignature: true,
+                  signatureDueAt: document.signatureDueAt,
                 });
-                await resendRes.json();
+
+                await resend.emails.send({
+                  from: "noreply@peoplecore.co.nz",
+                  to: user.email,
+                  subject,
+                  html,
+                  text,
+                });
               } catch (err) {
                 console.error("Resend error (signature notify):", err);
               }

--- a/app/api/documents/upload-employee/route.ts
+++ b/app/api/documents/upload-employee/route.ts
@@ -4,6 +4,9 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import supabase from "@/lib/supabase-admin";
 import { randomUUID } from "crypto";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl } from "@/lib/email/template";
+import { buildDocumentNotificationEmail } from "@/lib/email/documentNotifications";
 
 export const runtime = "nodejs"; // Ensure Node runtime for FormData upload
 
@@ -151,29 +154,24 @@ export async function POST(req: NextRequest) {
       console.log("User found for notification:", user);
 
       if (user?.email) {
-        const docLink = `${process.env.NEXT_PUBLIC_BASE_URL}/employees/${employeeId}/documents?open=${document.id}`;
-        const resendRes = await fetch("https://api.resend.com/emails", {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            from: "noreply@peoplecore.co.nz",
-            to: user.email,
-            subject: requiresSignature
-              ? "New Document Requires Your Signature"
-              : "New Document Requires Your Acknowledgement",
-            html: `
-                          <p>Hi ${user.name || "there"},</p>
-                          <p>A new document <b>${name}</b> (${category || "General"}) has been uploaded and requires your ${requiresSignature ? "signature" : "acknowledgement"}.</p>
-                          <p>${signatureDueAt ? `Due by: <b>${new Date(signatureDueAt).toLocaleString()}</b><br/>` : ""}<a href="${docLink}">View ${requiresSignature ? "& Sign" : "& Acknowledge"} Document</a></p>
-                          <p>Thank you,<br/>HR Team</p>
-                        `,
-          }),
+        const baseUrl = getAppBaseUrl();
+        const docLink = `${baseUrl}/employees/${employeeId}/documents?open=${document.id}`;
+        const { subject, html, text } = buildDocumentNotificationEmail({
+          recipientName: user.name,
+          documentName: name,
+          category,
+          docLink,
+          requiresSignature,
+          signatureDueAt,
         });
-        const resendJson = await resendRes.json();
-        console.log("Resend API response:", resendJson);
+
+        await resend.emails.send({
+          from: "noreply@peoplecore.co.nz",
+          to: user.email,
+          subject,
+          html,
+          text,
+        });
       }
     }
   }

--- a/app/api/documents/upload/route.ts
+++ b/app/api/documents/upload/route.ts
@@ -4,6 +4,9 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import supabase from "@/lib/supabase-admin";
 import { z } from "zod";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl } from "@/lib/email/template";
+import { buildDocumentNotificationEmail } from "@/lib/email/documentNotifications";
 
 const optionalStringFromForm = z.preprocess(
   (val) => {
@@ -265,30 +268,24 @@ export async function POST(req: Request) {
         console.log("User found for notification:", user);
 
         if (user?.email) {
-          const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+          const baseUrl = getAppBaseUrl();
           const docLink = `${baseUrl}/employees/${document.employeeId}/documents?open=${document.id}`;
-          const resendRes = await fetch("https://api.resend.com/emails", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              from: "noreply@peoplecore.co.nz",
-              to: user.email,
-              subject: requiresSignature
-                ? "New Document Requires Your Signature"
-                : "New Document Requires Your Acknowledgement",
-              html: `
-                <p>Hi ${user.name || "there"},</p>
-                <p>A new document <b>${document.name}</b> (${document.category || "General"}) has been uploaded and requires your ${requiresSignature ? "signature" : "acknowledgement"}.</p>
-                <p>${signatureDueAt ? `Due by: <b>${new Date(signatureDueAt).toLocaleString()}</b><br/>` : ""}<a href="${docLink}">View ${requiresSignature ? "& Sign" : "& Acknowledge"} Document</a></p>
-                <p>Thank you,<br/>HR Team</p>
-              `,
-            }),
+          const { subject, html, text } = buildDocumentNotificationEmail({
+            recipientName: user.name,
+            documentName: document.name,
+            category: document.category,
+            docLink,
+            requiresSignature,
+            signatureDueAt,
           });
-          const resendJson = await resendRes.json();
-          console.log("Resend API response:", resendJson);
+
+          await resend.emails.send({
+            from: "noreply@peoplecore.co.nz",
+            to: user.email,
+            subject,
+            html,
+            text,
+          });
         }
       }
     }
@@ -351,33 +348,24 @@ export async function POST(req: Request) {
         const chunk = users.slice(i, i + chunkSize);
         await Promise.all(
           chunk.map(async (user) => {
-            const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+            const baseUrl = getAppBaseUrl();
             const docLink = `${baseUrl}/documents?open=${document.id}`;
-            const resendRes = await fetch("https://api.resend.com/emails", {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                from: "noreply@peoplecore.co.nz",
-                to: user.email,
-                subject: requiresSignature
-                  ? "New Document Requires Your Signature"
-                  : "New Document Requires Your Acknowledgement",
-                html: `
-                  <p>Hi ${user.name || "there"},</p>
-                  <p>A new document <b>${document.name}</b> (${document.category || "General"}) has been uploaded and requires your ${requiresSignature ? "signature" : "acknowledgement"}.</p>
-                  <p>${signatureDueAt ? `Due by: <b>${new Date(signatureDueAt).toLocaleString()}</b><br/>` : ""}<a href="${docLink}">View ${requiresSignature ? "& Sign" : "& Acknowledge"} Document</a></p>
-                  <p>Thank you,<br/>HR Team</p>
-                `,
-              }),
+            const { subject, html, text } = buildDocumentNotificationEmail({
+              recipientName: user.name,
+              documentName: document.name,
+              category: document.category,
+              docLink,
+              requiresSignature,
+              signatureDueAt,
             });
-            const resendJson = await resendRes.json();
-            console.log(
-              `Resend API response for user ${user.email}:`,
-              resendJson,
-            );
+
+            await resend.emails.send({
+              from: "noreply@peoplecore.co.nz",
+              to: user.email,
+              subject,
+              html,
+              text,
+            });
           }),
         );
       }

--- a/app/api/employees/[id]/send-invite/route.ts
+++ b/app/api/employees/[id]/send-invite/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
-import { Resend } from "resend";
 import { randomBytes } from "crypto";
-
-const resend = new Resend(process.env.RESEND_API_KEY);
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "@/lib/email/template";
 
 export async function POST(
   _req: NextResponse extends never ? never : any,
@@ -38,17 +37,37 @@ export async function POST(
     const redirectPath = employee.onboardingTemplateId
       ? `/${employee.id}/onboarding`
       : `/dashboard`;
-    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
+    const baseUrl = getAppBaseUrl();
+    const activationLink = `${baseUrl}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
+
+    const employeeName =
+      `${employee.User.firstName ?? ""} ${employee.User.lastName ?? ""}`.trim() ||
+      employee.User.email;
+
+    const { html, text } = renderPeopleCoreEmail({
+      preheader: "Activate your PeopleCore account",
+      title: "Activate Your PeopleCore Account",
+      intro: [
+        `Hi ${employeeName},`,
+        "Welcome to PeopleCore! Use the button below to activate your account and get started.",
+      ],
+      ctas: {
+        label: "Activate Account",
+        href: activationLink,
+      },
+      outro: [
+        "If you weren't expecting this email, please ignore it.",
+        "Thank you,",
+        "The PeopleCore Team",
+      ],
+    });
 
     await resend.emails.send({
       from: "noreply@peoplecore.co.nz",
       to: employee.User.email,
       subject: "Activate Your PeopleCore Account",
-      html: `
-        <p>Hi ${employee.User.firstName || ""},</p>
-        <p>Welcome to PeopleCore! Please click the link below to activate your account and get started:</p>
-        <p><a href="${activationLink}">Activate Your Account</a></p>
-      `,
+      html,
+      text,
     });
 
     return NextResponse.json({ ok: true });

--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { prisma, ensurePrismaConnected } from "@/lib/prisma";
-import { Resend } from "resend";
 import { randomBytes } from "crypto";
 import bcrypt from "bcryptjs";
 import type { Prisma } from "@prisma/client";
@@ -9,6 +8,8 @@ import { authOptions } from "@/lib/auth-options";
 import { canAccessEmployee } from "@/lib/permissions";
 import { z } from "zod";
 import supabase from "@/lib/supabase-admin";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "@/lib/email/template";
 
 const optionalTrimmedString = z.preprocess(
   (val) => {
@@ -73,8 +74,6 @@ const createEmployeeSchema = z.object({
     z.number().nonnegative().optional(),
   ),
 });
-
-const resend = new Resend(process.env.RESEND_API_KEY);
 
 // ✅ GET: Return employees with their user data for listing
 export async function GET(req: Request) {
@@ -211,6 +210,7 @@ export async function POST(req: Request) {
     }
 
     const companyId = session.user.companyId;
+    const appBaseUrl = getAppBaseUrl();
 
     const {
       firstName,
@@ -367,18 +367,33 @@ export async function POST(req: Request) {
     const redirectPath = normalizedTemplateId
       ? `/${employee.id}/onboarding`
       : `/dashboard`;
-    const activationLink = `${process.env.NEXT_PUBLIC_APP_URL}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
+    const activationLink = `${appBaseUrl}/activate?token=${activationToken}&redirect=${encodeURIComponent(redirectPath)}`;
 
     if (sendInviteNow) {
+      const { html, text } = renderPeopleCoreEmail({
+        preheader: "Activate your PeopleCore account",
+        title: "Activate Your PeopleCore Account",
+        intro: [
+          `Hi ${firstName},`,
+          "Welcome to PeopleCore! Use the link below to activate your account and get started.",
+        ],
+        ctas: {
+          label: "Activate Account",
+          href: activationLink,
+        },
+        outro: [
+          "If you weren't expecting this email, you can ignore it.",
+          "Thank you,",
+          "The PeopleCore Team",
+        ],
+      });
+
       await resend.emails.send({
         from: "noreply@peoplecore.co.nz",
         to: email,
         subject: "Activate Your PeopleCore Account",
-        html: `
-          <p>Hi ${firstName},</p>
-          <p>Welcome to PeopleCore! Please click the link below to activate your account and get started:</p>
-          <p><a href="${activationLink}">Activate Your Account</a></p>
-        `,
+        html,
+        text,
       });
     }
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -2,12 +2,11 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { Resend } from "resend";
+import { resend } from "@/lib/resend";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import supabase from "@/lib/supabase-admin";
-
-const resend = new Resend(process.env.RESEND_API_KEY);
+import { renderPeopleCoreEmail, getAppBaseUrl } from "@/lib/email/template";
 
 export async function POST(req: NextRequest) {
   try {
@@ -217,24 +216,42 @@ async function sendNewsEmails(audience: any, title: string, content: any, compan
     }
 
     // ✅ Batch send logic
-    const batchRecipients = users.map((user) => ({
-      from: "noreply@peoplecore.co.nz",
-      to: user.email,
-      subject: `New News Post: ${title}`,
-      html: `
-        <p>Hi ${user.firstName || "there"},</p>
-        <p>There's a new news post on your portal.</p>
-        <p><strong>${title}</strong></p>
-        <p>${renderContentPreview(content)}</p>
-        <p>Log in to view the full post.</p>
-      `,
-    }));
+    const baseUrl = getAppBaseUrl();
+    const previewText = renderContentPreview(content);
 
-    console.log("📨 Sending batch of", batchRecipients.length, "emails");
+    console.log("📨 Sending batch of", users.length, "emails");
 
-    for (const emailData of batchRecipients) {
+    for (const user of users) {
+      const { html, text } = renderPeopleCoreEmail({
+        preheader: title,
+        title: "New PeopleCore News",
+        intro: [
+          `Hi ${user.firstName || "there"},`,
+          "There's a new news post on your portal.",
+        ],
+        sections: [
+          {
+            title,
+            description: previewText ? [previewText] : undefined,
+          },
+        ],
+        ctas: {
+          label: "View News Post",
+          href: `${baseUrl}/news`,
+        },
+        outro: [
+          "Log in to view the full post.",
+        ],
+      });
+
       await resend.emails
-        .send(emailData)
+        .send({
+          from: "noreply@peoplecore.co.nz",
+          to: user.email,
+          subject: `New News Post: ${title}`,
+          html,
+          text,
+        })
         .then((result) => console.log("✅ Resend success:", result))
         .catch((err) => console.error("❌ Resend failed:", err));
     }

--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { resend } from "@/lib/resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "@/lib/email/template";
 
 async function findBestOnboardingTemplate(employee: any, companyId: string) {
   // 1. By Job Role
@@ -157,22 +158,40 @@ export async function POST(req: NextRequest) {
 
     if (sendEmail) {
       try {
-        const baseUrl =
-          process.env.NEXT_PUBLIC_APP_URL ||
-          process.env.NEXT_PUBLIC_BASE_URL ||
-          "";
-        const onboardingLink = `${baseUrl}/${employee.id}/onboarding`;
+        const baseUrl = getAppBaseUrl();
         const loginWithNext = `${baseUrl}/login?next=/${employee.id}/onboarding`;
+
+        const { html, text } = renderPeopleCoreEmail({
+          preheader: "Your PeopleCore onboarding is ready",
+          title: "Welcome to PeopleCore",
+          intro: [
+            `Hi ${user.firstName || "there"},`,
+            "Your onboarding journey has started. Log in to review your tasks and begin working through them.",
+          ],
+          sections: [
+            {
+              description: [
+                "You can access your personalised onboarding checklist at any time from PeopleCore.",
+              ],
+            },
+          ],
+          ctas: {
+            label: "Start Onboarding",
+            href: loginWithNext,
+          },
+          outro: [
+            "If you need any help, reach out to your HR team.",
+            "Thank you,",
+            "The PeopleCore Team",
+          ],
+        });
+
         await resend.emails.send({
           from: "PeopleCore Notifications <noreply@peoplecore.co.nz>",
           to: user.email,
           subject: "Welcome to PeopleCore – Your onboarding is ready",
-          html: `
-            <p>Hi ${user.firstName || "there"},</p>
-            <p>Your onboarding has been started. Please log in and complete your onboarding steps.</p>
-            <p><a href="${loginWithNext}">Login to start onboarding</a></p>
-            <p>Thank you,<br/>HR Team</p>
-          `,
+          html,
+          text,
         });
       } catch (e) {
         console.error("Failed to send onboarding email:", e);

--- a/app/lib/email/documentNotifications.ts
+++ b/app/lib/email/documentNotifications.ts
@@ -1,0 +1,67 @@
+import { renderPeopleCoreEmail } from "./template";
+
+export interface DocumentNotificationOptions {
+  recipientName?: string | null;
+  documentName: string;
+  category?: string | null;
+  docLink: string;
+  requiresSignature: boolean;
+  signatureDueAt?: Date | string | null;
+}
+
+function formatDueDate(value?: Date | string | null): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleString();
+}
+
+export function buildDocumentNotificationEmail({
+  recipientName,
+  documentName,
+  category,
+  docLink,
+  requiresSignature,
+  signatureDueAt,
+}: DocumentNotificationOptions): { subject: string; html: string; text: string } {
+  const subject = requiresSignature
+    ? "New Document Requires Your Signature"
+    : "New Document Requires Your Acknowledgement";
+
+  const formattedDue = formatDueDate(signatureDueAt);
+  const safeCategory = category || "General";
+  const greetingName = recipientName?.trim() || "there";
+  const actionPhrase = requiresSignature ? "signature" : "acknowledgement";
+  const buttonLabel = requiresSignature ? "View & Sign Document" : "View Document";
+
+  const { html, text } = renderPeopleCoreEmail({
+    preheader: `${documentName} requires your ${actionPhrase}`,
+    title: subject,
+    intro: [
+      `Hi ${greetingName},`,
+      `A new document ${documentName} (${safeCategory}) has been uploaded and requires your ${actionPhrase}.`,
+    ],
+    sections: [
+      {
+        title: "Document Details",
+        description: [
+          `Document: ${documentName}`,
+          `Category: ${safeCategory}`,
+          ...(formattedDue ? [`Due by: ${formattedDue}`] : []),
+        ],
+      },
+    ],
+    ctas: {
+      label: buttonLabel,
+      href: docLink,
+    },
+    outro: [
+      "Thank you,",
+      "The PeopleCore Team",
+    ],
+  });
+
+  return { subject, html, text };
+}

--- a/app/lib/email/send.ts
+++ b/app/lib/email/send.ts
@@ -1,4 +1,3 @@
-import { Resend } from "resend";
 import { prisma } from "@/lib/prisma";
 import {
   buildExitInterviewConfirmationICS,
@@ -6,9 +5,29 @@ import {
 } from "@/lib/calendar/ics";
 import { formatLondon } from "@/lib/time";
 import { createHash, randomBytes } from "crypto";
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "./template";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
 const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@peoplecore.co.nz";
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
 
 export interface EmailRecipient {
   email: string;
@@ -93,54 +112,99 @@ export async function sendExitInterviewConfirmation(
     );
     const interviewTime = formatLondon(offboarding.exitInterviewDate, "HH:mm");
     const location = offboarding.location || "Online/Office";
+    const employeeName =
+      `${employee.User.firstName ?? ""} ${employee.User.lastName ?? ""}`.trim() ||
+      employee.User.email;
+    const interviewerName =
+      interviewer.name ||
+      `${interviewer.firstName ?? ""} ${interviewer.lastName ?? ""}`.trim();
 
-    const subject = `Exit Interview — ${employee.User.firstName} ${employee.User.lastName} on ${interviewDate} at ${interviewTime}`;
+    const subject = `Exit Interview — ${employeeName} on ${interviewDate} at ${interviewTime}`;
 
-    let formLink = "";
+    let formLink: string | null = null;
     if (
       offboarding.sendForm &&
       offboarding.formTiming === "NOW" &&
       offboarding.completionTokenHash
     ) {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+      const baseUrl = getAppBaseUrl();
       formLink = `${baseUrl}/exit-interview/${offboarding.completionTokenHash}`;
     }
 
-    const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #333;">Exit Interview Confirmation</h2>
-
-        <p>Dear ${employee.User.firstName} ${employee.User.lastName},</p>
-
-        <p>Your exit interview has been scheduled with the following details:</p>
-        
-        <div style="background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <p><strong>Date:</strong> ${interviewDate}</p>
-          <p><strong>Time:</strong> ${interviewTime}</p>
-          <p><strong>Location:</strong> ${location}</p>
-          <p><strong>Interviewer:</strong> ${interviewer.name || `${interviewer.firstName} ${interviewer.lastName}`}</p>
-          ${offboarding.exitInterviewNotes ? `<p><strong>Notes:</strong> ${offboarding.exitInterviewNotes}</p>` : ""}
-        </div>
-        
-        <p>A calendar invitation has been attached to this email. Please add it to your calendar.</p>
-        
-        ${
-          formLink
-            ? `
-          <div style="background: #e8f4fd; padding: 15px; border-radius: 8px; margin: 20px 0;">
-            <p><strong>Exit Interview Form</strong></p>
-            <p>Please complete your exit interview form before the interview:</p>
-            <a href="${formLink}" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; display: inline-block;">Complete Form</a>
-          </div>
-        `
-            : ""
-        }
-        
-        <p>If you have any questions or need to reschedule, please contact HR.</p>
-        
-        <p>Best regards,<br>HR Team</p>
-      </div>
+    const detailsHtml = `
+      <table style="width: 100%; border-collapse: collapse;">
+        <tbody>
+          <tr>
+            <td style="padding: 8px 0; font-weight: 600; color: #0f172a;">Date</td>
+            <td style="padding: 8px 0; color: #0f172a;">${escapeHtml(interviewDate)}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; font-weight: 600; color: #0f172a;">Time</td>
+            <td style="padding: 8px 0; color: #0f172a;">${escapeHtml(interviewTime)} (London)</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; font-weight: 600; color: #0f172a;">Location</td>
+            <td style="padding: 8px 0; color: #0f172a;">${escapeHtml(location)}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; font-weight: 600; color: #0f172a;">Interviewer</td>
+            <td style="padding: 8px 0; color: #0f172a;">${escapeHtml(interviewerName)}</td>
+          </tr>
+          ${
+            offboarding.exitInterviewNotes
+              ? `<tr>
+                  <td style="padding: 8px 0; font-weight: 600; color: #0f172a; vertical-align: top;">Notes</td>
+                  <td style="padding: 8px 0; color: #0f172a; white-space: pre-line;">${escapeHtml(
+                    offboarding.exitInterviewNotes,
+                  )}</td>
+                </tr>`
+              : ""
+          }
+        </tbody>
+      </table>
     `;
+
+    const detailsText = [
+      `Date: ${interviewDate}`,
+      `Time: ${interviewTime} (London)`,
+      `Location: ${location}`,
+      `Interviewer: ${interviewerName}`,
+    ];
+    if (offboarding.exitInterviewNotes) {
+      detailsText.push(`Notes: ${offboarding.exitInterviewNotes}`);
+    }
+
+    const { html: htmlContent, text } = renderPeopleCoreEmail({
+      preheader: `Exit interview scheduled for ${employeeName} on ${interviewDate}`,
+      title: "Exit Interview Confirmation",
+      intro: [
+        `Hi ${employeeName},`,
+        "Your exit interview has been scheduled. The details are below.",
+      ],
+      sections: [
+        {
+          title: "Interview Details",
+          html: detailsHtml,
+          text: detailsText,
+        },
+        {
+          description: [
+            "A calendar invitation (.ics) has been attached to this email so you can add the interview to your diary.",
+          ],
+        },
+      ],
+      ctas: formLink
+        ? {
+            label: "Complete Exit Interview Form",
+            href: formLink,
+          }
+        : undefined,
+      outro: [
+        "If you have any questions or need to reschedule, please contact your HR team.",
+        "Thank you,",
+        "The PeopleCore Team",
+      ],
+    });
 
     console.log("Sending email to employee:", {
       from: FROM_EMAIL,
@@ -155,6 +219,7 @@ export async function sendExitInterviewConfirmation(
       to: employee.User.email,
       subject,
       html: htmlContent,
+      text,
       attachments: [
         {
           filename: ics.filename,
@@ -172,6 +237,7 @@ export async function sendExitInterviewConfirmation(
       to: interviewer.email,
       subject: `Copy: ${subject}`,
       html: htmlContent,
+      text,
       attachments: [
         {
           filename: ics.filename,
@@ -246,38 +312,46 @@ export async function sendExitInterviewFormInvite(
     });
 
     const employee = offboarding.Employee;
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL;
+    const employeeName =
+      `${employee.User.firstName ?? ""} ${employee.User.lastName ?? ""}`.trim() ||
+      employee.User.email;
+    const baseUrl = getAppBaseUrl();
     const formLink = `${baseUrl}/exit-interview/${offboarding.completionTokenHash}`;
     const today = formatLondon(new Date(), "dd MMMM yyyy");
 
     const subject = `Please complete your Exit Interview — ${today}`;
 
-    const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #333;">Exit Interview Form</h2>
-
-        <p>Dear ${employee.User.firstName} ${employee.User.lastName},</p>
-
-        <p>As part of your exit process, please complete your exit interview form today.</p>
-        
-        <div style="background: #e8f4fd; padding: 20px; border-radius: 8px; margin: 20px 0; text-align: center;">
-          <p style="margin-bottom: 15px;"><strong>Exit Interview Form</strong></p>
-          <a href="${formLink}" style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">Complete Form Now</a>
-        </div>
-        
-        <p>This form will help us understand your experience and gather feedback for improvement.</p>
-        
-        <p>If you have any issues accessing the form, please contact HR.</p>
-        
-        <p>Best regards,<br>HR Team</p>
-      </div>
-    `;
+    const { html, text } = renderPeopleCoreEmail({
+      preheader: "Your exit interview form is ready to complete",
+      title: "Exit Interview Form",
+      intro: [
+        `Hi ${employeeName},`,
+        "As part of your exit process, please complete your exit interview form today.",
+      ],
+      sections: [
+        {
+          description: [
+            "Your responses help us learn from your experience and continue improving the PeopleCore workplace.",
+          ],
+        },
+      ],
+      ctas: {
+        label: "Complete Form Now",
+        href: formLink,
+      },
+      outro: [
+        "If you have any issues accessing the form, please contact your HR team.",
+        "Thank you,",
+        "The PeopleCore Team",
+      ],
+    });
 
     await resend.emails.send({
       from: FROM_EMAIL,
       to: employee.User.email,
       subject,
-      html: htmlContent,
+      html,
+      text,
     });
 
     // Update completion status to STARTED
@@ -332,23 +406,31 @@ export async function sendExitInterviewCancellation(
       interviewer,
     );
 
-    const subject = `Exit Interview Cancelled — ${employee.User.firstName} ${employee.User.lastName}`;
+    const employeeName =
+      `${employee.User.firstName ?? ""} ${employee.User.lastName ?? ""}`.trim() ||
+      employee.User.email;
+    const subject = `Exit Interview Cancelled — ${employeeName}`;
 
-    const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #d32f2f;">Exit Interview Cancelled</h2>
-        
-        <p>Dear ${employee.User.firstName} ${employee.User.lastName},</p>
-        
-        <p>Your scheduled exit interview has been cancelled.</p>
-        
-        <p>A cancellation notice has been attached to this email to remove the event from your calendar.</p>
-        
-        <p>If you have any questions, please contact HR.</p>
-        
-        <p>Best regards,<br>HR Team</p>
-      </div>
-    `;
+    const { html: htmlContent, text } = renderPeopleCoreEmail({
+      preheader: `Exit interview cancelled for ${employeeName}`,
+      title: "Exit Interview Cancelled",
+      intro: [
+        `Hi ${employeeName},`,
+        "Your scheduled exit interview has been cancelled.",
+      ],
+      sections: [
+        {
+          description: [
+            "We've attached an updated calendar notice (.ics) so you can remove the interview from your diary.",
+          ],
+        },
+      ],
+      outro: [
+        "If you have any questions, please contact your HR team.",
+        "Thank you,",
+        "The PeopleCore Team",
+      ],
+    });
 
     // Send cancellation to employee
     await resend.emails.send({
@@ -356,6 +438,7 @@ export async function sendExitInterviewCancellation(
       to: employee.User.email,
       subject,
       html: htmlContent,
+      text,
       attachments: [
         {
           filename: ics.filename,
@@ -372,6 +455,7 @@ export async function sendExitInterviewCancellation(
         to: interviewer.email,
         subject: `Copy: ${subject}`,
         html: htmlContent,
+        text,
         attachments: [
           {
             filename: ics.filename,

--- a/app/lib/email/template.ts
+++ b/app/lib/email/template.ts
@@ -1,0 +1,270 @@
+const BRAND = {
+  background: "#f1f5f9",
+  surface: "#ffffff",
+  primary: "#2563eb",
+  primaryDark: "#1d4ed8",
+  text: "#0f172a",
+  muted: "#475569",
+  border: "#e2e8f0",
+};
+
+export interface EmailTemplateCTA {
+  label: string;
+  href: string;
+}
+
+export interface EmailTemplateSection {
+  title?: string;
+  description?: string | string[];
+  bulletPoints?: string[];
+  html?: string;
+  text?: string | string[];
+}
+
+export interface PeopleCoreEmailTemplate {
+  preheader?: string;
+  title: string;
+  intro?: string | string[];
+  sections?: EmailTemplateSection[];
+  outro?: string | string[];
+  ctas?: EmailTemplateCTA | EmailTemplateCTA[];
+  footer?: string;
+}
+
+const DEFAULT_FOOTER =
+  "You're receiving this message because your organisation uses PeopleCore. This inbox is unattended.";
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
+
+function normaliseLines(value?: string | string[]): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.filter(Boolean);
+  }
+  return value.split(/\n+/).map((line) => line.trim()).filter(Boolean);
+}
+
+function normaliseCTA(cta?: EmailTemplateCTA | EmailTemplateCTA[]): EmailTemplateCTA[] {
+  if (!cta) return [];
+  return Array.isArray(cta) ? cta : [cta];
+}
+
+function getLogoUrl(): string {
+  const explicit = process.env.PEOPLECORE_LOGO_URL;
+  const base =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_VERCEL_URL ||
+    "";
+
+  const trimmedBase = base ? base.replace(/\/$/, "") : "";
+  if (explicit) return explicit;
+  if (trimmedBase) return `${trimmedBase}/peoplecore-logo.svg`;
+  return "https://peoplecore.vercel.app/peoplecore-logo.svg";
+}
+
+export function getAppBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_VERCEL_URL ||
+    "https://peoplecore.vercel.app"
+  );
+}
+
+export function renderPeopleCoreEmail(
+  template: PeopleCoreEmailTemplate,
+): { html: string; text: string } {
+  const preheader =
+    template.preheader || normaliseLines(template.intro)[0] || template.title;
+  const intro = normaliseLines(template.intro);
+  const outro = normaliseLines(template.outro);
+  const ctas = normaliseCTA(template.ctas);
+  const sections = template.sections ?? [];
+  const footer = template.footer || DEFAULT_FOOTER;
+  const logoUrl = getLogoUrl();
+
+  const sectionHtml = sections
+    .map((section) => {
+      const description = normaliseLines(section.description);
+      const points = section.bulletPoints ?? [];
+      const bodyParts: string[] = [];
+
+      if (description.length) {
+        bodyParts.push(
+          description
+            .map(
+              (line) =>
+                `<p style="margin: 0 0 12px 0; color: ${BRAND.text}; font-size: 15px; line-height: 1.6;">${escapeHtml(
+                  line,
+                )}</p>`,
+            )
+            .join(""),
+        );
+      }
+
+      if (points.length) {
+        bodyParts.push(
+          `<ul style="margin: 0 0 12px 0; padding-left: 20px; color: ${BRAND.text}; font-size: 15px; line-height: 1.6;">${points
+            .map(
+              (point) =>
+                `<li style=\"margin-bottom: 6px;\">${escapeHtml(point)}</li>`,
+            )
+            .join("")}</ul>`,
+        );
+      }
+
+      if (section.html) {
+        bodyParts.push(
+          `<div style="margin: 0 0 12px 0; font-size: 15px; line-height: 1.6; color: ${BRAND.text};">${section.html}</div>`,
+        );
+      }
+
+      if (!bodyParts.length) {
+        return "";
+      }
+
+      const titleHtml = section.title
+        ? `<h3 style="margin: 0 0 12px 0; color: ${BRAND.primary}; font-size: 18px;">${escapeHtml(
+            section.title,
+          )}</h3>`
+        : "";
+
+      return `<section style="padding: 20px; border: 1px solid ${BRAND.border}; border-radius: 16px; background: ${BRAND.surface}; margin-bottom: 16px;">${titleHtml}${bodyParts.join(
+        "",
+      )}</section>`;
+    })
+    .filter(Boolean)
+    .join("");
+
+  const ctaHtml = ctas
+    .map(
+      (cta) =>
+        `<a href="${cta.href}" style="display: inline-block; background: ${BRAND.primary}; color: #ffffff; padding: 14px 28px; border-radius: 9999px; font-weight: 600; font-size: 16px; text-decoration: none; margin: 0 8px 12px 0;">${escapeHtml(
+          cta.label,
+        )}</a>`,
+    )
+    .join("");
+
+  const outroHtml = outro
+    .map(
+      (line) =>
+        `<p style="margin: 0 0 12px 0; color: ${BRAND.muted}; font-size: 14px; line-height: 1.6;">${escapeHtml(
+          line,
+        )}</p>`,
+    )
+    .join("");
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charSet="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(template.title)}</title>
+  </head>
+  <body style="margin:0; padding:0; background-color:${BRAND.background}; font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; color:${BRAND.text};">
+    <span style="display:none; visibility:hidden; opacity:0; color:transparent; height:0; width:0;">${escapeHtml(
+      preheader,
+    )}</span>
+    <table role="presentation" width="100%" cellPadding="0" cellSpacing="0" style="background-color:${BRAND.background}; padding: 32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" style="max-width:640px; background:${BRAND.surface}; border-radius:24px; box-shadow:0 20px 45px rgba(15, 23, 42, 0.08); overflow:hidden; border:1px solid ${BRAND.border};">
+            <tr>
+              <td style="background: linear-gradient(135deg, rgba(37,99,235,0.12) 0%, rgba(124,58,237,0.12) 100%); padding: 28px 32px; text-align:left;">
+                <img src="${logoUrl}" alt="PeopleCore" style="height: 32px; width: auto; display: block; margin-bottom: 16px;" />
+                <h1 style="margin: 0; font-size: 26px; line-height: 1.2; color: ${BRAND.text};">${escapeHtml(
+                  template.title,
+                )}</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 32px;">
+                ${intro
+                  .map(
+                    (line) =>
+                      `<p style="margin: 0 0 16px 0; font-size: 16px; line-height: 1.7; color: ${BRAND.text};">${escapeHtml(
+                        line,
+                      )}</p>`,
+                  )
+                  .join("")}
+                ${sectionHtml}
+                ${ctaHtml ? `<div style="margin: 24px 0;">${ctaHtml}</div>` : ""}
+                ${outroHtml}
+              </td>
+            </tr>
+            <tr>
+              <td style="background-color:${BRAND.background}; padding: 20px 32px; text-align: center; border-top: 1px solid ${BRAND.border};">
+                <p style="margin:0; font-size:12px; color:${BRAND.muted}; line-height:1.5;">${escapeHtml(
+                  footer,
+                )}</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const textSections = sections
+    .map((section) => {
+      const lines: string[] = [];
+      const description = normaliseLines(section.description);
+      const textLines = normaliseLines(section.text);
+
+      if (section.title) {
+        lines.push(section.title.toUpperCase());
+      }
+      if (textLines.length) {
+        lines.push(...textLines);
+      } else {
+        if (description.length) {
+          lines.push(...description);
+        }
+        if (section.bulletPoints?.length) {
+          lines.push(...section.bulletPoints.map((point) => `- ${point}`));
+        }
+      }
+      return lines.join("\n");
+    })
+    .filter(Boolean);
+
+  const textCtas = ctas.map((cta) => `${cta.label}: ${cta.href}`);
+
+  const text = [
+    template.title.toUpperCase(),
+    "",
+    preheader,
+    "",
+    ...intro,
+    "",
+    ...textSections.flatMap((block) => [block, ""]),
+    ...outro,
+    ...(textCtas.length ? ["", ...textCtas] : []),
+    "",
+    footer,
+  ]
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return { html, text };
+}

--- a/app/lib/news/sendNewsEmail.ts
+++ b/app/lib/news/sendNewsEmail.ts
@@ -1,6 +1,5 @@
-import { Resend } from "resend";
-
-const resend = new Resend(process.env.RESEND_API_KEY);
+import { resend } from "@/lib/resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "@/lib/email/template";
 
 interface SendNewsEmailProps {
   title: string;
@@ -16,15 +15,35 @@ export async function sendNewsEmail({
   if (!recipients.length) return;
 
   try {
+    const baseUrl = getAppBaseUrl();
+    const { html, text } = renderPeopleCoreEmail({
+      preheader: title,
+      title: "New PeopleCore News",
+      intro: [
+        "Hi there,",
+        "A new news post has been published on your PeopleCore portal.",
+      ],
+      sections: [
+        {
+          title: title,
+          description: ["Catch up on the latest update from your organisation."],
+        },
+      ],
+      ctas: {
+        label: "View News Post",
+        href: `${baseUrl}/news/${slug}`,
+      },
+      outro: [
+        "You're receiving this update because you're subscribed to PeopleCore news alerts.",
+      ],
+    });
+
     await resend.emails.send({
       from: "noreply@peoplecore.co.nz",
       to: recipients,
       subject: "New News Post",
-      html: `
-        <h2>${title}</h2>
-        <p>A new news post has been published.</p>
-        <p><a href="${process.env.NEXT_PUBLIC_BASE_URL}/news/${slug}">View Post</a></p>
-      `,
+      html,
+      text,
     });
   } catch (err) {
     console.error("Failed to send news email:", err);

--- a/app/lib/sendLeaveNotification.ts
+++ b/app/lib/sendLeaveNotification.ts
@@ -1,4 +1,5 @@
 import { resend } from "./resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "./email/template";
 
 interface LeaveNotificationParams {
   to: string;
@@ -22,36 +23,41 @@ export async function sendLeaveNotification({
   try {
     const formattedStart = new Date(startDate).toLocaleDateString();
     const formattedEnd = new Date(endDate).toLocaleDateString();
+    const baseUrl = getAppBaseUrl();
 
-    const html = `
-      <div style="font-family: sans-serif; max-width: 500px; margin: auto; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px;">
-        <h2 style="color: #111827;">PeopleCore Leave Notification</h2>
-        <p>Hello,</p>
-        <p>This is a notification regarding <strong>${employeeName}</strong>'s leave request:</p>
-        <ul>
-          <li><strong>Type:</strong> ${type}</li>
-          <li><strong>Dates:</strong> ${formattedStart} to ${formattedEnd}</li>
-          <li><strong>Status:</strong> ${status}</li>
-        </ul>
-        <p>
-          <a 
-            href="https://peoplecore.vercel.app/dashboard/approvals" 
-            style="background-color:#1d4ed8;color:white;padding:10px 15px;text-decoration:none;border-radius:5px;display:inline-block;"
-            target="_blank"
-          >
-            Click here to login and approve this request
-          </a>
-        </p>
-        <br/>
-        <p style="font-size: 12px; color: #6b7280;">PeopleCore HRIS System</p>
-      </div>
-    `;
+    const { html, text } = renderPeopleCoreEmail({
+      preheader: `${employeeName}'s ${type} leave is ${status.toLowerCase()}`,
+      title: "Leave Request Notification",
+      intro: [
+        "Hello,",
+        `This is a notification regarding ${employeeName}'s leave request.`,
+      ],
+      sections: [
+        {
+          title: "Leave Details",
+          description: [
+            `Employee: ${employeeName}`,
+            `Type: ${type}`,
+            `Dates: ${formattedStart} to ${formattedEnd}`,
+            `Status: ${status}`,
+          ],
+        },
+      ],
+      ctas: {
+        label: "Review Request",
+        href: `${baseUrl}/dashboard/approvals`,
+      },
+      outro: [
+        "PeopleCore HRIS System",
+      ],
+    });
 
     const data = await resend.emails.send({
       from: "PeopleCore Notifications <noreply@peoplecore.co.nz>",
       to,
       subject,
       html,
+      text,
     });
 
     console.log("✅ Email sent via Resend:", data);

--- a/app/lib/sendLeaveStatusUpdate.ts
+++ b/app/lib/sendLeaveStatusUpdate.ts
@@ -1,4 +1,5 @@
 import { resend } from "./resend";
+import { getAppBaseUrl, renderPeopleCoreEmail } from "./email/template";
 
 interface LeaveStatusUpdateParams {
   to: string;
@@ -22,36 +23,40 @@ export async function sendLeaveStatusUpdate({
   try {
     const formattedStart = new Date(startDate).toLocaleDateString();
     const formattedEnd = new Date(endDate).toLocaleDateString();
+    const baseUrl = getAppBaseUrl();
 
-    const html = `
-      <div style="font-family: sans-serif; max-width: 500px; margin: auto; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px;">
-        <h2 style="color: #111827;">PeopleCore Leave Update</h2>
-        <p>Hello ${employeeName},</p>
-        <p>Your leave request has been <strong>${status.toLowerCase()}</strong>:</p>
-        <ul>
-          <li><strong>Type:</strong> ${type}</li>
-          <li><strong>Dates:</strong> ${formattedStart} to ${formattedEnd}</li>
-          <li><strong>Status:</strong> ${status}</li>
-        </ul>
-        <p>
-          <a 
-            href="https://peoplecore.vercel.app/profile" 
-            style="background-color:#1d4ed8;color:white;padding:10px 15px;text-decoration:none;border-radius:5px;display:inline-block;"
-            target="_blank"
-          >
-            Click here to view your leave in PeopleCore
-          </a>
-        </p>
-        <br/>
-        <p style="font-size: 12px; color: #6b7280;">PeopleCore HRIS System</p>
-      </div>
-    `;
+    const { html, text } = renderPeopleCoreEmail({
+      preheader: `Your ${type} leave request is ${status.toLowerCase()}`,
+      title: "Leave Request Update",
+      intro: [
+        `Hi ${employeeName},`,
+        `Your leave request has been ${status.toLowerCase()}.`,
+      ],
+      sections: [
+        {
+          title: "Leave Details",
+          description: [
+            `Type: ${type}`,
+            `Dates: ${formattedStart} to ${formattedEnd}`,
+            `Status: ${status}`,
+          ],
+        },
+      ],
+      ctas: {
+        label: "View Leave in PeopleCore",
+        href: `${baseUrl}/profile`,
+      },
+      outro: [
+        "PeopleCore HRIS System",
+      ],
+    });
 
     const data = await resend.emails.send({
       from: "PeopleCore Notifications <noreply@peoplecore.co.nz>",
       to,
       subject,
       html,
+      text,
     });
 
     console.log("✅ Leave status update email sent via Resend:", data);

--- a/app/lib/transactional-notifications.ts
+++ b/app/lib/transactional-notifications.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { resend } from "@/lib/resend";
+import { renderPeopleCoreEmail } from "@/lib/email/template";
 import { labelForField, formatAuditValue } from "@/lib/audit-field-labels";
 import { Employee, User, Department, TransactionalNotificationPreference } from "@prisma/client";
 
@@ -199,81 +200,39 @@ export function buildTransactionalEmail({
 
   changesHtml += '</tbody></table>';
 
-  const html = `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    </head>
-    <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
-      <div style="max-width: 800px; margin: 0 auto; padding: 20px;">
-        <!-- Header -->
-        <div style="border-bottom: 3px solid #3b82f6; padding-bottom: 20px; margin-bottom: 30px;">
-          <h1 style="color: #1f2937; margin: 0 0 8px 0; font-size: 28px;">Employee Record Updated</h1>
-          <p style="color: #6b7280; margin: 0; font-size: 14px;">${currentDate}</p>
-        </div>
-        
-        <!-- Summary -->
-        <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 24px; border-radius: 12px; margin-bottom: 30px;">
-          <p style="margin: 0 0 12px 0; font-size: 16px;">
-            <strong>${actorName}</strong> has updated
-          </p>
-          <h2 style="margin: 0 0 8px 0; font-size: 24px;">${employeeName}'s ${sectionConfig.label}</h2>
-          <p style="margin: 0; opacity: 0.9; font-size: 14px;">
-            ${changeCount} ${changeCount === 1 ? 'change' : 'changes'} made
-          </p>
-        </div>
-        
-        <!-- Changes Table -->
-        <div style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; margin-bottom: 30px;">
-          <h3 style="color: #1f2937; margin: 0 0 16px 0; font-size: 18px;">Detailed Changes</h3>
-          ${changesHtml}
-        </div>
-        
-        <!-- Call to Action -->
-        <div style="text-align: center; margin: 40px 0;">
-          <a href="${sectionUrl}" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 14px 32px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 16px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
-            View Employee Record →
-          </a>
-        </div>
-        
-        <!-- Footer -->
-        <div style="border-top: 1px solid #e5e7eb; padding-top: 20px; margin-top: 40px;">
-          <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 0;">
-            This is an automated notification from PeopleCore HR System.<br>
-            Please do not reply to this email. For assistance, contact your HR administrator.
-          </p>
-        </div>
-      </div>
-    </body>
-    </html>
-  `;
+  const summaryDescription = [
+    `Employee: ${employeeName}`,
+    `Updated by: ${actorName}`,
+    `Changes: ${changeCount}`,
+    `Date: ${currentDate}`,
+  ];
 
-  const text = `
-EMPLOYEE RECORD UPDATED
-========================
-${currentDate}
-
-${actorName} has updated ${employeeName}'s ${sectionConfig.label}
-
-SUMMARY
--------
-Total changes: ${changeCount}
-
-DETAILED CHANGES
-----------------
-${textChanges}
-
-VIEW RECORD
------------
-To view the complete employee record, visit:
-${sectionUrl}
-
----
-This is an automated notification from PeopleCore HR System.
-Please do not reply to this email. For assistance, contact your HR administrator.
-`;
+  const { html, text } = renderPeopleCoreEmail({
+    preheader: `${actorName} updated ${employeeName}'s ${sectionConfig.label}`,
+    title: "Employee Record Updated",
+    intro: [
+      `${actorName} has updated ${employeeName}'s ${sectionConfig.label}.`,
+    ],
+    sections: [
+      {
+        title: "Summary",
+        description: summaryDescription,
+      },
+      {
+        title: "Detailed Changes",
+        html: changesHtml,
+        text: textChanges.trim() ? textChanges.trim() : undefined,
+      },
+    ],
+    ctas: {
+      label: "View Employee Record",
+      href: sectionUrl,
+    },
+    outro: [
+      "This is an automated notification from PeopleCore HR System.",
+      "Please do not reply to this email. For assistance, contact your HR administrator.",
+    ],
+  });
 
   return { html, text };
 }

--- a/pages/api/set-password.ts
+++ b/pages/api/set-password.ts
@@ -3,6 +3,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
+import { resend } from "@/lib/resend";
+import { renderPeopleCoreEmail } from "@/lib/email/template";
 
 export default async function handler(
   req: NextApiRequest,
@@ -93,18 +95,25 @@ export default async function handler(
         .map((u) => u.email)
         .filter(Boolean) as string[];
       if (recipients.length) {
-        await fetch("https://api.resend.com/emails", {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            from: "noreply@peoplecore.co.nz",
-            to: recipients,
-            subject: "User activated their account",
-            html: `<p>${user.firstName || ""} ${user.lastName || ""} (${user.email}) has activated their account.</p>`,
-          }),
+        const actorName = `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email;
+        const { html, text } = renderPeopleCoreEmail({
+          preheader: `${actorName} activated their account`,
+          title: "Account Activation Notice",
+          intro: [
+            `Hello,`,
+            `${actorName} (${user.email}) has activated their PeopleCore account.`,
+          ],
+          outro: [
+            "You are receiving this notification because you are listed as an administrator.",
+          ],
+        });
+
+        await resend.emails.send({
+          from: "noreply@peoplecore.co.nz",
+          to: recipients,
+          subject: "User activated their account",
+          html,
+          text,
         });
       }
     } catch (e) {

--- a/public/peoplecore-logo.svg
+++ b/public/peoplecore-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" role="img" aria-labelledby="title desc">
+  <title id="title">PeopleCore</title>
+  <desc id="desc">PeopleCore wordmark in brand colors</desc>
+  <defs>
+    <linearGradient id="pcGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="50%" stop-color="#4f46e5" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="80" fill="white" rx="16" ry="16"/>
+  <g fill="url(#pcGradient)" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="40">
+    <text x="32" y="52">People</text>
+    <text x="184" y="52" fill="#0ea5e9">Core</text>
+  </g>
+  <circle cx="40" cy="28" r="10" fill="#38bdf8" opacity="0.4" />
+  <circle cx="60" cy="20" r="6" fill="#2563eb" opacity="0.6" />
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable PeopleCore email template helper with a shared brand wrapper, logo asset, and plain-text output
- refactor exit interview, leave, onboarding, activation, news, document, and expiry alert emails to build bodies through the helper (including a shared document notification builder)
- update transactional audit notifications to reuse the shared email chrome while keeping the change table intact

## Testing
- `npm run lint` *(fails: next binary missing because dependencies cannot be installed in the sandbox)*
- `npm test` *(fails: tsx binary missing because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d0542b20d08331b8308cce1f75f259