### PR TITLE
Add tenant branding context and update UI branding

### DIFF
--- a/app/activate/ActivateClient.tsx
+++ b/app/activate/ActivateClient.tsx
@@ -2,18 +2,26 @@
 
 import { useSearchParams, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
 
 export default function ActivateClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams?.get("token") ?? "";
   const redirect = searchParams?.get("redirect") ?? "/dashboard";
+  const { branding } = useTenantBranding();
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const brandName = branding.shortName || branding.name;
+  const brandInitials = branding.initials || brandName.slice(0, 2).toUpperCase();
+  const brandLogo = branding.squareLogoUrl || branding.logoUrl || null;
+  const activationHeadline = `Activate Your ${brandName} Account`;
+  const activationSubtitle = `Set your password to get started with ${brandName}`;
 
   // Derived validation flags
   const hasMinLength = password.length >= 6;
@@ -68,33 +76,23 @@ export default function ActivateClient() {
       <div className="w-full max-w-md bg-white p-8 shadow-xl rounded-2xl">
         <div className="text-center mb-6">
           <div className="flex justify-center mb-3">
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 100 100"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect width="100" height="100" rx="20" fill="#000" />
-              <text
-                x="50%"
-                y="55%"
-                textAnchor="middle"
-                fill="white"
-                fontSize="28"
-                fontFamily="Arial, sans-serif"
-                dy=".3em"
-              >
-                PC
-              </text>
-            </svg>
+            {brandLogo ? (
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gray-900/5">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={brandLogo}
+                  alt={`${brandName} logo`}
+                  className="h-10 w-10 object-contain"
+                />
+              </div>
+            ) : (
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-black text-white text-xl font-semibold">
+                {brandInitials}
+              </div>
+            )}
           </div>
-          <h1 className="text-xl font-bold text-gray-900">
-            Activate Your PeopleCore Account
-          </h1>
-          <p className="text-sm text-gray-500">
-            Set your password to get started
-          </p>
+          <h1 className="text-xl font-bold text-gray-900">{activationHeadline}</h1>
+          <p className="text-sm text-gray-500">{activationSubtitle}</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/app/components/Providers.tsx
+++ b/app/components/Providers.tsx
@@ -6,31 +6,36 @@ import { Toaster } from "sonner";
 import ErrorBoundary from "./ErrorBoundary";
 import ChunkErrorHandler from "./ChunkErrorHandler";
 import { CommandPaletteMount } from "./CommandPaletteMount";
+import { TenantBrandingProvider } from "./TenantBrandingProvider";
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
     <ErrorBoundary>
       <ChunkErrorHandler />
       <SessionProvider>
-        {children}
-        <Toaster
-          position="bottom-right"
-          richColors
-          closeButton
-          toastOptions={{
-            className: "shadow-glass border-glass rounded-2xl",
-            style: {
-              background: "rgba(255, 255, 255, 0.8)",
-              backdropFilter: "blur(16px)",
-              color: "hsl(var(--card-foreground))",
-              border: "1px solid rgba(255, 255, 255, 0.4)",
-            },
-          }}
-        />
-        <CommandPaletteMount />
+        <TenantBrandingProvider>
+          {children}
+          <Toaster
+            position="bottom-right"
+            richColors
+            closeButton
+            toastOptions={{
+              className: "shadow-glass border-glass rounded-2xl",
+              style: {
+                background: "rgba(255, 255, 255, 0.8)",
+                backdropFilter: "blur(16px)",
+                color: "hsl(var(--card-foreground))",
+                border: "1px solid rgba(255, 255, 255, 0.4)",
+              },
+            }}
+          />
+          <CommandPaletteMount />
+        </TenantBrandingProvider>
       </SessionProvider>
     </ErrorBoundary>
   );
 }
+
+export { useTenantBranding } from "./TenantBrandingProvider";
 
 

--- a/app/components/TenantBrandingProvider.tsx
+++ b/app/components/TenantBrandingProvider.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useSession } from "next-auth/react";
+import {
+  extractBrandingFromSession,
+  normalizeTenantBranding,
+  requestTenantBranding,
+  type TenantBranding,
+  type TenantBrandingInput,
+} from "@/lib/tenant-branding";
+
+type TenantBrandingContextValue = {
+  branding: TenantBranding;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<TenantBranding>;
+};
+
+const TenantBrandingContext =
+  createContext<TenantBrandingContextValue | undefined>(undefined);
+
+interface TenantBrandingProviderProps {
+  children: ReactNode;
+  initialBranding?: TenantBrandingInput;
+}
+
+export function TenantBrandingProvider({
+  children,
+  initialBranding,
+}: TenantBrandingProviderProps) {
+  const { data: session, status } = useSession();
+  const [branding, setBranding] = useState<TenantBranding>(() =>
+    normalizeTenantBranding(initialBranding),
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(!initialBranding);
+  const [error, setError] = useState<string | null>(null);
+
+  const sessionBranding = useMemo(
+    () => extractBrandingFromSession(session),
+    [session],
+  );
+
+  useEffect(() => {
+    if (sessionBranding) {
+      setBranding(sessionBranding);
+      setIsLoading(false);
+      setError(null);
+    }
+  }, [sessionBranding]);
+
+  useEffect(() => {
+    if (sessionBranding || status === "loading") {
+      if (sessionBranding) {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadBrandingFromApi = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const apiBranding = await requestTenantBranding();
+        if (!cancelled) {
+          setBranding(apiBranding);
+        }
+      } catch (caught) {
+        if (!cancelled) {
+          console.error(
+            "[tenant-branding] Failed to fetch tenant branding",
+            caught,
+          );
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Failed to load tenant branding",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadBrandingFromApi();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionBranding, status]);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const apiBranding = await requestTenantBranding();
+      setBranding(apiBranding);
+      return apiBranding;
+    } catch (caught) {
+      console.error(
+        "[tenant-branding] Failed to refresh tenant branding",
+        caught,
+      );
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Failed to load tenant branding",
+      );
+      return branding;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [branding]);
+
+  const value = useMemo(
+    () => ({
+      branding,
+      isLoading,
+      error,
+      refresh,
+    }),
+    [branding, isLoading, error, refresh],
+  );
+
+  return (
+    <TenantBrandingContext.Provider value={value}>
+      {children}
+    </TenantBrandingContext.Provider>
+  );
+}
+
+export function useTenantBranding(): TenantBrandingContextValue {
+  const context = useContext(TenantBrandingContext);
+
+  if (!context) {
+    throw new Error(
+      "useTenantBranding must be used within a TenantBrandingProvider",
+    );
+  }
+
+  return context;
+}

--- a/app/components/sidebars/AdminSidebar.tsx
+++ b/app/components/sidebars/AdminSidebar.tsx
@@ -19,11 +19,15 @@ import {
   X,
   LogOut,
 } from "lucide-react";
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
 
 export default function AdminSidebar() {
+  const { branding } = useTenantBranding();
   const [collapsed, setCollapsed] = useState(false);
   const toggleSidebar = () => setCollapsed(!collapsed);
   const pathname = usePathname();
+  const brandName = branding.shortName || branding.name;
+  const brandLogo = branding.squareLogoUrl || branding.logoUrl || null;
 
   return (
     <div
@@ -42,12 +46,21 @@ export default function AdminSidebar() {
               collapsed ? "opacity-0 w-0" : "opacity-100",
             )}
           >
-            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm">
-              <span className="text-primary-foreground font-bold text-lg">
-                P
-              </span>
+            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm overflow-hidden">
+              {brandLogo ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={brandLogo}
+                  alt={`${brandName} logo`}
+                  className="h-8 w-8 object-contain"
+                />
+              ) : (
+                <span className="text-primary-foreground font-bold text-lg">
+                  {branding.initials}
+                </span>
+              )}
             </div>
-            <h1 className="font-bold text-foreground text-2xl">PeopleCore</h1>
+            <h1 className="font-bold text-foreground text-2xl">{brandName}</h1>
           </div>
           <button
             onClick={toggleSidebar}

--- a/app/components/sidebars/EmployeeSidebar.tsx
+++ b/app/components/sidebars/EmployeeSidebar.tsx
@@ -6,9 +6,13 @@ import { usePathname } from "next/navigation";
 import { LogOut, LayoutDashboard, Calendar, Clock, User } from "lucide-react";
 import { signOut } from "next-auth/react";
 import clsx from "clsx";
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
 
 export default function EmployeeSidebar() {
+  const { branding } = useTenantBranding();
   const pathname = usePathname();
+  const brandName = branding.shortName || branding.name;
+  const brandLogo = branding.squareLogoUrl || branding.logoUrl || null;
 
   const navItems = [
     {
@@ -28,13 +32,22 @@ export default function EmployeeSidebar() {
         {/* Logo Section */}
         <div className="px-8 py-8 border-b border-glass">
           <div className="flex items-center">
-            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm">
-              <span className="text-primary-foreground font-bold text-lg">
-                P
-              </span>
+            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm overflow-hidden">
+              {brandLogo ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={brandLogo}
+                  alt={`${brandName} logo`}
+                  className="h-8 w-8 object-contain"
+                />
+              ) : (
+                <span className="text-primary-foreground font-bold text-lg">
+                  {branding.initials}
+                </span>
+              )}
             </div>
             <div>
-              <h2 className="text-2xl font-bold text-foreground">PeopleCore</h2>
+              <h2 className="text-2xl font-bold text-foreground">{brandName}</h2>
               <p className="text-sm text-muted-foreground">Employee Portal</p>
             </div>
           </div>

--- a/app/components/sidebars/ManagerSidebar.tsx
+++ b/app/components/sidebars/ManagerSidebar.tsx
@@ -5,9 +5,13 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { LogOut } from "lucide-react";
 import { signOut } from "next-auth/react";
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
 
 export default function ManagerSidebar() {
+  const { branding } = useTenantBranding();
   const pathname = usePathname();
+  const brandName = branding.shortName || branding.name;
+  const brandLogo = branding.squareLogoUrl || branding.logoUrl || null;
 
   const navItems = [
     { label: "Dashboard", href: "/dashboard" },
@@ -24,13 +28,22 @@ export default function ManagerSidebar() {
         {/* Logo Section */}
         <div className="px-8 py-8 border-b border-glass">
           <div className="flex items-center">
-            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm">
-              <span className="text-primary-foreground font-bold text-lg">
-                P
-              </span>
+            <div className="w-10 h-10 bg-primary rounded-2xl flex items-center justify-center mr-4 shadow-warm overflow-hidden">
+              {brandLogo ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={brandLogo}
+                  alt={`${brandName} logo`}
+                  className="h-8 w-8 object-contain"
+                />
+              ) : (
+                <span className="text-primary-foreground font-bold text-lg">
+                  {branding.initials}
+                </span>
+              )}
             </div>
             <div>
-              <h2 className="text-2xl font-bold text-foreground">PeopleCore</h2>
+              <h2 className="text-2xl font-bold text-foreground">{brandName}</h2>
               <p className="text-sm text-muted-foreground">Manager Panel</p>
             </div>
           </div>

--- a/app/lib/tenant-branding.ts
+++ b/app/lib/tenant-branding.ts
@@ -1,0 +1,188 @@
+import type { Session } from "next-auth";
+
+export type TenantBranding = {
+  /** Display name for the tenant. */
+  name: string;
+  /** Short display name that can be used in headings. */
+  shortName: string;
+  /** Initials rendered when a logo is unavailable. */
+  initials: string;
+  /** Full width logo for marketing/login screens. */
+  logoUrl?: string | null;
+  /** Square logo suitable for avatars or sidebar marks. */
+  squareLogoUrl?: string | null;
+  /** Optional brand accent colour. */
+  accentColor?: string | null;
+  /** Optional support email for contextual copy. */
+  supportEmail?: string | null;
+  /** Optional tagline or helper copy. */
+  tagline?: string | null;
+  /** Optional custom login headline. */
+  loginHeadline?: string | null;
+  /** Optional custom login subtitle. */
+  loginSubtitle?: string | null;
+};
+
+export type TenantBrandingInput = Partial<TenantBranding> | null | undefined;
+
+export const DEFAULT_TENANT_BRANDING: TenantBranding = {
+  name: "PeopleCore",
+  shortName: "PeopleCore",
+  initials: "PC",
+  logoUrl: "/peoplecore-logo.svg",
+  squareLogoUrl: "/peoplecore-logo.svg",
+  accentColor: null,
+  supportEmail: null,
+  tagline: null,
+  loginHeadline: null,
+  loginSubtitle: null,
+};
+
+export function computeInitials(
+  name: string | null | undefined,
+  fallback: string = DEFAULT_TENANT_BRANDING.initials,
+): string {
+  const value = name?.trim();
+  if (!value) {
+    return fallback;
+  }
+  const cleaned = value
+    // Replace any non letter/number characters with spaces so initials derive from readable words.
+    .replace(/[^\p{L}\p{N} ]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!cleaned) {
+    return fallback;
+  }
+
+  const parts = cleaned.split(" ");
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase() || fallback;
+  }
+
+  const initials = parts
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+
+  return initials || fallback;
+}
+
+export function normalizeTenantBranding(
+  input?: TenantBrandingInput,
+): TenantBranding {
+  if (!input) {
+    return { ...DEFAULT_TENANT_BRANDING };
+  }
+
+  const name = input.name?.trim() || DEFAULT_TENANT_BRANDING.name;
+  const shortName = input.shortName?.trim() || name;
+  const initials = computeInitials(
+    input.initials?.trim() || shortName,
+    DEFAULT_TENANT_BRANDING.initials,
+  );
+
+  const logoUrl =
+    input.logoUrl ?? DEFAULT_TENANT_BRANDING.logoUrl ?? undefined;
+  const squareLogoUrl =
+    input.squareLogoUrl ?? logoUrl ?? DEFAULT_TENANT_BRANDING.squareLogoUrl;
+
+  return {
+    ...DEFAULT_TENANT_BRANDING,
+    ...input,
+    name,
+    shortName,
+    initials,
+    logoUrl,
+    squareLogoUrl,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractBrandingCandidate(source: unknown): TenantBrandingInput {
+  if (!isRecord(source)) {
+    return null;
+  }
+
+  const tenantRecord = isRecord(source["tenant"]) ? source["tenant"] : null;
+  const companyRecord = isRecord(source["company"]) ? source["company"] : null;
+  const profileRecord = isRecord(source["profile"]) ? source["profile"] : null;
+
+  const candidate =
+    source["branding"] ??
+    source["tenantBranding"] ??
+    (tenantRecord ? tenantRecord["branding"] : undefined) ??
+    (companyRecord ? companyRecord["branding"] : undefined) ??
+    (profileRecord ? profileRecord["branding"] : undefined);
+
+  if (isRecord(candidate)) {
+    return candidate as TenantBrandingInput;
+  }
+
+  const nameCandidate =
+    source["tenantName"] ??
+    source["companyName"] ??
+    (companyRecord ? companyRecord["name"] : undefined) ??
+    (tenantRecord ? tenantRecord["name"] : undefined);
+
+  if (typeof nameCandidate === "string" && nameCandidate.trim().length > 0) {
+    return { name: nameCandidate };
+  }
+
+  return null;
+}
+
+export function extractBrandingFromSession(
+  session: Session | null | undefined,
+): TenantBranding | null {
+  if (!session) {
+    return null;
+  }
+
+  const directCandidate = extractBrandingCandidate(session);
+  if (directCandidate) {
+    return normalizeTenantBranding(directCandidate);
+  }
+
+  const userCandidate = extractBrandingCandidate(session.user);
+  if (userCandidate) {
+    return normalizeTenantBranding(userCandidate);
+  }
+
+  return null;
+}
+
+export async function requestTenantBranding(): Promise<TenantBranding> {
+  const response = await fetch("/api/tenant/branding", {
+    credentials: "include",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load tenant branding (${response.status})`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error("Unable to parse tenant branding response");
+  }
+
+  let brandingData: unknown = payload;
+  if (isRecord(payload) && "branding" in payload) {
+    brandingData = (payload as { branding?: unknown }).branding;
+  }
+
+  if (!isRecord(brandingData)) {
+    throw new Error("Tenant branding response was empty");
+  }
+
+  return normalizeTenantBranding(brandingData as TenantBrandingInput);
+}

--- a/app/login/LoginClient.tsx
+++ b/app/login/LoginClient.tsx
@@ -7,6 +7,7 @@ import { useState, FormEvent } from "react";
 import { FcGoogle } from "react-icons/fc";
 import { Input } from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
 
 const MicrosoftIcon = () => (
   <span className="grid h-5 w-5 grid-cols-2 gap-[2px]">
@@ -20,10 +21,17 @@ const MicrosoftIcon = () => (
 export default function LoginClient() {
   const router = useRouter();
   const search = useSearchParams();
+  const { branding } = useTenantBranding();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const brandName = branding.shortName || branding.name;
+  const logoSrc = branding.logoUrl || branding.squareLogoUrl || null;
+  const loginHeading = branding.loginHeadline?.trim() || brandName;
+  const loginSubtitle =
+    branding.loginSubtitle?.trim() || `Sign in to your ${brandName} account`;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -69,9 +77,19 @@ export default function LoginClient() {
     <div className="flex min-h-screen items-center justify-center bg-surface dark:bg-surface-dark px-4">
       <div className="w-full max-w-md rounded-2xl bg-white dark:bg-surface-dark p-8 shadow-sm transition-colors">
         <div className="mb-6 text-center">
-          <h1 className="text-2xl font-bold text-primary">PeopleCore</h1>
+          {logoSrc ? (
+            <div className="mb-3 flex justify-center">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={logoSrc}
+                alt={`${brandName} logo`}
+                className="h-12 w-auto"
+              />
+            </div>
+          ) : null}
+          <h1 className="text-2xl font-bold text-primary">{loginHeading}</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Sign in to your account
+            {loginSubtitle}
           </p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,23 @@
 "use client";
+
+import { useTenantBranding } from "@/components/TenantBrandingProvider";
+
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {
+  const { branding } = useTenantBranding();
+  const brandName = branding.shortName || branding.name;
+
   return (
     <div className="h-screen flex items-center justify-center text-center">
       <div>
-        <h1 className="text-3xl font-bold mb-4">Welcome to PeopleCore</h1>
+        <h1 className="text-3xl font-bold mb-4">Welcome to {brandName}</h1>
         <p className="text-gray-600">
           Please{" "}
           <a href="/login" className="text-blue-600 underline">
             log in
           </a>{" "}
-          to continue.
+          to access your {brandName} workspace.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add tenant branding utilities and a provider that reads from the session or `/api/tenant/branding`
- wrap the global provider tree with the tenant branding provider and export a `useTenantBranding` hook
- update login, activation, home, and sidebar components to render tenant-specific names or logos with PeopleCore fallbacks

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files as shown in the lint output)*

------
https://chatgpt.com/codex/tasks/task_e_68d187e474988331821947cbbd9da8ef