### PR TITLE
Add skeleton loading components and apply them to key pages

### DIFF
--- a/app/(withSidebar)/calendar/page.tsx
+++ b/app/(withSidebar)/calendar/page.tsx
@@ -9,6 +9,7 @@ import interactionPlugin from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
 import { PageShell } from "@/components/ui/PageShell";
 import { Card } from "@/components/ui/Card";
+import { SectionSkeleton } from "@/components/ui/PageSkeleton";
 import Button from "@/components/ui/Button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { List, CalendarDays, Trash2 } from "lucide-react";
@@ -619,7 +620,11 @@ export default function CalendarPage() {
         )}
         <div className="bg-white rounded-xl overflow-hidden">
           {loading ? (
-            <p className="p-4">Loading...</p>
+            <SectionSkeleton
+              showContainer={false}
+              rows={1}
+              lineClassName="h-[520px] w-full"
+            />
           ) : (
             <FullCalendar
               ref={calendarRef}

--- a/app/(withSidebar)/news/[slug]/edit/page.tsx
+++ b/app/(withSidebar)/news/[slug]/edit/page.tsx
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { uploadFileToSupabase } from "@/lib/news/uploadFileToSupabase";
 import dynamic from "next/dynamic";
 import AudienceSelector from "@/components/news/AudienceSelector";
+import { SectionSkeleton } from "@/components/ui/PageSkeleton";
 
 const NewsContentBuilder = dynamic(
   () => import("@/components/news/NewsContentBuilder"),
@@ -106,7 +107,21 @@ export default function EditNewsPostPage({ params }: Props) {
   };
 
   if (loading || status === "loading")
-    return <p className="p-4">Loading post…</p>;
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-10 space-y-8">
+        <SectionSkeleton
+          showContainer={false}
+          rows={1}
+          lineClassName="h-9 w-2/3"
+        />
+        <SectionSkeleton
+          showContainer={false}
+          rows={1}
+          lineClassName="h-64 w-full rounded-xl"
+        />
+        <SectionSkeleton showContainer={false} rows={4} />
+      </div>
+    );
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-10">

--- a/app/(withSidebar)/settings/leave-policies/page.tsx
+++ b/app/(withSidebar)/settings/leave-policies/page.tsx
@@ -41,6 +41,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { Plus, Edit, Trash2, Users, Calendar, Settings, AlertTriangle } from "lucide-react";
 import { PageShell } from "@/components/ui/PageShell";
+import { SectionSkeleton } from "@/components/ui/PageSkeleton";
 import { breadcrumbConfigs } from "@/components/ui/Breadcrumb";
 
 interface EventCategory {
@@ -295,12 +296,6 @@ export default function LeavePoliciesPage() {
     }));
   };
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">Loading...</div>
-    );
-  }
-
   return (
     <PageShell
       title="Leave Policies"
@@ -308,28 +303,47 @@ export default function LeavePoliciesPage() {
       breadcrumbs={breadcrumbConfigs.settingsSection('Leave Policies')}
       showHomeIcon={false}
     >
-      <div className="flex justify-end mb-6">
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger asChild>
-            <Button onClick={resetForm}>
-              <Plus className="w-4 h-4 mr-2" />
-              Add Policy
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>
-                {editingPolicy ? "Edit Leave Policy" : "Create Leave Policy"}
-              </DialogTitle>
-              <DialogDescription>
-                Configure accrual rates and rules for leave entitlements. This
-                affects only entitlement calculations - booking rules are
-                managed in Event Rules.
-              </DialogDescription>
-            </DialogHeader>
+      {loading ? (
+        <div className="space-y-6">
+          <div className="flex justify-end">
+            <SectionSkeleton
+              showContainer={false}
+              rows={1}
+              lineClassName="h-10 w-36 rounded-lg"
+            />
+          </div>
+          <SectionSkeleton
+            showHeader
+            variant="grid"
+            gridItems={4}
+            gridCols={2}
+          />
+          <SectionSkeleton showHeader variant="table" rows={5} />
+        </div>
+      ) : (
+        <>
+          <div className="flex justify-end mb-6">
+            <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+              <DialogTrigger asChild>
+                <Button onClick={resetForm}>
+                  <Plus className="w-4 h-4 mr-2" />
+                  Add Policy
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+                <DialogHeader>
+                  <DialogTitle>
+                    {editingPolicy ? "Edit Leave Policy" : "Create Leave Policy"}
+                  </DialogTitle>
+                  <DialogDescription>
+                    Configure accrual rates and rules for leave entitlements. This
+                    affects only entitlement calculations - booking rules are
+                    managed in Event Rules.
+                  </DialogDescription>
+                </DialogHeader>
 
-            <form onSubmit={handleSubmit} className="space-y-6">
-              <Tabs defaultValue="basic" className="w-full">
+                <form onSubmit={handleSubmit} className="space-y-6">
+                  <Tabs defaultValue="basic" className="w-full">
                 <TabsList className="grid w-full grid-cols-3">
                   <TabsTrigger value="basic">Basic Settings</TabsTrigger>
                   <TabsTrigger value="accrual">Accrual Rules</TabsTrigger>
@@ -785,6 +799,8 @@ export default function LeavePoliciesPage() {
           </div>
         )}
       </div>
+        </>
+      )}
     </PageShell>
   );
 }

--- a/app/(withSidebar)/settings/permissions/page.tsx
+++ b/app/(withSidebar)/settings/permissions/page.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { getScreenDisplayName } from "@/lib/permissions";
 import { PageShell } from "@/components/ui/PageShell";
+import { SectionSkeleton } from "@/components/ui/PageSkeleton";
 import { breadcrumbConfigs } from "@/components/ui/Breadcrumb";
 
 interface PermissionProfile {
@@ -236,7 +237,11 @@ export default function PermissionsPage() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div className="text-center py-8">Loading profiles...</div>
+            <SectionSkeleton
+              showContainer={false}
+              variant="table"
+              rows={5}
+            />
           ) : profiles.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
               No permission profiles found

--- a/app/components/ui/PageSkeleton.tsx
+++ b/app/components/ui/PageSkeleton.tsx
@@ -1,0 +1,213 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "./Skeleton";
+
+type GridColumnOption = 1 | 2 | 3 | 4;
+
+const GRID_COLUMNS: Record<GridColumnOption, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+};
+
+const LINE_WIDTHS = ["w-full", "w-11/12", "w-4/5", "w-2/3"];
+
+type SectionSkeletonVariant = "rows" | "grid" | "table";
+
+export interface SectionSkeletonProps {
+  /**
+   * Controls the general shape of the placeholders rendered inside the section.
+   * - `rows`: stacked text rows (default)
+   * - `grid`: grid of card placeholders (great for dashboards/forms)
+   * - `table`: table style rows with action buttons
+   */
+  variant?: SectionSkeletonVariant;
+  /** Number of row placeholders to render for `rows`/`table` variants. */
+  rows?: number;
+  /** Number of grid items to render when `variant` is `grid`. */
+  gridItems?: number;
+  /** Column configuration for grid placeholders. */
+  gridCols?: GridColumnOption;
+  /** Shows a header skeleton inside the card container. */
+  showHeader?: boolean;
+  /** Renders a button sized skeleton in the header area. */
+  showAction?: boolean;
+  /** Adds a toolbar style skeleton (search + actions) above the content. */
+  showToolbar?: boolean;
+  /** Wraps the skeletons with the standard card chrome. */
+  showContainer?: boolean;
+  /** Additional classes passed to the outer wrapper. */
+  className?: string;
+  /** Overrides the default height/width of row placeholders. */
+  lineClassName?: string;
+}
+
+export function SectionSkeleton({
+  variant = "rows",
+  rows = 4,
+  gridItems,
+  gridCols = 2,
+  showHeader = false,
+  showAction = false,
+  showToolbar = false,
+  showContainer = true,
+  className,
+  lineClassName,
+}: SectionSkeletonProps) {
+  const items = gridItems ?? rows;
+  const columnClass = GRID_COLUMNS[gridCols] ?? GRID_COLUMNS[2];
+
+  const toolbar = showToolbar ? (
+    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <Skeleton className="h-10 w-full rounded-lg md:w-72" />
+      <div className="flex flex-1 justify-end gap-2">
+        <Skeleton className="h-10 w-24 rounded-lg" />
+        <Skeleton className="h-10 w-24 rounded-lg" />
+      </div>
+    </div>
+  ) : null;
+
+  let body: ReactNode;
+
+  switch (variant) {
+    case "grid":
+      body = (
+        <div className={cn("grid gap-4", columnClass)}>
+          {Array.from({ length: items }).map((_, index) => (
+            <div
+              key={index}
+              className="space-y-3 rounded-xl border border-border bg-card/50 p-4"
+            >
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-10 w-full rounded-lg" />
+            </div>
+          ))}
+        </div>
+      );
+      break;
+    case "table":
+      body = (
+        <div className="space-y-3">
+          <div className="hidden items-center justify-between gap-4 rounded-xl border border-border bg-muted/20 px-4 py-3 md:flex">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+          {Array.from({ length: rows }).map((_, index) => (
+            <div
+              key={index}
+              className="grid grid-cols-2 gap-3 rounded-xl border border-border bg-card/50 px-4 py-4 md:grid-cols-6 md:items-center"
+            >
+              <Skeleton className="col-span-2 h-4 w-5/6 md:w-4/5" />
+              <Skeleton className="col-span-1 h-4 w-2/3" />
+              <Skeleton className="col-span-1 h-4 w-1/2" />
+              <Skeleton className="col-span-1 h-4 w-1/2" />
+              <div className="col-span-1 flex items-center justify-end gap-2">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-8 w-20 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+      break;
+    default:
+      body = (
+        <div className="space-y-3">
+          {Array.from({ length: rows }).map((_, index) => (
+            <Skeleton
+              key={index}
+              className={cn(
+                lineClassName ?? "h-4",
+                !lineClassName && LINE_WIDTHS[index % LINE_WIDTHS.length],
+              )}
+            />
+          ))}
+        </div>
+      );
+  }
+
+  if (showContainer) {
+    return (
+      <div
+        className={cn(
+          "rounded-2xl border border-border bg-card shadow-sm",
+          className,
+        )}
+      >
+        {(showHeader || showAction) && (
+          <div className="flex flex-col gap-3 border-b border-border px-6 py-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-40" />
+              {showHeader && <Skeleton className="h-4 w-64" />}
+            </div>
+            {showAction && <Skeleton className="h-10 w-28 rounded-lg" />}
+          </div>
+        )}
+        <div className="space-y-4 px-6 py-6">
+          {toolbar}
+          {body}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      {toolbar}
+      {body}
+    </div>
+  );
+}
+
+export interface PageSkeletonProps {
+  /** Optional list of sections to render inside the skeleton page. */
+  sections?: SectionSkeletonProps[];
+  /** Displays an action-sized skeleton in the page header. */
+  showHeaderAction?: boolean;
+  /** Shows a breadcrumb-sized skeleton above the page title. */
+  showBreadcrumb?: boolean;
+  /** Number of description lines to display under the title skeleton. */
+  headerLines?: number;
+  /** Additional classes applied to the page wrapper. */
+  className?: string;
+}
+
+export function PageSkeleton({
+  sections = [{}],
+  showHeaderAction = false,
+  showBreadcrumb = true,
+  headerLines = 2,
+  className,
+}: PageSkeletonProps) {
+  return (
+    <div className={cn("w-full min-h-screen bg-content-panel", className)}>
+      <div className="sticky top-0 z-10 border-b border-enhanced bg-content-panel backdrop-blur-sm">
+        <div className="px-8 py-6 space-y-4">
+          {showBreadcrumb && <Skeleton className="h-4 w-48" />}
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <Skeleton className="h-8 w-64" />
+              {Array.from({ length: Math.max(0, headerLines - 1) }).map(
+                (_, index) => (
+                  <Skeleton key={index} className="h-4 w-80" />
+                ),
+              )}
+            </div>
+            {showHeaderAction && <Skeleton className="h-10 w-36 rounded-lg" />}
+          </div>
+        </div>
+      </div>
+      <div className="px-8 py-6 space-y-6">
+        {sections.map((section, index) => (
+          <SectionSkeleton key={index} {...section} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/README.md
+++ b/app/components/ui/README.md
@@ -1,0 +1,57 @@
+# UI Skeletons
+
+The `PageSkeleton` and `SectionSkeleton` components provide reusable shimmering placeholders that match the layout patterns used across the app. Use them inside loading states and Suspense fallbacks instead of generic "Loading" text so that prefetching and navigation feel consistent.
+
+## SectionSkeleton
+
+`SectionSkeleton` is the workhorse placeholder. It can render stacked rows, table-style grids, or card grids depending on the `variant` you pick.
+
+```tsx
+import { SectionSkeleton } from "@/components/ui/PageSkeleton";
+
+// Table body loading state inside an existing Card
+<CardContent>
+  {isLoading ? (
+    <SectionSkeleton showContainer={false} variant="table" rows={5} />
+  ) : (
+    <Table>...</Table>
+  )}
+</CardContent>
+```
+
+Key props:
+
+- `variant`: `"rows" | "grid" | "table"` (defaults to `"rows"`).
+- `rows`: number of rows to render for the `rows`/`table` variants.
+- `gridItems` / `gridCols`: customise card grids.
+- `showContainer`: wrap the skeleton with the standard card chrome. Set to `false` when the parent already provides the card surface.
+- `showHeader`, `showAction`, `showToolbar`: opt-in skeletons for common header/toolbars.
+- `lineClassName`: override the default row height/width (handy for large content blocks like calendars or editors).
+
+## PageSkeleton
+
+`PageSkeleton` composes multiple `SectionSkeleton` instances and renders a page shell skeleton (title, optional breadcrumbs, header action). It is useful for Suspense fallbacks where no page content has rendered yet.
+
+```tsx
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+<Suspense
+  fallback={
+    <PageSkeleton
+      showHeaderAction
+      sections={[
+        { showHeader: true, variant: "grid", gridItems: 4, gridCols: 2 },
+        { showHeader: true, variant: "table", rows: 6, showToolbar: true },
+      ]}
+    />
+  }
+>
+  <ReportsPreviewClient />
+</Suspense>
+```
+
+### Usage notes
+
+- Match the structure of the loaded content: prefer a `grid` variant for filter/forms, a `table` variant for tabular data, and tall `lineClassName` overrides for large canvases (e.g. calendars or editors).
+- Keep `showContainer={false}` when dropping the skeleton inside an existing `Card` to avoid double borders.
+- Skeletons inherit the shimmering effect from the shared `Skeleton` primitive, so no extra animation wiring is needed.

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -2,4 +2,5 @@ export * from "./Button";
 export * from "./Card";
 export * from "./Input";
 export * from "./dialog";
+export * from "./PageSkeleton";
 

--- a/app/reports/preview/page.tsx
+++ b/app/reports/preview/page.tsx
@@ -1,11 +1,23 @@
 import { Suspense } from "react";
 import ReportsPreviewClient from "./ReportsPreviewClient";
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
 
 export default function ReportsPreviewPage() {
   return (
     <Suspense
       fallback={
-        <div className="p-6 text-center">Loading report preview...</div>
+        <PageSkeleton
+          showHeaderAction
+          showBreadcrumb={false}
+          sections={[
+            {
+              showHeader: true,
+              showToolbar: true,
+              variant: "table",
+              rows: 6,
+            },
+          ]}
+        />
       }
     >
       <ReportsPreviewClient />


### PR DESCRIPTION
## Summary
- add shared PageSkeleton and SectionSkeleton components for card-based loading placeholders
- document the skeleton usage pattern for future contributors
- replace existing text-only loading states on calendar, leave policies, permissions, news edit, and reports preview pages to use the new skeletons

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1880100fc83318ae942908f4fb318