### PR TITLE
feat(forms): add sticky action bar

### DIFF
--- a/app/(withSidebar)/settings/forms/exit-interview/new/page.tsx
+++ b/app/(withSidebar)/settings/forms/exit-interview/new/page.tsx
@@ -2,6 +2,12 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import {
+  Controller,
+  FormProvider,
+  useFieldArray,
+  useForm,
+} from "react-hook-form";
 import { PageShell } from "@/components/ui/PageShell";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
@@ -18,109 +24,119 @@ import {
 import { Checkbox } from "@/components/ui/Checkbox";
 import { toast } from "sonner";
 import { Plus, Trash2, Save } from "lucide-react";
+import { FormActionBar } from "@/components/forms/FormActionBar";
 
-interface FormField {
+interface TemplateField {
   id: string;
   type: string;
   label: string;
   required: boolean;
   placeholder?: string;
-  options?: string[];
+  options: string[];
 }
+
+interface ExitInterviewTemplateFormValues {
+  name: string;
+  description: string;
+  fields: TemplateField[];
+}
+
+const FIELD_TYPE_OPTIONS = [
+  { value: "text", label: "Text" },
+  { value: "textarea", label: "Long Text" },
+  { value: "email", label: "Email" },
+  { value: "select", label: "Dropdown" },
+  { value: "radio", label: "Radio Buttons" },
+  { value: "checkbox", label: "Checkboxes" },
+];
 
 export default function NewExitInterviewTemplatePage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [formData, setFormData] = useState({
-    name: "",
-    description: "",
+
+  const form = useForm<ExitInterviewTemplateFormValues>({
+    defaultValues: {
+      name: "",
+      description: "",
+      fields: [],
+    },
   });
-  const [fields, setFields] = useState<FormField[]>([]);
+
+  const {
+    control,
+    handleSubmit,
+    register,
+    setValue,
+    watch,
+    formState: { errors },
+  } = form;
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "fields",
+  });
 
   const breadcrumbItems = [
-    { label: 'Settings', href: '/settings' },
-    { label: 'Forms & Surveys', href: '/settings/forms' },
-    { label: 'Exit Interview Forms', href: '/settings/forms/exit-interview' },
-    { label: 'New Template', isCurrentPage: true }
-  ]
+    { label: "Settings", href: "/settings" },
+    { label: "Forms & Surveys", href: "/settings/forms" },
+    { label: "Exit Interview Forms", href: "/settings/forms/exit-interview" },
+    { label: "New Template", isCurrentPage: true },
+  ];
 
   const addField = () => {
-    const newField: FormField = {
-      id: `field_${Date.now()}`,
-      type: "text",
-      label: "",
-      required: false,
-      placeholder: "",
-    };
-    setFields([...fields, newField]);
-  };
-
-  const updateField = (index: number, updates: Partial<FormField>) => {
-    const updatedFields = [...fields];
-    updatedFields[index] = { ...updatedFields[index], ...updates };
-    setFields(updatedFields);
-  };
-
-  const removeField = (index: number) => {
-    setFields(fields.filter((_, i) => i !== index));
+    append(
+      {
+        id: `field_${Date.now()}`,
+        type: "text",
+        label: "",
+        required: false,
+        placeholder: "",
+        options: [],
+      },
+      { shouldDirty: true },
+    );
   };
 
   const addOption = (fieldIndex: number) => {
-    const updatedFields = [...fields];
-    if (!updatedFields[fieldIndex].options) {
-      updatedFields[fieldIndex].options = [];
-    }
-    updatedFields[fieldIndex].options!.push("");
-    setFields(updatedFields);
-  };
-
-  const updateOption = (
-    fieldIndex: number,
-    optionIndex: number,
-    value: string,
-  ) => {
-    const updatedFields = [...fields];
-    if (updatedFields[fieldIndex].options) {
-      updatedFields[fieldIndex].options![optionIndex] = value;
-      setFields(updatedFields);
-    }
+    const currentOptions = watch(`fields.${fieldIndex}.options`) || [];
+    setValue(
+      `fields.${fieldIndex}.options`,
+      [...currentOptions, ""],
+      { shouldDirty: true, shouldTouch: true },
+    );
   };
 
   const removeOption = (fieldIndex: number, optionIndex: number) => {
-    const updatedFields = [...fields];
-    if (updatedFields[fieldIndex].options) {
-      updatedFields[fieldIndex].options!.splice(optionIndex, 1);
-      setFields(updatedFields);
-    }
+    const currentOptions = watch(`fields.${fieldIndex}.options`) || [];
+    setValue(
+      `fields.${fieldIndex}.options`,
+      currentOptions.filter((_, i) => i !== optionIndex),
+      { shouldDirty: true, shouldTouch: true },
+    );
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!formData.name.trim()) {
+  const onSubmit = handleSubmit(async (values) => {
+    if (!values.name.trim()) {
       toast.error("Template name is required");
       return;
     }
 
-    if (fields.length === 0) {
+    if (values.fields.length === 0) {
       toast.error("At least one field is required");
       return;
     }
 
-    // Validate fields
-    for (const field of fields) {
+    for (const field of values.fields) {
       if (!field.label.trim()) {
         toast.error("All fields must have a label");
         return;
       }
 
       if (
-        (field.type === "select" ||
-          field.type === "checkbox" ||
-          field.type === "radio") &&
-        (!field.options || field.options.length === 0)
+        (field.type === "select" || field.type === "checkbox" || field.type === "radio") &&
+        (!field.options || field.options.filter((opt) => opt.trim() !== "").length === 0)
       ) {
-        toast.error(`${field.label} must have at least one option`);
+        toast.error(`${field.label || "This field"} must have at least one option`);
         return;
       }
     }
@@ -129,7 +145,7 @@ export default function NewExitInterviewTemplatePage() {
       setLoading(true);
 
       const schemaJson = {
-        fields: fields.map((field) => ({
+        fields: values.fields.map((field) => ({
           ...field,
           options: field.options?.filter((opt) => opt.trim() !== ""),
         })),
@@ -141,253 +157,240 @@ export default function NewExitInterviewTemplatePage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          name: formData.name,
-          description: formData.description,
+          name: values.name,
+          description: values.description,
           schemaJson,
         }),
       });
 
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || "Failed to create template");
+        const error = await response.json().catch(() => null);
+        throw new Error(error?.error || "Failed to create template");
       }
 
       toast.success("Template created successfully");
       router.push("/settings/forms/exit-interview");
     } catch (error) {
       console.error("Error creating template:", error);
-      toast.error(
-        error instanceof Error ? error.message : "Failed to create template",
-      );
+      toast.error(error instanceof Error ? error.message : "Failed to create template");
     } finally {
       setLoading(false);
     }
-  };
+  });
 
   return (
-    <PageShell
-      title="New Exit Interview Template"
-      description="Create a new exit interview form template"
-      breadcrumbs={{ items: breadcrumbItems }}
-      showHomeIcon={false}
-    >
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Template Information</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <Label htmlFor="name">Template Name *</Label>
-              <Input
-                id="name"
-                value={formData.name}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, name: e.target.value }))
-                }
-                placeholder="e.g., Standard Exit Interview"
-                required
-              />
-            </div>
-
-            <div>
-              <Label htmlFor="description">Description</Label>
-              <Textarea
-                id="description"
-                value={formData.description}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    description: e.target.value,
-                  }))
-                }
-                placeholder="Optional description of this template"
-                rows={3}
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              Form Fields
-              <Button type="button" onClick={addField} size="sm">
-                <Plus className="mr-2 h-4 w-4" />
-                Add Field
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {fields.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
-                <p>No fields added yet. Click "Add Field" to get started.</p>
+    <FormProvider {...form}>
+      <PageShell
+        title="New Exit Interview Template"
+        description="Create a new exit interview form template"
+        breadcrumbs={{ items: breadcrumbItems }}
+        showHomeIcon={false}
+      >
+        <form onSubmit={onSubmit} className="space-y-6 pb-32">
+          <Card>
+            <CardHeader>
+              <CardTitle>Template Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label htmlFor="name">Template Name *</Label>
+                <Input
+                  id="name"
+                  placeholder="e.g., Standard Exit Interview"
+                  {...register("name", { required: "Template name is required" })}
+                />
+                {errors.name && (
+                  <p className="mt-1 text-sm text-destructive">{errors.name.message}</p>
+                )}
               </div>
-            ) : (
-              <div className="space-y-6">
-                {fields.map((field, index) => (
-                  <div
-                    key={field.id}
-                    className="border rounded-lg p-4 space-y-4"
-                  >
-                    <div className="flex items-center justify-between">
-                      <h4 className="font-medium">Field {index + 1}</h4>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => removeField(index)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div>
-                        <Label>Field Type</Label>
-                        <Select
-                          value={field.type}
-                          onValueChange={(value) =>
-                            updateField(index, { type: value })
-                          }
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="text">Text</SelectItem>
-                            <SelectItem value="textarea">Long Text</SelectItem>
-                            <SelectItem value="email">Email</SelectItem>
-                            <SelectItem value="select">Dropdown</SelectItem>
-                            <SelectItem value="radio">Radio Buttons</SelectItem>
-                            <SelectItem value="checkbox">Checkboxes</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
+              <div>
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  rows={3}
+                  placeholder="Optional description of this template"
+                  {...register("description")}
+                />
+              </div>
+            </CardContent>
+          </Card>
 
-                      <div>
-                        <Label>Required</Label>
-                        <div className="flex items-center space-x-2 mt-2">
-                          <Checkbox
-                            id={`required-${index}`}
-                            checked={field.required}
-                            onCheckedChange={(checked) =>
-                              updateField(index, {
-                                required: checked as boolean,
-                              })
-                            }
-                          />
-                          <Label
-                            htmlFor={`required-${index}`}
-                            className="text-sm"
-                          >
-                            Required field
-                          </Label>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div>
-                      <Label>Field Label *</Label>
-                      <Input
-                        value={field.label}
-                        onChange={(e) =>
-                          updateField(index, { label: e.target.value })
-                        }
-                        placeholder="e.g., What is your reason for leaving?"
-                        required
-                      />
-                    </div>
-
-                    <div>
-                      <Label>Placeholder (Optional)</Label>
-                      <Input
-                        value={field.placeholder || ""}
-                        onChange={(e) =>
-                          updateField(index, { placeholder: e.target.value })
-                        }
-                        placeholder="Placeholder text for this field"
-                      />
-                    </div>
-
-                    {(field.type === "select" ||
-                      field.type === "radio" ||
-                      field.type === "checkbox") && (
-                      <div>
-                        <Label className="flex items-center justify-between">
-                          Options *
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Form Fields
+                <Button type="button" onClick={addField} size="sm">
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add Field
+                </Button>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {fields.length === 0 ? (
+                <div className="py-8 text-center text-gray-500">
+                  <p>No fields added yet. Click "Add Field" to get started.</p>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  {fields.map((field, index) => {
+                    const options = watch(`fields.${index}.options`) || [];
+                    const type = watch(`fields.${index}.type`);
+                    return (
+                      <div key={field.id} className="space-y-4 rounded-lg border p-4">
+                        <input type="hidden" {...register(`fields.${index}.id`)} defaultValue={field.id} />
+                        <div className="flex items-center justify-between">
+                          <h4 className="font-medium">Field {index + 1}</h4>
                           <Button
                             type="button"
-                            onClick={() => addOption(index)}
-                            size="sm"
                             variant="outline"
+                            size="sm"
+                            onClick={() => remove(index)}
                           >
-                            <Plus className="mr-2 h-3 w-3" />
-                            Add Option
+                            <Trash2 className="h-4 w-4" />
                           </Button>
-                        </Label>
-                        <div className="space-y-2 mt-2">
-                          {field.options?.map((option, optionIndex) => (
-                            <div
-                              key={optionIndex}
-                              className="flex items-center space-x-2"
-                            >
-                              <Input
-                                value={option}
-                                onChange={(e) =>
-                                  updateOption(
-                                    index,
-                                    optionIndex,
-                                    e.target.value,
-                                  )
-                                }
-                                placeholder={`Option ${optionIndex + 1}`}
-                                required
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                          <div>
+                            <Label>Field Type</Label>
+                            <Controller
+                              control={control}
+                              name={`fields.${index}.type`}
+                              defaultValue={field.type}
+                              render={({ field: controllerField }) => (
+                                <Select
+                                  value={controllerField.value}
+                                  onValueChange={(value) => controllerField.onChange(value)}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Choose a field type" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {FIELD_TYPE_OPTIONS.map((option) => (
+                                      <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
+                            />
+                          </div>
+
+                          <div>
+                            <Label>Required</Label>
+                            <div className="mt-2 flex items-center space-x-2">
+                              <Controller
+                                control={control}
+                                name={`fields.${index}.required`}
+                                defaultValue={field.required}
+                                render={({ field: controllerField }) => (
+                                  <Checkbox
+                                    id={`required-${field.id}`}
+                                    checked={controllerField.value}
+                                    onCheckedChange={(checked) => controllerField.onChange(Boolean(checked))}
+                                  />
+                                )}
                               />
+                              <Label htmlFor={`required-${field.id}`} className="text-sm">
+                                Required field
+                              </Label>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div>
+                          <Label htmlFor={`label-${field.id}`}>Field Label *</Label>
+                          <Input
+                            id={`label-${field.id}`}
+                            placeholder="e.g., What is your reason for leaving?"
+                            defaultValue={field.label}
+                            {...register(`fields.${index}.label`, { required: true })}
+                          />
+                        </div>
+
+                        <div>
+                          <Label htmlFor={`placeholder-${field.id}`}>Placeholder (Optional)</Label>
+                          <Input
+                            id={`placeholder-${field.id}`}
+                            placeholder="Placeholder text for this field"
+                            defaultValue={field.placeholder}
+                            {...register(`fields.${index}.placeholder`)}
+                          />
+                        </div>
+
+                        {(type === "select" || type === "radio" || type === "checkbox") && (
+                          <div>
+                            <Label className="flex items-center justify-between">
+                              Options *
                               <Button
                                 type="button"
-                                variant="outline"
+                                onClick={() => addOption(index)}
                                 size="sm"
-                                onClick={() => removeOption(index, optionIndex)}
+                                variant="outline"
                               >
-                                <Trash2 className="h-4 w-4" />
+                                <Plus className="mr-2 h-3 w-3" />
+                                Add Option
                               </Button>
+                            </Label>
+                            <div className="mt-2 space-y-2">
+                              {options.map((_, optionIndex) => (
+                                <div key={optionIndex} className="flex items-center space-x-2">
+                                  <Input
+                                    placeholder={`Option ${optionIndex + 1}`}
+                                    defaultValue={options[optionIndex]}
+                                    {...register(`fields.${index}.options.${optionIndex}`, { required: true })}
+                                  />
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => removeOption(index, optionIndex)}
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </div>
+                              ))}
+                              {options.length === 0 && (
+                                <p className="text-sm text-muted-foreground">Add at least one option.</p>
+                              )}
                             </div>
-                          ))}
-                        </div>
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
-        <div className="flex justify-end space-x-3">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => router.push("/settings/forms/exit-interview")}
-            disabled={loading}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" disabled={loading}>
-            {loading ? (
-              <>
-                <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                Creating...
-              </>
-            ) : (
-              <>
-                <Save className="mr-2 h-4 w-4" />
-                Create Template
-              </>
-            )}
-          </Button>
-        </div>
-      </form>
-    </PageShell>
+          <FormActionBar containerClassName="px-4 sm:px-8">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push("/settings/forms/exit-interview")}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading} className="gap-2">
+              {loading ? (
+                <>
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Creating...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4" />
+                  Create Template
+                </>
+              )}
+            </Button>
+          </FormActionBar>
+        </form>
+      </PageShell>
+    </FormProvider>
   );
 }

--- a/app/components/forms/DynamicFormRenderer.tsx
+++ b/app/components/forms/DynamicFormRenderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Button from "@/components/ui/Button";
@@ -11,8 +11,8 @@ import Checkbox from "@/components/ui/Checkbox";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { PageLoader } from "@/components/ui/LoadingSpinner";
-import { uploadToSupabase } from "@/lib/supabase";
 import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import { FormActionBar } from "./FormActionBar";
 
 interface DynamicFormRendererProps {
   formId: string;
@@ -81,11 +81,12 @@ export function DynamicFormRenderer({
   };
 
   const formSchema = buildValidationSchema();
+  const form = useForm({ resolver: zodResolver(formSchema) });
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm({ resolver: zodResolver(formSchema) });
+  } = form;
 
   const submitForm = async (data: Record<string, any>, reasons?: Record<string, string>) => {
     try {
@@ -147,59 +148,63 @@ export function DynamicFormRenderer({
   }
 
   return (
-    <form
-      onSubmit={handleSubmit(async (data) => {
-        const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({ field: k, oldValue: "", newValue: JSON.stringify(v ?? "") }));
-        setPendingData(data);
-        setPendingChanges(changes);
-        setIsReasonOpen(true);
-      })}
-      className="space-y-6 bg-white p-6 rounded-lg shadow-md"
-    >
-      {fields.map((field) => {
-        console.log("📦 Rendering field:", field);
-        return (
-          <div key={field.id} className="flex flex-col gap-2">
-            <label className="font-medium text-sm text-gray-700">
-              {field.label || "Untitled Field"}
-              {field.required && <span className="text-red-500 ml-1">*</span>}
-            </label>
-            {renderField(field, register)}
-            {errors[field.id] && (
-              <p className="text-red-500 text-xs mt-1">
-                {errors[field.id]?.message as string}
-              </p>
+    <FormProvider {...form}>
+      <form
+        onSubmit={handleSubmit(async (data) => {
+          const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({ field: k, oldValue: "", newValue: JSON.stringify(v ?? "") }));
+          setPendingData(data);
+          setPendingChanges(changes);
+          setIsReasonOpen(true);
+        })}
+        className="space-y-6 bg-white p-6 rounded-lg shadow-md pb-32"
+      >
+        {fields.map((field) => {
+          console.log("📦 Rendering field:", field);
+          return (
+            <div key={field.id} className="flex flex-col gap-2">
+              <label className="font-medium text-sm text-gray-700">
+                {field.label || "Untitled Field"}
+                {field.required && <span className="text-red-500 ml-1">*</span>}
+              </label>
+              {renderField(field, register)}
+              {errors[field.id] && (
+                <p className="text-red-500 text-xs mt-1">
+                  {errors[field.id]?.message as string}
+                </p>
+              )}
+            </div>
+          );
+        })}
+        <FormActionBar>
+          <Button type="submit" className="gap-2" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Submitting...
+              </>
+            ) : (
+              "Submit"
             )}
-          </div>
-        );
-      })}
-      <Button type="submit" className="w-full" disabled={isSubmitting}>
-        {isSubmitting ? (
-          <>
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" /> Submitting...
-          </>
-        ) : (
-          "Submit"
-        )}
-      </Button>
+          </Button>
+        </FormActionBar>
 
-      <ChangeReasonModal
-        isOpen={isReasonOpen}
-        onClose={() => {
-          setIsReasonOpen(false);
-          setPendingChanges([]);
-          setPendingData(null);
-        }}
-        changes={pendingChanges}
-        onSubmit={async (reasons) => {
-          if (!pendingData) return;
-          await submitForm(pendingData, reasons);
-          setIsReasonOpen(false);
-          setPendingChanges([]);
-          setPendingData(null);
-        }}
-      />
-    </form>
+        <ChangeReasonModal
+          isOpen={isReasonOpen}
+          onClose={() => {
+            setIsReasonOpen(false);
+            setPendingChanges([]);
+            setPendingData(null);
+          }}
+          changes={pendingChanges}
+          onSubmit={async (reasons) => {
+            if (!pendingData) return;
+            await submitForm(pendingData, reasons);
+            setIsReasonOpen(false);
+            setPendingChanges([]);
+            setPendingData(null);
+          }}
+        />
+      </form>
+    </FormProvider>
   );
 }
 

--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import Button from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,6 +11,7 @@ import { FormField, TableColumn, AnyFormSchema, normalizeToPages, FormPage, Form
 import { PageLoader } from "@/components/ui/LoadingSpinner";
 import HistoryButton from "@/components/audit/HistoryButton";
 import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import { FormActionBar } from "./FormActionBar";
 
 interface EnhancedFormRendererProps {
   formId: string;
@@ -44,7 +45,8 @@ export function EnhancedFormRenderer({
   const [pendingAction, setPendingAction] = useState<"data" | "submit" | null>(null);
   const [pendingPayload, setPendingPayload] = useState<Record<string, any> | null>(null);
 
-  const { register, handleSubmit, setValue, watch, reset } = useForm();
+  const form = useForm();
+  const { register, handleSubmit, setValue, watch, reset } = form;
 
   const evaluateCondition = (cond: any): boolean => {
     if (!cond) return true;
@@ -310,8 +312,9 @@ export function EnhancedFormRenderer({
         </div>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-        {pages.map((page) => (
+      <FormProvider {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 pb-32">
+          {pages.map((page) => (
           <div key={page.id} className="space-y-6">
             {page.title && (
               <h3 className="text-lg font-semibold">{page.title}</h3>
@@ -343,7 +346,7 @@ export function EnhancedFormRenderer({
                         : "col-span-12"
                       : "";
                     return (
-                    <div key={field.id} className={widthClass}>
+                      <div key={field.id} className={widthClass}>
                       {field.type === "sectionHeader" && (
                         <h5 className="text-base font-semibold">{field.label}</h5>
                       )}
@@ -381,27 +384,28 @@ export function EnhancedFormRenderer({
               </div>
             ))}
           </div>
-        ))}
+          ))}
 
-        <div className="flex justify-end pt-4">
-          <Button
-            type="submit"
-            disabled={saving || isReadOnly}
-            className="flex items-center gap-2"
-          >
-            {saving ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : formData.form.formType === "DATA_SCREEN" ? (
-              <Save className="h-4 w-4" />
-            ) : null}
-            {saving
-              ? "Saving..."
-              : formData.form.formType === "DATA_SCREEN"
-                ? "Save Data"
-                : "Submit Form"}
-          </Button>
-        </div>
-      </form>
+          <FormActionBar>
+            <Button
+              type="submit"
+              disabled={saving || isReadOnly}
+              className="flex items-center gap-2"
+            >
+              {saving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : formData.form.formType === "DATA_SCREEN" ? (
+                <Save className="h-4 w-4" />
+              ) : null}
+              {saving
+                ? "Saving..."
+                : formData.form.formType === "DATA_SCREEN"
+                  ? "Save Data"
+                  : "Submit Form"}
+            </Button>
+          </FormActionBar>
+        </form>
+      </FormProvider>
 
       <ChangeReasonModal
         isOpen={isReasonOpen}

--- a/app/components/forms/FormActionBar.tsx
+++ b/app/components/forms/FormActionBar.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { useFormContext, FieldErrors } from "react-hook-form";
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FormActionBarProps {
+  children: ReactNode;
+  className?: string;
+  containerClassName?: string;
+}
+
+function countErrors(errors: FieldErrors<any>): number {
+  const iterate = (value: any): number => {
+    if (!value) return 0;
+    if (Array.isArray(value)) {
+      return value.reduce((sum, item) => sum + iterate(item), 0);
+    }
+    if (typeof value === "object") {
+      if ("message" in value && value.message) {
+        return 1;
+      }
+      return Object.values(value).reduce((sum, item) => sum + iterate(item), 0);
+    }
+    return 0;
+  };
+  return iterate(errors);
+}
+
+export function FormActionBar({
+  children,
+  className,
+  containerClassName,
+}: FormActionBarProps) {
+  const { formState } = useFormContext();
+  const errorCount = useMemo(() => countErrors(formState.errors), [formState.errors]);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
+  const [expandedWhileKeyboardVisible, setExpandedWhileKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const viewport = window.visualViewport;
+    if (!viewport) {
+      const fallbackResize = () => {
+        if (window.innerWidth > 768) {
+          setIsKeyboardOpen(false);
+          return;
+        }
+        const screenHeight = window.screen?.height || window.innerHeight;
+        const diff = screenHeight - window.innerHeight;
+        setIsKeyboardOpen(diff > 160);
+      };
+      fallbackResize();
+      window.addEventListener("resize", fallbackResize);
+      return () => window.removeEventListener("resize", fallbackResize);
+    }
+    const handleViewportChange = () => {
+      if (window.innerWidth > 768) {
+        setIsKeyboardOpen(false);
+        return;
+      }
+      const diff = window.innerHeight - viewport.height;
+      setIsKeyboardOpen(diff > 120);
+    };
+    viewport.addEventListener("resize", handleViewportChange);
+    viewport.addEventListener("scroll", handleViewportChange);
+    handleViewportChange();
+    return () => {
+      viewport.removeEventListener("resize", handleViewportChange);
+      viewport.removeEventListener("scroll", handleViewportChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isKeyboardOpen) {
+      setExpandedWhileKeyboardVisible(false);
+    }
+  }, [isKeyboardOpen]);
+
+  const shouldCollapse = isMobile && isKeyboardOpen;
+  const isCollapsed = shouldCollapse && !expandedWhileKeyboardVisible;
+
+  const status = useMemo(() => {
+    if (errorCount > 0) {
+      return {
+        tone: "error",
+        icon: <AlertCircle className="h-4 w-4" aria-hidden="true" />,
+        text: `${errorCount} ${errorCount === 1 ? "issue" : "issues"} to review`,
+        summary: `${errorCount} ${errorCount === 1 ? "issue" : "issues"}`,
+        textClass: "text-destructive",
+      } as const;
+    }
+    if (formState.isDirty) {
+      return {
+        tone: "dirty",
+        icon: <Clock className="h-4 w-4" aria-hidden="true" />,
+        text: "You have unsaved changes",
+        summary: "Unsaved",
+        textClass: "text-amber-600",
+      } as const;
+    }
+    return {
+      tone: "clean",
+      icon: <CheckCircle2 className="h-4 w-4" aria-hidden="true" />,
+      text: "All changes saved",
+      summary: "Saved",
+      textClass: "text-muted-foreground",
+    } as const;
+  }, [errorCount, formState.isDirty]);
+
+  const safeAreaStyle = {
+    paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)",
+  } as const;
+
+  return (
+    <div className="pointer-events-none">
+      <div
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 px-3 sm:px-6",
+          containerClassName,
+        )}
+      >
+        <div
+          style={safeAreaStyle}
+          className={cn(
+            "mx-auto w-full max-w-5xl transition-transform duration-300 pointer-events-auto",
+            isCollapsed ? "translate-y-[calc(100%-3.25rem)]" : "translate-y-0",
+          )}
+        >
+          <div
+            className={cn(
+              "rounded-t-2xl border border-border/80 bg-content-panel/95 shadow-lg supports-[backdrop-filter]:backdrop-blur-lg",
+              className,
+            )}
+          >
+            {shouldCollapse && isCollapsed ? (
+              <button
+                type="button"
+                onClick={() => setExpandedWhileKeyboardVisible(true)}
+                className="flex w-full items-center justify-between gap-3 rounded-t-2xl px-4 py-3 text-sm font-medium text-foreground"
+              >
+                <span className="flex items-center gap-2">
+                  <ChevronUp className="h-4 w-4" aria-hidden="true" />
+                  Show actions
+                </span>
+                <span className={cn("flex items-center gap-2 text-xs", status.textClass)}>
+                  {status.icon}
+                  <span>{status.summary}</span>
+                </span>
+              </button>
+            ) : (
+              <>
+                <div className="px-4 py-4 sm:px-6 sm:py-5">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      className={cn(
+                        "flex items-center gap-2 text-sm font-medium",
+                        status.textClass,
+                      )}
+                    >
+                      {status.icon}
+                      <span>{status.text}</span>
+                    </div>
+                    <div className="flex flex-wrap justify-end gap-2 text-sm">
+                      {children}
+                    </div>
+                  </div>
+                </div>
+                {shouldCollapse && (
+                  <button
+                    type="button"
+                    onClick={() => setExpandedWhileKeyboardVisible(false)}
+                    className="flex w-full items-center justify-center gap-2 border-t border-border/70 bg-content-panel/90 px-4 py-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                    Hide actions
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `FormActionBar` that mirrors react-hook-form state, stays anchored to the viewport, and collapses on mobile keyboards
- wire the action bar into `EnhancedFormRenderer` and `DynamicFormRenderer`, wrapping them with `FormProvider` and giving their forms extra bottom padding
- migrate the exit interview template builder to react-hook-form with `useFieldArray`, surfacing validation and adopting the shared action bar

## Testing
- npm run lint *(fails: existing lint violations across unrelated API/lib files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1881a30d88331b43ba080bebde61e