### PR TITLE
Auto-select single onboarding template for admins

### DIFF
--- a/app/components/onboarding/EmployeeOnboardingPage.tsx
+++ b/app/components/onboarding/EmployeeOnboardingPage.tsx
@@ -80,7 +80,14 @@ export default function EmployeeOnboardingPage({
     const res = await fetch("/api/onboarding/templates");
     if (res.ok) {
       const data = await res.json();
-      setTemplates(data || []);
+      const templatesData = Array.isArray(data) ? data : [];
+      setTemplates(templatesData);
+      if (canAssignTemplate && templatesData.length === 1) {
+        const templateId = templatesData[0]?.id;
+        if (templateId) {
+          setSelectedTemplate((prev) => prev || templateId);
+        }
+      }
     }
   };
 
@@ -171,6 +178,11 @@ export default function EmployeeOnboardingPage({
                   ))}
                 </SelectContent>
               </Select>
+              {templates.length === 1 ? (
+                <p className="text-xs text-muted-foreground -mt-2 mb-4">
+                  Automatically selected because it's the only template.
+                </p>
+              ) : null}
               <Button onClick={handleAssignOnboarding} disabled={assigning}>
                 {assigning ? "Assigning..." : "Assign Onboarding"}
               </Button>


### PR DESCRIPTION
## Summary
- auto-select the only available onboarding template for admins without overriding existing selections
- show a helper caption explaining the automatic choice when a single template exists

## Testing
- npm run lint *(fails: Next CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d101b9937083319878b10eff4ed238