### PR TITLE
Use GlassSpinner while onboarding data loads

### DIFF
--- a/app/components/onboarding/EmployeeOnboardingPage.tsx
+++ b/app/components/onboarding/EmployeeOnboardingPage.tsx
@@ -7,6 +7,7 @@ import Button from "@/components/ui/Button";
 import { Progress } from "@/components/ui/progress";
 import OnboardingStepRenderer from "@/components/onboarding/OnboardingStepRenderer";
 import { OnboardingStep } from "@prisma/client";
+import { GlassSpinner } from "@/components/ui/LoadingSpinner";
 import {
   Select,
   SelectContent,
@@ -112,7 +113,11 @@ export default function EmployeeOnboardingPage({
   };
 
   if (loading) {
-    return <div className="p-8 text-lg">Loading onboarding…</div>;
+    return (
+      <div className="p-8 flex items-center justify-center">
+        <GlassSpinner size="lg" showText text="Loading onboarding…" />
+      </div>
+    );
   }
 
   if (!instance) {


### PR DESCRIPTION
## Summary
- import the GlassSpinner UI helper for onboarding
- show the spinner when onboarding data is loading while keeping page padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0de289c3c8331b4db12199c979c25