### PR TITLE
Add pagination support to report preview

### DIFF
--- a/app/api/reports/query/route.ts
+++ b/app/api/reports/query/route.ts
@@ -110,34 +110,48 @@ export async function POST(req: Request) {
 			sort: translatedSort,
 		});
 
-		if (queries.length === 0) {
-			return NextResponse.json({ status: "success", message: "No data", data: [] });
-		}
+                if (queries.length === 0) {
+                        return NextResponse.json({ status: "success", message: "No data", data: [], total: 0 });
+                }
 
-		// Single primary dataset
-		const primary = queries[0];
-		const model = primary.model as keyof typeof prisma;
-		// @ts-ignore dynamic access
-		let results = await (prisma[model] as any).findMany(primary.prismaQuery);
-		results = await attachComputedFields(results, sanitizedSelectedFields, primary.model);
+                // Single primary dataset
+                const primary = queries[0];
+                const model = primary.model as keyof typeof prisma;
 
-		return NextResponse.json({
-			status: "success",
-			message: "Report generated successfully",
-			data: results,
-		});
+                const countArgs = primary.prismaQuery.where
+                        ? { where: primary.prismaQuery.where }
+                        : {};
+
+                // @ts-ignore dynamic access
+                const total = await (prisma[model] as any).count(countArgs);
+                // @ts-ignore dynamic access
+                let results = await (prisma[model] as any).findMany(primary.prismaQuery);
+                results = await attachComputedFields(results, sanitizedSelectedFields, primary.model);
+
+                return NextResponse.json({
+                        status: "success",
+                        message: "Report generated successfully",
+                        data: results,
+                        total,
+                });
 	} catch (error: any) {
 		console.error("🔥 Error in report query API:", error);
 		if (error instanceof z.ZodError) {
-			return NextResponse.json(
-				{ status: "error", message: "Invalid request body", details: error.flatten(), data: [] },
-				{ status: 400 },
-			);
-		}
-		return NextResponse.json(
-			{ status: "error", message: error?.message || "Internal server error", data: [] },
-			{ status: 500 },
-		);
-	}
+                        return NextResponse.json(
+                                {
+                                        status: "error",
+                                        message: "Invalid request body",
+                                        details: error.flatten(),
+                                        data: [],
+                                        total: 0,
+                                },
+                                { status: 400 },
+                        );
+                }
+                return NextResponse.json(
+                        { status: "error", message: error?.message || "Internal server error", data: [], total: 0 },
+                        { status: 500 },
+                );
+        }
 }
 

--- a/app/components/reports/FilterableDataTable.tsx
+++ b/app/components/reports/FilterableDataTable.tsx
@@ -12,7 +12,12 @@ interface Column {
 interface FilterableDataTableProps {
   columns: Column[];
   data: any[];
+  total?: number;
+  page?: number;
+  pageSize?: number;
   onFilteredDataChange?: (filteredData: any[]) => void;
+  onPageChange?: (page: number) => void;
+  onPageSizeChange?: (pageSize: number) => void;
 }
 
 interface ColumnFilter {
@@ -54,12 +59,72 @@ function detectColumnType(sampleValues: string[], data: any[], accessorKey: stri
   return "string";
 }
 
-export default function FilterableDataTable({ columns, data, onFilteredDataChange }: FilterableDataTableProps) {
+export default function FilterableDataTable({
+  columns,
+  data,
+  total,
+  page,
+  pageSize,
+  onFilteredDataChange,
+  onPageChange,
+  onPageSizeChange,
+}: FilterableDataTableProps) {
   const [columnFilters, setColumnFilters] = useState<ColumnFilter>({});
   const [advancedFilters, setAdvancedFilters] = useState<Record<string, AdvancedFilter>>({});
   const [openFilters, setOpenFilters] = useState<Set<string>>(new Set());
   const [hasError, setHasError] = useState(false);
   const tableRef = useRef<HTMLDivElement>(null);
+  const [internalPage, setInternalPage] = useState(page ?? 1);
+  const [internalPageSize, setInternalPageSize] = useState(pageSize ?? 50);
+
+  useEffect(() => {
+    if (typeof page === "number") {
+      setInternalPage(page);
+    }
+  }, [page]);
+
+  useEffect(() => {
+    if (typeof pageSize === "number") {
+      setInternalPageSize(pageSize);
+    }
+  }, [pageSize]);
+
+  const currentPage = page ?? internalPage;
+  const currentPageSize = pageSize ?? internalPageSize;
+  const hasTotal = typeof total === "number" && !Number.isNaN(total);
+  const totalCount = hasTotal ? total! : data.length;
+  const safePageSize = currentPageSize > 0 ? currentPageSize : 1;
+  const pageCount = Math.max(1, Math.ceil((totalCount || 0) / safePageSize));
+
+  const pageSizeOptions = useMemo(() => {
+    const presets = [10, 25, 50, 100];
+    if (!presets.includes(safePageSize)) {
+      presets.push(safePageSize);
+      presets.sort((a, b) => a - b);
+    }
+    return presets;
+  }, [safePageSize]);
+
+  const changePage = (nextPage: number) => {
+    if (nextPage < 1) return;
+    if (onPageChange) {
+      onPageChange(nextPage);
+    }
+    if (page === undefined) {
+      setInternalPage(nextPage);
+    }
+  };
+
+  const changePageSize = (nextPageSize: number) => {
+    if (nextPageSize <= 0) return;
+    if (onPageSizeChange) {
+      onPageSizeChange(nextPageSize);
+    }
+    if (pageSize === undefined) {
+      setInternalPageSize(nextPageSize);
+      setInternalPage(1);
+    }
+  };
 
   // Error boundary effect
   useEffect(() => {
@@ -207,6 +272,10 @@ export default function FilterableDataTable({ columns, data, onFilteredDataChang
 
     return result;
   }, [data, columnFilters, advancedFilters, columnTypes]);
+
+  const disablePrev = currentPage <= 1;
+  const disableNext = hasTotal ? currentPage >= pageCount : filteredData.length < safePageSize;
+  const currentPageDisplay = Math.min(currentPage, pageCount);
 
   // Notify parent component of filtered data changes
   useEffect(() => {
@@ -533,13 +602,53 @@ export default function FilterableDataTable({ columns, data, onFilteredDataChang
       {/* Footer Info */}
       <div className="flex justify-between items-center text-sm text-gray-500">
         <span>
-          Showing {filteredData.length} of {data.length} rows
+          Showing {filteredData.length} of {totalCount} rows
         </span>
         {getActiveFilterCount() > 0 && (
           <span>
             {getActiveFilterCount()} filter{getActiveFilterCount() !== 1 ? 's' : ''} applied
           </span>
         )}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-sm text-gray-600">
+        <label className="flex items-center gap-2">
+          <span>Rows per page:</span>
+          <select
+            value={safePageSize}
+            onChange={(event) => changePageSize(Number(event.target.value))}
+            className="px-3 py-1.5 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            aria-label="Rows per page"
+          >
+            {pageSizeOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => changePage(currentPage - 1)}
+            disabled={disablePrev}
+            className="px-3 py-1.5 border border-gray-300 rounded-md bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Previous page"
+          >
+            Previous
+          </button>
+          <span>
+            Page {currentPageDisplay} of {pageCount}
+          </span>
+          <button
+            onClick={() => changePage(currentPage + 1)}
+            disabled={disableNext}
+            className="px-3 py-1.5 border border-gray-300 rounded-md bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Next page"
+          >
+            Next
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/reports/preview/ReportsPreviewClient.tsx
+++ b/app/reports/preview/ReportsPreviewClient.tsx
@@ -48,7 +48,11 @@ export default function ReportsPreviewClient() {
 	const [reportConfig, setReportConfig] = useState<any>(null);
 
 	const [data, setData] = useState<any[]>([]);
-	const [filteredData, setFilteredData] = useState<any[]>([]);
+        const [filteredData, setFilteredData] = useState<any[]>([]);
+        const [page, setPage] = useState(1);
+        const [pageSize, setPageSize] = useState(50);
+        const [total, setTotal] = useState<number>(0);
+        const [exportingFull, setExportingFull] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const [loadingReport, setLoadingReport] = useState(false);
 	const [fieldLabels, setFieldLabels] = useState<Record<string, string>>({});
@@ -90,34 +94,53 @@ export default function ReportsPreviewClient() {
 		loadReport();
 	}, [reportIdParam]);
 
-	// Load report data when fields are available
-	useEffect(() => {
-		if (selectedFields.length === 0) return;
-		const fetchData = async () => {
-			setLoading(true);
-			try {
-				const res = await fetch("/api/reports/query", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						selectedFields,
-						filters: [],
-						pagination: { page: 1, limit: 50 },
-						sort: { field: selectedFields[0], direction: "asc" },
-					}),
-				});
-				const json = await res.json();
-				const results = Array.isArray(json.data) ? json.data : [];
-				setData([...results]);
-				setFilteredData([...results]);
-			} catch (error) {
-				console.error("❌ Error fetching report data:", error);
-			} finally {
-				setLoading(false);
-			}
-		};
-		fetchData();
-	}, [selectedFields]);
+        useEffect(() => {
+                setPage((prev) => (prev === 1 ? prev : 1));
+        }, [selectedFields.join(",")]);
+
+        const fetchReportPage = async (pageToFetch: number, limitToFetch: number) => {
+                const sortField = selectedFields[0];
+                const res = await fetch("/api/reports/query", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                                selectedFields,
+                                filters: [],
+                                pagination: { page: pageToFetch, limit: limitToFetch },
+                                sort: sortField ? { field: sortField, direction: "asc" } : undefined,
+                        }),
+                });
+                const json = await res.json();
+                const results = Array.isArray(json.data) ? json.data : [];
+                const totalCount = typeof json.total === "number" ? json.total : results.length;
+                return { results, totalCount };
+        };
+
+        // Load report data when fields are available
+        useEffect(() => {
+                if (selectedFields.length === 0) return;
+                let cancelled = false;
+                const fetchData = async () => {
+                        setLoading(true);
+                        try {
+                                const { results, totalCount } = await fetchReportPage(page, pageSize);
+                                if (cancelled) return;
+                                setData([...results]);
+                                setFilteredData([...results]);
+                                setTotal(totalCount);
+                        } catch (error) {
+                                console.error("❌ Error fetching report data:", error);
+                        } finally {
+                                if (!cancelled) {
+                                        setLoading(false);
+                                }
+                        }
+                };
+                fetchData();
+                return () => {
+                        cancelled = true;
+                };
+        }, [selectedFields, page, pageSize]);
 
 	const handleSaveReport = async () => {
 		const reportName = prompt("Enter a name for this report:");
@@ -201,17 +224,56 @@ export default function ReportsPreviewClient() {
 		return { header: label, accessorKey };
 	});
 
-	return (
-		<main className="p-6">
-			<h1 className="text-2xl font-bold mb-4">Report Preview</h1>
-			<p className="mb-4">Your custom report is displayed below. You can sort and filter as needed.</p>
-			<div className="flex gap-2 mb-4">
-				<Button onClick={() => downloadCSV(filteredData, columns)}>Download CSV ({filteredData.length} rows)</Button>
-				<Button onClick={handleSaveReport}>Save Report</Button>
-			</div>
-			<div className="min-h-[200px]">
-				<FilterableDataTable columns={columns} data={data} onFilteredDataChange={setFilteredData} />
-			</div>
-		</main>
-	);
+        return (
+                <main className="p-6">
+                        <h1 className="text-2xl font-bold mb-4">Report Preview</h1>
+                        <p className="mb-4">Your custom report is displayed below. You can sort and filter as needed.</p>
+                        <div className="flex gap-2 mb-4">
+                                <Button onClick={() => downloadCSV(filteredData, columns)}>Download CSV ({filteredData.length} rows)</Button>
+                                {total > data.length ? (
+                                        <Button
+                                                disabled={exportingFull}
+                                                onClick={async () => {
+                                                        if (exportingFull) return;
+                                                        setExportingFull(true);
+                                                        try {
+                                                                const combined: any[] = [];
+                                                                const pagesToFetch = Math.max(1, Math.ceil(total / pageSize));
+                                                                for (let currentPage = 1; currentPage <= pagesToFetch; currentPage++) {
+                                                                        const { results } = await fetchReportPage(currentPage, pageSize);
+                                                                        combined.push(...results);
+                                                                }
+                                                                downloadCSV(combined, columns);
+                                                        } catch (error) {
+                                                                console.error("❌ Error exporting full report:", error);
+                                                                alert("Failed to export full report. Please try again.");
+                                                        } finally {
+                                                                setExportingFull(false);
+                                                        }
+                                                }}
+                                        >
+                                                {exportingFull
+                                                        ? "Exporting full report..."
+                                                        : `Download Full CSV (${total} rows)`}
+                                        </Button>
+                                ) : null}
+                                <Button onClick={handleSaveReport}>Save Report</Button>
+                        </div>
+                        <div className="min-h-[200px]">
+                                <FilterableDataTable
+                                        columns={columns}
+                                        data={data}
+                                        total={total}
+                                        page={page}
+                                        pageSize={pageSize}
+                                        onFilteredDataChange={setFilteredData}
+                                        onPageChange={setPage}
+                                        onPageSizeChange={(size) => {
+                                                setPageSize(size);
+                                                setPage(1);
+                                        }}
+                                />
+                        </div>
+                </main>
+        );
 }

--- a/tests/filterableDataTablePagination.test.tsx
+++ b/tests/filterableDataTablePagination.test.tsx
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const columns = [{ header: "ID", accessorKey: "id" }];
+const data = [{ id: 1 }, { id: 2 }];
+
+test("FilterableDataTable renders pagination controls with totals", async () => {
+  const mod = await import("../app/components/reports/FilterableDataTable");
+  const html = renderToStaticMarkup(
+    React.createElement((mod as any).default, {
+      columns,
+      data,
+      total: 25,
+      page: 2,
+      pageSize: 10,
+    }),
+  );
+
+  assert(html.includes("Rows per page"));
+  assert(html.includes("Page 2 of 3"));
+  assert(html.includes("Showing 2 of 25 rows"));
+});

--- a/tests/reportsQueryRoute.test.ts
+++ b/tests/reportsQueryRoute.test.ts
@@ -6,11 +6,12 @@ import { POST as ReportsQueryPOST } from "@/app/api/reports/query/route";
 // Mocks
 const mockGetServerSession = mock.fn();
 const mockPrismaFindMany = mock.fn();
+const mockPrismaCount = mock.fn();
 const mockPrisma = new Proxy(
   {},
   {
-    get: (_target, prop) => {
-      return { findMany: mockPrismaFindMany };
+    get: () => {
+      return { findMany: mockPrismaFindMany, count: mockPrismaCount };
     },
   },
 );
@@ -27,6 +28,8 @@ describe("/api/reports/query route", () => {
   beforeEach(() => {
     mockGetServerSession.mock.resetCalls();
     mockPrismaFindMany.mock.resetCalls();
+    mockPrismaCount.mock.resetCalls();
+    mockPrismaCount.mock.mockImplementation(() => Promise.resolve(0));
   });
 
   it("rejects unauthenticated users", async () => {
@@ -44,6 +47,7 @@ describe("/api/reports/query route", () => {
       Promise.resolve({ user: { id: "u1", companyId: "c1" } }),
     );
     mockPrismaFindMany.mock.mockImplementationOnce(() => Promise.resolve([]));
+    mockPrismaCount.mock.mockImplementationOnce(() => Promise.resolve(4));
 
     const req = new NextRequest("http://localhost:3000/api/reports/query", {
       method: "POST",
@@ -63,6 +67,11 @@ describe("/api/reports/query route", () => {
     const args = mockPrismaFindMany.mock.calls[0].arguments[0];
     assert(args);
     assert.deepStrictEqual(args.where.email, { contains: "@corp", mode: "insensitive" });
+    const countArgs = mockPrismaCount.mock.calls[0].arguments[0];
+    assert(countArgs);
+    assert.deepStrictEqual(countArgs.where.email, { contains: "@corp", mode: "insensitive" });
+    const json = await res.json();
+    assert.strictEqual(json.total, 4);
   });
 
   it("maps number and boolean operators and nested orderBy", async () => {
@@ -70,6 +79,7 @@ describe("/api/reports/query route", () => {
       Promise.resolve({ user: { id: "u1", companyId: "c1" } }),
     );
     mockPrismaFindMany.mock.mockImplementationOnce(() => Promise.resolve([]));
+    mockPrismaCount.mock.mockImplementationOnce(() => Promise.resolve(2));
 
     const req = new NextRequest("http://localhost:3000/api/reports/query", {
       method: "POST",
@@ -90,6 +100,8 @@ describe("/api/reports/query route", () => {
     assert.deepStrictEqual(args.where.salaryAmount, { gt: 50000 });
     assert.deepStrictEqual(args.where.isActive, { equals: true });
     assert.deepStrictEqual(args.orderBy, { salaryAmount: "desc" });
+    const json = await res.json();
+    assert.strictEqual(json.total, 2);
   });
 
   it("maps date_between operator correctly", async () => {
@@ -97,6 +109,7 @@ describe("/api/reports/query route", () => {
       Promise.resolve({ user: { id: "u1", companyId: "c1" } }),
     );
     mockPrismaFindMany.mock.mockImplementationOnce(() => Promise.resolve([]));
+    mockPrismaCount.mock.mockImplementationOnce(() => Promise.resolve(1));
 
     const req = new NextRequest("http://localhost:3000/api/reports/query", {
       method: "POST",
@@ -114,6 +127,31 @@ describe("/api/reports/query route", () => {
     assert(args);
     assert(args.where.startDate.gte instanceof Date);
     assert(args.where.startDate.lte instanceof Date);
+    const json = await res.json();
+    assert.strictEqual(json.total, 1);
+  });
+
+  it("returns total count alongside page data", async () => {
+    mockGetServerSession.mock.mockImplementationOnce(() =>
+      Promise.resolve({ user: { id: "u1", companyId: "c1" } }),
+    );
+    const rows = [{ id: "u1" }, { id: "u2" }];
+    mockPrismaFindMany.mock.mockImplementationOnce(() => Promise.resolve(rows));
+    mockPrismaCount.mock.mockImplementationOnce(() => Promise.resolve(15));
+
+    const req = new NextRequest("http://localhost:3000/api/reports/query", {
+      method: "POST",
+      body: JSON.stringify({
+        selectedFields: ["User.id"],
+        pagination: { page: 2, limit: 2 },
+      }),
+    });
+
+    const res = await ReportsQueryPOST(req);
+    assert.strictEqual(res.status, 200);
+    const json = await res.json();
+    assert.strictEqual(json.total, 15);
+    assert.deepStrictEqual(json.data, rows);
   });
 });
 
@@ -146,6 +184,7 @@ test("POST /api/reports/query restricts selectedFields to allowed reportFields",
         prisma: {
           User: {
             findMany: async (_args: any) => [{ id: "u1", email: "a@b.com" }],
+            count: async () => 1,
           },
         },
       };
@@ -183,9 +222,10 @@ test("POST /api/reports/query restricts selectedFields to allowed reportFields",
   assert.equal(res.status, 200);
   const data = await res.json();
   assert.equal(data.status, "success");
-  assert.ok(data.data.User);
-  assert.equal(data.data.User.length, 1);
-  assert.equal(Object.keys(data.data.User[0]).includes("password"), false);
+  assert.ok(Array.isArray(data.data));
+  assert.equal(data.data.length, 1);
+  assert.equal(Object.keys(data.data[0]).includes("password"), false);
+  assert.equal(data.total, 1);
   (Module as any)._load = originalLoad;
 });
 
@@ -201,6 +241,7 @@ test("POST /api/reports/query injects tenant filter for User.companyId", async (
               capturedWhere = args?.where;
               return [{ id: "u1", email: "a@b.com" }];
             },
+            count: async (_args: any) => 1,
           },
         },
       };


### PR DESCRIPTION
## Summary
- return total counts from the reports query endpoint alongside the rows
- add client-side pagination controls and full export workflow to the reports preview
- extend the filterable table with reusable pagination props and document the UI via tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d11761fb9483319d84111530c3e581