### PR TITLE
Improve reports page resiliency and feedback

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
 import Button from "@/components/ui/Button";
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/Table";
+import { toast } from "@/hooks/use-toast";
 
 interface SavedReport {
   id: number;
@@ -31,23 +32,101 @@ interface SavedReport {
 export default function ReportsPage() {
   const [reports, setReports] = useState<SavedReport[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingIds, setDeletingIds] = useState<number[]>([]);
   const router = useRouter();
   const breadcrumbs = useBreadcrumbs();
 
-  useEffect(() => {
-    const fetchReports = async () => {
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
       const res = await fetch("/api/reports");
+
+      if (!res.ok) {
+        let message = "Failed to load reports.";
+        try {
+          const errorBody = await res.json();
+          message = errorBody?.error ?? message;
+        } catch (jsonError) {
+          console.error("Failed to parse reports error response", jsonError);
+          message = `${message} (${res.status})`;
+        }
+        throw new Error(message);
+      }
+
       const data = await res.json();
       setReports(data);
+      toast({
+        title: "Reports loaded",
+        description: "Saved reports are up to date.",
+      });
+    } catch (err) {
+      console.error("Failed to fetch reports", err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : "An unexpected error occurred while loading reports.";
+      setError(message);
+      toast({
+        title: "Unable to load reports",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
       setLoading(false);
-    };
-    fetchReports();
+    }
   }, []);
+
+  useEffect(() => {
+    void fetchReports();
+  }, [fetchReports]);
 
   const handleDelete = async (id: number) => {
     if (!confirm("Delete this report?")) return;
-    await fetch(`/api/reports/${id}`, { method: "DELETE" });
+    const previousReports = reports;
+    const reportToDelete = reports.find((report) => report.id === id);
+
+    setDeletingIds((prev) => [...prev, id]);
     setReports((prev) => prev.filter((r) => r.id !== id));
+
+    try {
+      const response = await fetch(`/api/reports/${id}`, { method: "DELETE" });
+
+      if (!response.ok) {
+        let message = "Failed to delete report.";
+        try {
+          const errorBody = await response.json();
+          message = errorBody?.error ?? message;
+        } catch (jsonError) {
+          console.error("Failed to parse delete error response", jsonError);
+          message = `${message} (${response.status})`;
+        }
+        throw new Error(message);
+      }
+
+      toast({
+        title: "Report deleted",
+        description: reportToDelete?.name
+          ? `${reportToDelete.name} has been removed.`
+          : "The report has been removed.",
+      });
+    } catch (err) {
+      console.error("Failed to delete report", err);
+      setReports(previousReports);
+      const message =
+        err instanceof Error
+          ? err.message
+          : "An unexpected error occurred while deleting the report.";
+      toast({
+        title: "Failed to delete report",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingIds((prev) => prev.filter((reportId) => reportId !== id));
+    }
   };
 
   if (loading) {
@@ -74,8 +153,8 @@ export default function ReportsPage() {
           <Button onClick={() => router.push("/reports/builder-new")}>
             + New Report Builder
           </Button>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={() => router.push("/reports/builder")}
           >
             Legacy Builder
@@ -83,15 +162,30 @@ export default function ReportsPage() {
         </div>
       }
     >
-      {reports.length === 0 ? (
-        <div className="text-center py-16">
-          <FileText className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
-          <p className="text-lg font-medium text-foreground mb-2">No saved reports found</p>
-          <p className="text-muted-foreground mb-6">Create your first report to get started</p>
-          <Button onClick={() => router.push("/reports/builder-new")}>
-            Create Report
-          </Button>
+      {error && (
+        <div className="mb-6 rounded-md border border-destructive/20 bg-destructive/10 p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-medium text-destructive">Unable to load reports</p>
+              <p className="text-sm text-destructive/80">{error}</p>
+            </div>
+            <Button variant="outline" onClick={() => void fetchReports()}>
+              Retry
+            </Button>
+          </div>
         </div>
+      )}
+      {reports.length === 0 ? (
+        error ? null : (
+          <div className="text-center py-16">
+            <FileText className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+            <p className="text-lg font-medium text-foreground mb-2">No saved reports found</p>
+            <p className="text-muted-foreground mb-6">Create your first report to get started</p>
+            <Button onClick={() => router.push("/reports/builder-new")}>
+              Create Report
+            </Button>
+          </div>
+        )
       ) : (
         <Table>
           <TableHeader>
@@ -141,9 +235,10 @@ export default function ReportsPage() {
                   </Button>
                   <Button
                     variant="ghost"
+                    disabled={deletingIds.includes(report.id)}
                     onClick={() => handleDelete(report.id)}
                   >
-                    Delete
+                    {deletingIds.includes(report.id) ? "Deleting..." : "Delete"}
                   </Button>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
## Summary
- add explicit error and deletion tracking state to the reports page
- harden report fetch/delete flows with retryable error handling, inline messaging, and toast feedback
- disable delete actions while pending and restore rows if an API failure occurs

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1173ed32883318e9c71dd50b61be0