### PR TITLE
Use Next.js router for onboarding redirect

### DIFF
--- a/app/components/onboarding/EmployeeOnboardingPage.tsx
+++ b/app/components/onboarding/EmployeeOnboardingPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import { Progress } from "@/components/ui/progress";
@@ -43,12 +44,17 @@ export default function EmployeeOnboardingPage({
   canComplete = true,
 }: Props) {
   const { data: session } = useSession();
+  const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [instance, setInstance] = useState<OnboardingInstance | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [assigning, setAssigning] = useState(false);
   const [templates, setTemplates] = useState<any[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<string>("");
+
+  useEffect(() => {
+    router.prefetch("/dashboard");
+  }, [router]);
 
   const fetchOnboarding = async () => {
     setLoading(true);
@@ -236,7 +242,7 @@ export default function EmployeeOnboardingPage({
             <div className="text-lg font-bold text-green-700 mb-4">
               🎉 Onboarding Complete!
             </div>
-            <Button onClick={() => (window.location.href = "/dashboard")}>
+            <Button onClick={() => router.push("/dashboard")}>
               Go to Dashboard
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- use the Next.js router inside `EmployeeOnboardingPage` to keep navigation within the SPA
- prefetch and push the dashboard route when onboarding is complete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0ebdd9fb88331ac64df91e93b9335