### PR TITLE
Use onboarding spinner while loading form

### DIFF
--- a/app/components/onboarding/OnboardingStepRenderer.tsx
+++ b/app/components/onboarding/OnboardingStepRenderer.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useSession } from "next-auth/react";
 import { DynamicFormRenderer } from "@/components/forms/DynamicFormRenderer";
 import { EnhancedFormRenderer } from "@/components/forms/EnhancedFormRenderer";
+import { GlassSpinner } from "@/components/ui/LoadingSpinner";
 import { toast } from "sonner";
 
 type OnboardingStepProps = {
@@ -224,7 +225,9 @@ export default function OnboardingStepRenderer({
           <Card className="p-4">
             <div className="mb-2 font-semibold">{title}</div>
             <div className="mb-3 text-sm">{desc}</div>
-            <div>Loading form...</div>
+            <div className="flex justify-center py-6">
+              <GlassSpinner showText text="Loading form…" />
+            </div>
           </Card>
         );
       }


### PR DESCRIPTION
## Summary
- import the shared GlassSpinner into the onboarding step renderer
- replace the temporary loading text with the centered GlassSpinner while forms load

## Testing
- npm run lint *(fails: next: not found in PATH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d101bc99d483318a5847b0c8270d60