### PR TITLE
Add tenant-aware date formatting helpers

### DIFF
--- a/app/(withSidebar)/Layout.tsx
+++ b/app/(withSidebar)/Layout.tsx
@@ -6,6 +6,9 @@ import { authOptions } from "@/lib/auth-options";
 import AdminSidebar from "@/components/sidebars/AdminSidebar";
 import ManagerSidebar from "@/components/sidebars/ManagerSidebar";
 import EmployeeSidebar from "@/components/sidebars/EmployeeSidebar";
+import { TenantProvider } from "@/components/TenantProvider";
+import { prisma } from "@/lib/prisma";
+import { resolveTenantDatePreferences } from "@/lib/datetime";
 
 export default async function WithSidebarLayout({
   children,
@@ -14,6 +17,18 @@ export default async function WithSidebarLayout({
 }) {
   const session = await getServerSession(authOptions);
   const role = session?.user?.role ?? "EMPLOYEE";
+  const companyId = session?.user?.companyId;
+
+  const company = companyId
+    ? await prisma.company.findUnique({
+        where: { id: companyId },
+        select: { publicHolidayTemplate: true },
+      })
+    : null;
+
+  const tenantPreferences = resolveTenantDatePreferences(
+    company?.publicHolidayTemplate ?? null,
+  );
 
   let Sidebar: React.ReactElement | null = null;
 
@@ -26,9 +41,11 @@ export default async function WithSidebarLayout({
   }
 
   return (
-    <div className="flex min-h-screen bg-app-background">
-      {Sidebar}
-      <main className="flex-1 overflow-y-auto">{children}</main>
-    </div>
+    <TenantProvider initialValue={tenantPreferences}>
+      <div className="flex min-h-screen bg-app-background">
+        {Sidebar}
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </TenantProvider>
   );
 }

--- a/app/(withSidebar)/calendar/page.tsx
+++ b/app/(withSidebar)/calendar/page.tsx
@@ -24,6 +24,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { Lock } from "lucide-react";
+import { useTenantSettings } from "@/components/TenantProvider";
+import { formatTenantDateRange } from "@/lib/datetime";
 
 interface Department {
   id: string;
@@ -31,6 +33,7 @@ interface Department {
 }
 
 export default function CalendarPage() {
+  const tenant = useTenantSettings();
   const [departments, setDepartments] = useState<Department[]>([]);
   const [selectedDepartment, setSelectedDepartment] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -423,7 +426,11 @@ export default function CalendarPage() {
           <div className="mt-3 space-y-1">
             {categoryName ? <Badge className="!text-[10px] !px-1.5 !py-0">{categoryName}</Badge> : null}
             <div className="text-xs text-gray-600">
-              {new Date(content.event.start!).toLocaleDateString()} – {new Date((content.event.end as any) || content.event.start!).toLocaleDateString()}
+              {formatTenantDateRange(
+                content.event.start!,
+                (content.event.end as any) ?? undefined,
+                { tenant },
+              )}
             </div>
             {content.event.extendedProps?.reason ? (
               <div className="text-xs text-gray-700">{String(content.event.extendedProps.reason)}</div>

--- a/app/(withSidebar)/dashboard/manager/page.tsx
+++ b/app/(withSidebar)/dashboard/manager/page.tsx
@@ -17,6 +17,8 @@ import {
 } from "lucide-react";
 import Button from "@/components/ui/Button";
 import Link from "next/link";
+import { useTenantSettings } from "@/components/TenantProvider";
+import { formatTenantDateRange } from "@/lib/datetime";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -61,6 +63,7 @@ function MetricsSummary() {
 }
 
 function PendingLeaveApprovals() {
+  const tenant = useTenantSettings();
   const { data, error, isLoading, mutate } = useSWR(
     "/api/leave-request?approvalStatus=PENDING",
     fetcher,
@@ -124,8 +127,10 @@ function PendingLeaveApprovals() {
                   </div>
                   <div className="text-muted-foreground">
                     {r.eventCategory?.name} —{" "}
-                    {new Date(r.startDate).toLocaleDateString()} to{" "}
-                    {new Date(r.endDate).toLocaleDateString()}
+                    {formatTenantDateRange(r.startDate, r.endDate, {
+                      tenant,
+                      separator: " to ",
+                    })}
                   </div>
                 </div>
                 <div className="flex gap-2">

--- a/app/(withSidebar)/offboarding/page.tsx
+++ b/app/(withSidebar)/offboarding/page.tsx
@@ -24,8 +24,9 @@ import {
   Calendar,
   User,
 } from "lucide-react";
-import { format } from "date-fns";
 import Link from "next/link";
+import { useTenantSettings } from "@/components/TenantProvider";
+import { formatTenantDate, formatTenantDateTime } from "@/lib/datetime";
 
 interface OffboardingRecord {
   id: string;
@@ -82,6 +83,7 @@ export default function OffboardingPage() {
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("all");
   const breadcrumbs = useBreadcrumbs();
+  const tenant = useTenantSettings();
 
   useEffect(() => {
     fetchOffboardingRecords();
@@ -290,7 +292,10 @@ export default function OffboardingPage() {
                       <span>Last Working Date</span>
                     </div>
                     <p className="font-medium">
-                      {format(new Date(record.lastWorkingDate), "MMM dd, yyyy")}
+                      {formatTenantDate(record.lastWorkingDate, {
+                        tenant,
+                        formatStr: "MMM dd, yyyy",
+                      })}
                     </p>
                   </div>
 
@@ -323,10 +328,10 @@ export default function OffboardingPage() {
                   <div className="mt-4 pt-4 border-t">
                     <p className="text-sm text-muted-foreground">
                       Completed on{" "}
-                      {format(
-                        new Date(record.completedAt),
-                        "MMM dd, yyyy 'at' h:mm a",
-                      )}
+                      {formatTenantDateTime(record.completedAt, {
+                        tenant,
+                        formatStr: "MMM dd, yyyy 'at' h:mm a",
+                      })}
                     </p>
                   </div>
                 )}

--- a/app/components/TenantProvider.tsx
+++ b/app/components/TenantProvider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import {
+  DEFAULT_TENANT_PREFERENCES,
+  resolveTenantDatePreferences,
+  type TenantDatePreferences,
+} from "@/lib/datetime";
+
+interface TenantProviderProps {
+  children: ReactNode;
+  initialValue?: TenantDatePreferences;
+}
+
+const TenantContext = createContext<TenantDatePreferences>(DEFAULT_TENANT_PREFERENCES);
+
+export function TenantProvider({ children, initialValue }: TenantProviderProps) {
+  const [value, setValue] = useState<TenantDatePreferences>(
+    initialValue ?? DEFAULT_TENANT_PREFERENCES,
+  );
+
+  useEffect(() => {
+    if (initialValue) {
+      setValue(initialValue);
+    }
+  }, [initialValue]);
+
+  useEffect(() => {
+    if (initialValue) return;
+
+    let active = true;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/public-holidays", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!active) return;
+        setValue(resolveTenantDatePreferences(data?.template ?? null));
+      } catch (error) {
+        console.error("Failed to resolve tenant preferences", error);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [initialValue]);
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>;
+}
+
+export function useTenantSettings() {
+  return useContext(TenantContext);
+}

--- a/app/components/dashboard/NewsWidget.tsx
+++ b/app/components/dashboard/NewsWidget.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import { DashboardWidget } from "@/components/ui/DashboardWidget";
 import { Megaphone } from "lucide-react";
 import Link from "next/link";
+import { useTenantSettings } from "@/components/TenantProvider";
+import { formatTenantDate } from "@/lib/datetime";
 
 interface NewsPost {
   id: string;
@@ -21,6 +23,7 @@ type NewsWidgetProps = {
 export function NewsWidget({ limit = 1 }: NewsWidgetProps) {
   const [items, setItems] = useState<NewsPost[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const tenant = useTenantSettings();
 
   useEffect(() => {
     const fetchLatestNews = async () => {
@@ -70,7 +73,7 @@ export function NewsWidget({ limit = 1 }: NewsWidgetProps) {
                         {post.title}
                       </h3>
                       <p className="text-white/80 text-xs mt-1">
-                        {new Date(post.createdAt).toLocaleDateString()}
+                        {formatTenantDate(post.createdAt, { tenant })}
                       </p>
                       {post.preview && (
                         <p className="text-white/90 text-sm mt-2 line-clamp-2">
@@ -105,7 +108,7 @@ export function NewsWidget({ limit = 1 }: NewsWidgetProps) {
                         {post.title}
                       </h3>
                       <p className="text-sm text-muted-foreground">
-                        {new Date(post.createdAt).toLocaleDateString()}
+                        {formatTenantDate(post.createdAt, { tenant })}
                       </p>
                       {post.preview && (
                         <p className="text-sm text-muted-foreground line-clamp-2">

--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -11,6 +11,8 @@ import { FormField, TableColumn, AnyFormSchema, normalizeToPages, FormPage, Form
 import { PageLoader } from "@/components/ui/LoadingSpinner";
 import HistoryButton from "@/components/audit/HistoryButton";
 import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import { useTenantSettings } from "@/components/TenantProvider";
+import { formatTenantDateTime } from "@/lib/datetime";
 
 interface EnhancedFormRendererProps {
   formId: string;
@@ -35,6 +37,7 @@ export function EnhancedFormRenderer({
   employeeId,
   onDataChange,
 }: EnhancedFormRendererProps) {
+  const tenant = useTenantSettings();
   const [formData, setFormData] = useState<FormDataShape | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -304,7 +307,7 @@ export function EnhancedFormRenderer({
           )}
           {formData.lastUpdated && (
             <span>
-              Last updated: {new Date(formData.lastUpdated).toLocaleString()}
+              Last updated: {formatTenantDateTime(formData.lastUpdated ?? "", { tenant })}
             </span>
           )}
         </div>

--- a/app/lib/datetime.ts
+++ b/app/lib/datetime.ts
@@ -1,0 +1,132 @@
+import { formatInTimeZone, utcToZonedTime } from "date-fns-tz";
+import { isSameDay } from "date-fns";
+import type { Locale } from "date-fns";
+import { enAU, enGB, enNZ } from "date-fns/locale";
+
+export type TenantTemplate = "NZ" | "AU" | "UK" | "UNKNOWN";
+
+export interface TenantDatePreferences {
+  tenant: TenantTemplate;
+  locale: string;
+  timeZone: string;
+}
+
+export interface TenantDateFormatOptions {
+  tenant?: TenantDatePreferences;
+  formatStr?: string;
+}
+
+export interface TenantDateRangeFormatOptions extends TenantDateFormatOptions {
+  separator?: string;
+  endFormatStr?: string;
+}
+
+type DateInput = Date | string | number;
+
+type TemplateInput = TenantTemplate | "NZ" | "AU" | "UK" | string | null | undefined;
+
+const DEFAULT_TENANT_PREFERENCES: TenantDatePreferences = {
+  tenant: "NZ",
+  locale: "en-NZ",
+  timeZone: "Pacific/Auckland",
+};
+
+const localeMap: Record<string, Locale> = {
+  "en-NZ": enNZ,
+  "en-AU": enAU,
+  "en-GB": enGB,
+};
+
+function resolveLocale(localeCode: string): Locale {
+  return localeMap[localeCode] ?? enNZ;
+}
+
+function toDate(value: DateInput): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function resolveTenantDatePreferences(template: TemplateInput): TenantDatePreferences {
+  const normalized = typeof template === "string" ? template.toUpperCase() : template;
+
+  if (normalized === "AU") {
+    return { tenant: "AU", locale: "en-AU", timeZone: "Australia/Sydney" };
+  }
+
+  if (normalized === "UK") {
+    return { tenant: "UK", locale: "en-GB", timeZone: "Europe/London" };
+  }
+
+  if (normalized === "NZ") {
+    return { tenant: "NZ", locale: "en-NZ", timeZone: "Pacific/Auckland" };
+  }
+
+  return { ...DEFAULT_TENANT_PREFERENCES, tenant: "UNKNOWN" };
+}
+
+export function formatTenantDate(
+  date: DateInput,
+  options: TenantDateFormatOptions = {},
+): string {
+  const tenant = options.tenant ?? DEFAULT_TENANT_PREFERENCES;
+  const parsed = toDate(date);
+  if (!parsed) return "Invalid Date";
+
+  const formatStr = options.formatStr ?? "P";
+  const locale = resolveLocale(tenant.locale);
+
+  return formatInTimeZone(parsed, tenant.timeZone, formatStr, { locale });
+}
+
+export function formatTenantDateTime(
+  date: DateInput,
+  options: TenantDateFormatOptions = {},
+): string {
+  const tenant = options.tenant ?? DEFAULT_TENANT_PREFERENCES;
+  const parsed = toDate(date);
+  if (!parsed) return "Invalid Date";
+
+  const formatStr = options.formatStr ?? "Pp";
+  const locale = resolveLocale(tenant.locale);
+
+  return formatInTimeZone(parsed, tenant.timeZone, formatStr, { locale });
+}
+
+export function formatTenantDateRange(
+  start: DateInput,
+  end: DateInput | null | undefined,
+  options: TenantDateRangeFormatOptions = {},
+): string {
+  const tenant = options.tenant ?? DEFAULT_TENANT_PREFERENCES;
+  const parsedStart = toDate(start);
+  const parsedEnd = end != null ? toDate(end) : null;
+
+  if (!parsedStart) return "Invalid Date";
+  if (!parsedEnd) {
+    return formatTenantDate(parsedStart, options);
+  }
+
+  const startZoned = utcToZonedTime(parsedStart, tenant.timeZone);
+  const endZoned = utcToZonedTime(parsedEnd, tenant.timeZone);
+
+  const sameDay = isSameDay(startZoned, endZoned);
+  if (sameDay) {
+    return formatTenantDate(parsedStart, options);
+  }
+
+  const separator = options.separator ?? " – ";
+  const endFormat = options.endFormatStr ?? options.formatStr;
+
+  const startFormatted = formatTenantDate(parsedStart, options);
+  const endFormatted = formatTenantDate(parsedEnd, {
+    ...options,
+    formatStr: endFormat,
+  });
+
+  return `${startFormatted}${separator}${endFormatted}`;
+}
+
+export { DEFAULT_TENANT_PREFERENCES };

--- a/tests/datetime.test.ts
+++ b/tests/datetime.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_TENANT_PREFERENCES,
+  formatTenantDate,
+  formatTenantDateRange,
+  formatTenantDateTime,
+  resolveTenantDatePreferences,
+} from "@/lib/datetime";
+
+test("resolveTenantDatePreferences maps templates to locales and zones", () => {
+  const nz = resolveTenantDatePreferences("NZ");
+  assert.deepEqual(nz, {
+    tenant: "NZ",
+    locale: "en-NZ",
+    timeZone: "Pacific/Auckland",
+  });
+
+  const au = resolveTenantDatePreferences("AU");
+  assert.deepEqual(au, {
+    tenant: "AU",
+    locale: "en-AU",
+    timeZone: "Australia/Sydney",
+  });
+
+  const uk = resolveTenantDatePreferences("UK");
+  assert.deepEqual(uk, {
+    tenant: "UK",
+    locale: "en-GB",
+    timeZone: "Europe/London",
+  });
+
+  const fallback = resolveTenantDatePreferences("UNKNOWN");
+  assert.equal(fallback.tenant, "UNKNOWN");
+  assert.equal(fallback.locale, DEFAULT_TENANT_PREFERENCES.locale);
+  assert.equal(fallback.timeZone, DEFAULT_TENANT_PREFERENCES.timeZone);
+});
+
+test("formatTenantDate respects tenant time zones", () => {
+  const nz = resolveTenantDatePreferences("NZ");
+  const au = resolveTenantDatePreferences("AU");
+  const iso = "2024-03-15T12:30:00Z";
+
+  assert.equal(formatTenantDate(iso, { tenant: nz }), "16/03/2024");
+  assert.equal(formatTenantDate(iso, { tenant: au }), "15/03/2024");
+});
+
+test("formatTenantDateTime renders locale-aware timestamps", () => {
+  const nz = resolveTenantDatePreferences("NZ");
+  const au = resolveTenantDatePreferences("AU");
+  const iso = "2024-03-15T12:30:00Z";
+
+  assert.equal(formatTenantDateTime(iso, { tenant: nz }), "16/03/2024, 1:30 AM");
+  assert.equal(formatTenantDateTime(iso, { tenant: au }), "15/03/2024, 11:30 PM");
+});
+
+test("formatTenantDateRange collapses same-day ranges", () => {
+  const nz = resolveTenantDatePreferences("NZ");
+  const start = "2024-03-15T02:00:00Z";
+  const end = "2024-03-15T05:00:00Z";
+
+  assert.equal(formatTenantDateRange(start, end, { tenant: nz }), "15/03/2024");
+});
+
+test("formatTenantDateRange formats multi-day ranges", () => {
+  const nz = resolveTenantDatePreferences("NZ");
+  const start = "2024-03-15T12:30:00Z";
+  const end = "2024-03-16T12:30:00Z";
+
+  assert.equal(
+    formatTenantDateRange(start, end, { tenant: nz }),
+    "16/03/2024 – 17/03/2024",
+  );
+});
+
+test("formatTenantDate handles invalid dates", () => {
+  assert.equal(formatTenantDate(""), "Invalid Date");
+  assert.equal(formatTenantDateTime("not-a-date"), "Invalid Date");
+  assert.equal(formatTenantDateRange("not-a-date", null), "Invalid Date");
+});


### PR DESCRIPTION
## Summary
- add tenant date formatting utilities backed by date-fns-tz and map tenant templates to locales/timezones
- expose a TenantProvider and server layout wiring so client pages can access tenant-aware formatting helpers
- update dashboard, calendar, offboarding, forms, and news components to use the new helpers and cover behaviour with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d187f484248331aa322f6e93638d4c