### PR TITLE
Handle onboarding error state with retry option

### DIFF
--- a/app/components/onboarding/EmployeeOnboardingPage.tsx
+++ b/app/components/onboarding/EmployeeOnboardingPage.tsx
@@ -120,6 +120,28 @@ export default function EmployeeOnboardingPage({
     );
   }
 
+  if (error) {
+    return (
+      <div className="p-8 flex items-center justify-center">
+        <Card className="max-w-xl w-full p-6 text-center space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold mb-1">
+              We couldn't load your onboarding.
+            </h2>
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Try again below. If the issue persists, please refresh the page or
+            contact your administrator.
+          </p>
+          <Button variant="secondary" onClick={fetchOnboarding}>
+            Retry loading onboarding
+          </Button>
+        </Card>
+      </div>
+    );
+  }
+
   if (!instance) {
     return (
       <div className="p-8 text-center">


### PR DESCRIPTION
## Summary
- render a dedicated error card when onboarding data fails to load so users see a clearer message
- add a secondary retry button that re-triggers onboarding fetching without a refresh
- keep the "no onboarding assigned" empty state for cases with no instance and no error

## Testing
- `npm run lint` *(fails: missing local Next.js binary because dependencies could not be installed due to npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e3f7d2f0833183a778ea1f8bf2e2