### PR TITLE
fix: normalise employee search filters

### DIFF
--- a/app/(withSidebar)/news/create/page.tsx
+++ b/app/(withSidebar)/news/create/page.tsx
@@ -2,26 +2,23 @@
 
 export const dynamic = "force-dynamic";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import { Switch } from "@/components/ui/switch";
-import { uploadFileToSupabase } from "@/lib/news/uploadFileToSupabase";
 import NewsEditor from "@/components/news/NewsEditor";
 import AudienceCampaignPanel from "@/components/news/AudienceCampaignPanel";
 import NewsChip from "@/components/ui/NewsChip";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
+import FileDropzone, { FileDropzoneItem, UploadHelpers } from "@/components/ui/FileDropzone";
 import {
   ArrowLeft,
   Save,
   Send,
-  Upload,
-  Image,
   Video,
-  FileText,
   X,
   Plus,
   Hash,
@@ -31,14 +28,74 @@ import {
   AlertCircle,
 } from "lucide-react";
 
+type NewsUploadMeta = {
+  path: string;
+  url: string | null;
+  name: string;
+  size: number;
+  type: string;
+};
+
+const uploadWithProgress = (
+  endpoint: string,
+  file: File,
+  { onProgress, signal }: UploadHelpers,
+) =>
+  new Promise<any>((resolve, reject) => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", endpoint, true);
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        const percent = Math.round((event.loaded / event.total) * 100);
+        onProgress(percent);
+      } else {
+        onProgress(50);
+      }
+    };
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return;
+      const status = xhr.status;
+      if (status >= 200 && status < 300) {
+        try {
+          const json = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+          resolve(json);
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        const message = xhr.responseText || `Upload failed (${status})`;
+        reject(new Error(message));
+      }
+    };
+
+    xhr.onerror = () => reject(new Error("Network error during upload"));
+    xhr.onabort = () => reject(new Error("Upload cancelled"));
+
+    signal.addEventListener("abort", () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) {
+        xhr.abort();
+      }
+    });
+
+    xhr.send(formData);
+  });
+
 export default function CreateNewsPostPage() {
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [content, setContent] = useState<any>(null);
   const [coverImage, setCoverImage] = useState("");
-  const [isUploadingCover, setIsUploadingCover] = useState(false);
+  const [coverStoragePath, setCoverStoragePath] = useState<string | null>(null);
   const [videoUrl, setVideoUrl] = useState("");
-  const [attachments, setAttachments] = useState<File[]>([]);
+  const [attachmentItems, setAttachmentItems] = useState<
+    FileDropzoneItem<NewsUploadMeta>[]
+  >([]);
+  const [coverItems, setCoverItems] = useState<FileDropzoneItem<NewsUploadMeta>[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
   const [pinned, setPinned] = useState(false);
@@ -54,45 +111,36 @@ export default function CreateNewsPostPage() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
-  const coverFileInputRef = useRef<HTMLInputElement | null>(null);
+  const handleAttachmentUpload = (
+    file: File,
+    helpers: UploadHelpers,
+  ): Promise<NewsUploadMeta> =>
+    uploadWithProgress("/api/news/attachment-upload", file, helpers) as Promise<NewsUploadMeta>;
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      setAttachments(Array.from(e.target.files));
+  const handleCoverUpload = (
+    file: File,
+    helpers: UploadHelpers,
+  ): Promise<NewsUploadMeta> =>
+    uploadWithProgress("/api/news/cover-upload", file, helpers) as Promise<NewsUploadMeta>;
+
+  useEffect(() => {
+    const successful = coverItems.find(
+      (item) => item.status === "success" && item.meta,
+    );
+    if (successful?.meta) {
+      const meta = successful.meta as NewsUploadMeta;
+      setCoverStoragePath(meta.path);
+      setCoverImage(meta.url || meta.path || "");
+    } else if (coverItems.length === 0 && coverStoragePath) {
+      setCoverStoragePath(null);
+      setCoverImage("");
     }
-  };
+  }, [coverItems, coverStoragePath]);
 
-  const removeAttachment = (index: number) => {
-    setAttachments(attachments.filter((_, i) => i !== index));
-  };
-
-  const handleCoverFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setIsUploadingCover(true);
-    try {
-      const form = new FormData();
-      form.append("file", file);
-      const res = await fetch("/api/news/cover-upload", {
-        method: "POST",
-        body: form,
-      });
-      if (!res.ok) {
-        const errText = await res.text().catch(() => "");
-        throw new Error(errText || "Upload failed");
-      }
-      const data = await res.json();
-      setCoverImage(data.url || "");
-      toast.success("Cover image uploaded");
-    } catch (err) {
-      console.error(err);
-      toast.error("Failed to upload cover image");
-    } finally {
-      setIsUploadingCover(false);
-      if (coverFileInputRef.current) coverFileInputRef.current.value = "";
-    }
+  const clearCover = () => {
+    setCoverImage("");
+    setCoverStoragePath(null);
+    if (coverItems.length) setCoverItems([]);
   };
 
   const handleAddTag = () => {
@@ -133,22 +181,46 @@ export default function CreateNewsPostPage() {
 
     if (!validateForm()) return;
 
+    const hasUploadingAttachments = attachmentItems.some(
+      (item) => item.status === "uploading",
+    );
+    if (hasUploadingAttachments) {
+      toast.error("Please wait for attachments to finish uploading.");
+      return;
+    }
+
+    const hasFailedAttachments = attachmentItems.some(
+      (item) => item.status === "error",
+    );
+    if (hasFailedAttachments) {
+      toast.error("Remove or retry failed attachments before submitting.");
+      return;
+    }
+
+    const hasUploadingCover = coverItems.some(
+      (item) => item.status === "uploading",
+    );
+    if (hasUploadingCover) {
+      toast.error("Please wait for the cover image upload to finish.");
+      return;
+    }
+
+    const uploadedAttachments = attachmentItems
+      .filter((item) => item.status === "success" && item.meta)
+      .map((item) => item.meta as NewsUploadMeta);
+
     setIsSubmitting(true);
 
     try {
-      // Upload attachments
-      const uploadedUrls = await Promise.all(
-        attachments.map((file) => uploadFileToSupabase(file))
-      );
-
       const res = await fetch("/api/news", {
         method: "POST",
         body: JSON.stringify({
           title,
           content,
-          coverImage: normalizeCoverForSave(coverImage) || null,
+          coverImage:
+            normalizeCoverForSave(coverStoragePath || coverImage) || null,
           videoEmbedUrl: videoUrl || null,
-          attachments: uploadedUrls,
+          attachments: uploadedAttachments,
           sendEmail,
           audience,
           tags,
@@ -321,55 +393,59 @@ export default function CreateNewsPostPage() {
               <label className="block text-sm font-medium text-foreground">
                 Cover Image
               </label>
-              <div className="flex gap-3">
-                <input
-                  type="url"
-                  value={coverImage}
-                  onChange={(e) => setCoverImage(e.target.value)}
-                  placeholder="https://example.com/image.jpg"
-                  className={cn(
-                    "flex-1 px-4 py-2",
-                    "bg-card border border-border rounded-lg",
-                    "focus:outline-none focus:ring-2 focus:ring-primary"
-                  )}
-                />
-                <button
-                  type="button"
-                  onClick={() => coverFileInputRef.current?.click()}
-                  disabled={isUploadingCover}
-                  className={cn(
-                    "px-4 py-2 rounded-lg transition-all flex items-center gap-2",
-                    "bg-muted hover:bg-muted/80",
-                    isUploadingCover && "opacity-60 cursor-not-allowed"
-                  )}
-                >
-                  <Image className="w-4 h-4" />
-                  {isUploadingCover ? "Uploading..." : "Upload"}
-                </button>
-              </div>
-              <input
-                ref={coverFileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleCoverFileChange}
-                className="hidden"
-              />
-              {coverImage && (
-                <div className="relative mt-2 rounded-lg overflow-hidden">
-                  <img
-                    src={coverImage}
-                    alt="Cover"
-                    className="w-full h-48 object-cover"
+              <div className="space-y-3">
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <input
+                    type="url"
+                    value={coverImage}
+                    onChange={(e) => {
+                      setCoverImage(e.target.value);
+                      setCoverStoragePath(null);
+                      if (coverItems.length) setCoverItems([]);
+                    }}
+                    placeholder="https://example.com/image.jpg"
+                    className={cn(
+                      "flex-1 px-4 py-2",
+                      "bg-card border border-border rounded-lg",
+                      "focus:outline-none focus:ring-2 focus:ring-primary"
+                    )}
                   />
-                  <button
-                    onClick={() => setCoverImage("")}
-                    className="absolute top-2 right-2 p-1 bg-black/50 text-white rounded-full hover:bg-black/70"
-                    type="button"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
+                  {coverImage && (
+                    <button
+                      type="button"
+                      onClick={clearCover}
+                      className="h-10 rounded-lg border border-border px-4 text-sm font-medium transition hover:bg-muted"
+                    >
+                      Clear
+                    </button>
+                  )}
                 </div>
-              )}
+                <FileDropzone
+                  files={coverItems}
+                  onFilesChange={setCoverItems}
+                  onUpload={handleCoverUpload}
+                  multiple={false}
+                  accept="image/*"
+                  description="Upload a hero image for this post"
+                  helperText="Images are stored securely in your tenant bucket."
+                />
+                {coverImage && (
+                  <div className="relative mt-2 rounded-lg overflow-hidden">
+                    <img
+                      src={coverImage}
+                      alt="Cover"
+                      className="w-full h-48 object-cover"
+                    />
+                    <button
+                      onClick={clearCover}
+                      className="absolute top-2 right-2 rounded-full bg-black/50 p-1 text-white transition hover:bg-black/70"
+                      type="button"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+              </div>
             </motion.div>
 
             {/* Content Editor */}
@@ -434,54 +510,23 @@ export default function CreateNewsPostPage() {
               <label className="block text-sm font-medium text-foreground">
                 Attachments
               </label>
-              <div className="border-2 border-dashed border-border rounded-xl p-6 text-center hover:border-primary/50 transition-colors">
-                <input
-                  type="file"
-                  multiple
-                  onChange={handleFileChange}
-                  className="hidden"
-                  id="file-upload"
-                />
-                <label
-                  htmlFor="file-upload"
-                  className="cursor-pointer flex flex-col items-center gap-2"
-                >
-                  <Upload className="w-8 h-8 text-muted-foreground" />
-                  <span className="text-sm text-muted-foreground">
-                    Click to upload or drag and drop
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    PDF, DOC, XLS, PPT up to 10MB each
-                  </span>
-                </label>
-              </div>
-              {attachments.length > 0 && (
-                <div className="grid gap-2 mt-3">
-                  {attachments.map((file, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between p-3 bg-muted/30 rounded-lg"
-                    >
-                      <div className="flex items-center gap-3">
-                        <FileText className="w-4 h-4 text-muted-foreground" />
-                        <div>
-                          <p className="text-sm font-medium">{file.name}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {(file.size / 1024 / 1024).toFixed(2)} MB
-                          </p>
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => removeAttachment(index)}
-                        className="p-1 hover:bg-muted rounded-lg"
-                        type="button"
-                      >
-                        <X className="w-4 h-4" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
+              <FileDropzone
+                files={attachmentItems}
+                onFilesChange={setAttachmentItems}
+                onUpload={handleAttachmentUpload}
+                accept={[
+                  ".pdf",
+                  ".doc",
+                  ".docx",
+                  ".xls",
+                  ".xlsx",
+                  ".ppt",
+                  ".pptx",
+                  "image/*",
+                ]}
+                description="Upload supporting documents or images"
+                helperText="Files are uploaded to your tenant's secure storage bucket."
+              />
             </motion.div>
           </div>
 

--- a/app/api/news/attachment-upload/route.ts
+++ b/app/api/news/attachment-upload/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import supabase from "@/lib/supabase-admin";
+import { randomUUID } from "crypto";
+
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    const companyId = session?.user?.companyId;
+    if (!session?.user?.id || !companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -18,36 +22,38 @@ export async function POST(req: NextRequest) {
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
-    const ext = (file.name.split(".").pop() || "jpg").toLowerCase();
-    const objectPath = `news-covers/${session.user.companyId || "company"}/${Date.now()}-${Math.random()
-      .toString(36)
-      .slice(2)}.${ext}`;
+
+    const safeName = file.name.replace(/[^a-zA-Z0-9.\-_]+/g, "_");
+    const objectPath = `news-attachments/${companyId}/${Date.now()}-${randomUUID()}-${safeName}`;
 
     const { error: uploadError } = await supabase.storage
       .from("documents")
-      .upload(objectPath, buffer, { upsert: false, contentType: file.type });
+      .upload(objectPath, buffer, {
+        contentType: file.type || "application/octet-stream",
+        upsert: false,
+      });
+
     if (uploadError) {
       return NextResponse.json({ error: uploadError.message }, { status: 400 });
     }
 
-    // Return a short-lived signed URL for immediate preview
-    const { data: signed, error: signErr } = await supabase.storage
+    const { data: signed, error: signedError } = await supabase.storage
       .from("documents")
       .createSignedUrl(objectPath, 60 * 10);
-    if (signErr) {
-      return NextResponse.json({ error: signErr.message }, { status: 400 });
+
+    if (signedError) {
+      return NextResponse.json({ error: signedError.message }, { status: 400 });
     }
 
     return NextResponse.json({
       path: objectPath,
-      url: signed?.signedUrl || null,
+      url: signed?.signedUrl ?? null,
       name: file.name,
       size: file.size,
       type: file.type || "application/octet-stream",
     });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || "Server error" }, { status: 500 });
+  } catch (error) {
+    console.error("Attachment upload error", error);
+    return NextResponse.json({ error: "Failed to upload attachment" }, { status: 500 });
   }
 }
-
-

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getServerSession } from "next-auth";
+import type { Prisma } from "@prisma/client";
+
+import { ensurePrismaConnected, prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth-options";
+import supabase from "@/lib/supabase-admin";
+
+const querySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .transform((value) => value.replace(/\s+/g, " "))
+    .optional(),
+  limit: z
+    .string()
+    .transform((value) => Number.parseInt(value, 10))
+    .pipe(z.number().int().min(1).max(50))
+    .optional(),
+});
+
+const DEFAULT_LIMIT = 10;
+
+const CASE_INSENSITIVE_CONTAINS = (value: string) => ({
+  contains: value,
+  mode: "insensitive" as const,
+});
+
+function appendEmployeeSearchFilters(
+  employeeWhere: Prisma.EmployeeWhereInput,
+  searchTerms: string[],
+) {
+  if (!searchTerms.length) {
+    return;
+  }
+
+  const andFilters = searchTerms.map<Prisma.EmployeeWhereInput>((term) => ({
+    OR: [
+      { User: { firstName: CASE_INSENSITIVE_CONTAINS(term) } },
+      { User: { lastName: CASE_INSENSITIVE_CONTAINS(term) } },
+      { User: { email: CASE_INSENSITIVE_CONTAINS(term) } },
+      { Department: { name: CASE_INSENSITIVE_CONTAINS(term) } },
+      { JobRole: { name: CASE_INSENSITIVE_CONTAINS(term) } },
+    ],
+  }));
+
+  const existing = employeeWhere.AND;
+  const normalised = Array.isArray(existing)
+    ? existing
+    : existing
+      ? [existing]
+      : [];
+
+  employeeWhere.AND = [...normalised, ...andFilters];
+}
+
+async function buildEmployeeResults(
+  employeeWhere: Prisma.EmployeeWhereInput,
+  limit: number,
+) {
+  const employees = await prisma.employee.findMany({
+    where: employeeWhere,
+    include: {
+      User: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          profileImageUrl: true,
+        },
+      },
+      Department: { select: { id: true, name: true } },
+      JobRole: { select: { id: true, name: true } },
+    },
+    take: limit,
+    orderBy: { User: { updatedAt: "desc" } },
+  });
+
+  return Promise.all(
+    employees.map(async (employee) => {
+      let profileUrl: string | null = null;
+
+      if (employee.User.profileImageUrl) {
+        try {
+          const { data } = await supabase.storage
+            .from("documents")
+            .createSignedUrl(employee.User.profileImageUrl, 60 * 5);
+
+          profileUrl = data?.signedUrl ?? null;
+        } catch (error) {
+          console.error("Failed to sign profile image", error);
+          profileUrl = null;
+        }
+      }
+
+      return {
+        type: "employee" as const,
+        id: employee.id,
+        userId: employee.User.id,
+        firstName: employee.User.firstName,
+        lastName: employee.User.lastName,
+        email: employee.User.email,
+        department: employee.Department
+          ? { id: employee.Department.id, name: employee.Department.name }
+          : null,
+        jobRole: employee.JobRole
+          ? { id: employee.JobRole.id, name: employee.JobRole.name }
+          : null,
+        profileImageUrl: profileUrl,
+        isActive: employee.isActive,
+      };
+    }),
+  );
+}
+
+export async function GET(req: Request) {
+  try {
+    await ensurePrismaConnected();
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.companyId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const parsed = querySchema.safeParse(Object.fromEntries(searchParams));
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid query", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const query = parsed.data.q ?? "";
+    const limit = parsed.data.limit ?? DEFAULT_LIMIT;
+    const searchTerms = query
+      .split(" ")
+      .map((term) => term.trim())
+      .filter(Boolean);
+
+    const employeeWhere: Prisma.EmployeeWhereInput = {
+      companyId: session.user.companyId,
+      isActive: true,
+    };
+
+    appendEmployeeSearchFilters(employeeWhere, searchTerms);
+
+    const employees = await buildEmployeeResults(employeeWhere, limit);
+
+    return NextResponse.json({ employees });
+  } catch (error) {
+    console.error("Global search failed", error);
+    return NextResponse.json(
+      { error: "Failed to run search" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import Button from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/textarea";
+import FileDropzone, { FileDropzoneItem, UploadHelpers } from "@/components/ui/FileDropzone";
 import { toast } from "sonner";
 import { Loader2, Plus, Trash2, Save } from "lucide-react";
 import { FormField, TableColumn, AnyFormSchema, normalizeToPages, FormPage, FormSection } from "@/api/forms/[id]/types";
@@ -184,7 +185,8 @@ export function EnhancedFormRenderer({
       .flatMap((s) => s.fields);
     for (const field of allFields) {
       if (field.type === "file") {
-        const file = toFile(rawData[field.id]);
+        const value = rawData[field.id];
+        const file = toFile(value);
         if (file) {
           const fd = new FormData();
           fd.append("file", file);
@@ -207,19 +209,21 @@ export function EnhancedFormRenderer({
               return;
             }
             const uploadResult = await uploadRes.json();
-            if (!uploadResult?.document) {
+            const payload = uploadResult?.document || uploadResult?.Document;
+            if (!payload) {
               toast.error(`Failed to upload file for ${field.label}`);
               return;
             }
-            data[field.id] = uploadResult.document;
+            data[field.id] = payload;
           } catch {
             toast.error(`Upload error: ${field.label}`);
             return;
           }
-        } else if (rawData[field.id]?.url) {
-          // keep existing document if no new file selected
-          data[field.id] = rawData[field.id];
-        } else {
+        } else if (value?.document || value?.Document) {
+          data[field.id] = value.document || value.Document;
+        } else if (value?.url || value?.path) {
+          data[field.id] = value;
+        } else if (!value) {
           data[field.id] = null;
         }
       }
@@ -371,7 +375,12 @@ export function EnhancedFormRenderer({
                               />
                             </div>
                           </div>
-                          {renderField(field, register, watch, setValue, isReadOnly)}
+                          {renderField(field, register, watch, setValue, isReadOnly, {
+                            uploadContext: {
+                              employeeId,
+                              formName: formData.form.name,
+                            },
+                          })}
                         </>
                       )}
                     </div>
@@ -429,12 +438,20 @@ export function EnhancedFormRenderer({
   );
 }
 
+interface RenderFieldOptions {
+  uploadContext?: {
+    employeeId?: string;
+    formName?: string;
+  };
+}
+
 export function renderField(
   field: FormField,
   register: any,
   watch: any,
   setValue: any,
   readOnly?: boolean,
+  options?: RenderFieldOptions,
 ) {
   const baseInput =
     "border rounded px-3 py-2 w-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400 transition";
@@ -587,32 +604,14 @@ export function renderField(
         </div>
       );
     case "file":
-      const existing = watch(field.id);
       return (
-        <div className="space-y-2">
-          {existing?.url && (
-            <div className="space-y-2">
-              <iframe
-                src={existing.url}
-                className="w-full h-64 rounded border"
-              />
-              <a
-                href={existing.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 underline block"
-              >
-                {existing.name || "View document"}
-              </a>
-            </div>
-          )}
-          <input
-            type="file"
-            className="border rounded px-3 py-2 w-full text-sm"
-            disabled={readOnly}
-            {...register(field.id, { required: field.required })}
-          />
-        </div>
+        <FormFileUploadField
+          field={field}
+          watch={watch}
+          setValue={setValue}
+          readOnly={readOnly}
+          uploadContext={options?.uploadContext}
+        />
       );
 
     case "text":
@@ -748,6 +747,180 @@ export function renderField(
         />
       );
   }
+}
+
+interface FormFileUploadFieldProps {
+  field: FormField;
+  watch: any;
+  setValue: any;
+  readOnly?: boolean;
+  uploadContext?: {
+    employeeId?: string;
+    formName?: string;
+  };
+}
+
+function FormFileUploadField({
+  field,
+  watch,
+  setValue,
+  readOnly,
+  uploadContext,
+}: FormFileUploadFieldProps) {
+  const currentValue = watch(field.id);
+  const [files, setFiles] = useState<FileDropzoneItem<any>[]>(() =>
+    normalizeToDropzoneItems(currentValue, field.id),
+  );
+
+  useEffect(() => {
+    setFiles((prev) => {
+      const next = normalizeToDropzoneItems(currentValue, field.id);
+      const prevMeta = JSON.stringify(prev.map((item) => item.meta));
+      const nextMeta = JSON.stringify(next.map((item) => item.meta));
+      return prevMeta === nextMeta ? prev : next;
+    });
+  }, [currentValue, field.id]);
+
+  const handleFilesChange = (items: FileDropzoneItem<any>[]) => {
+    setFiles(items);
+    const successful = items.find(
+      (item) => item.status === "success" && item.meta,
+    );
+    if (successful?.meta) {
+      setValue(field.id, successful.meta, { shouldDirty: true, shouldTouch: true });
+    } else {
+      setValue(field.id, null, { shouldDirty: true, shouldTouch: true });
+    }
+  };
+
+  const uploadFile = (file: File, helpers: UploadHelpers) =>
+    uploadEmployeeDocumentWithProgress(file, helpers, {
+      employeeId: uploadContext?.employeeId,
+      formName: uploadContext?.formName,
+      fieldLabel: field.label,
+    });
+
+  return (
+    <FileDropzone
+      files={files}
+      onFilesChange={handleFilesChange}
+      onUpload={uploadFile}
+      multiple={false}
+      disabled={readOnly}
+      description={
+        field.placeholder || "Drag a document here or click to browse"
+      }
+      helperText={
+        readOnly
+          ? undefined
+          : "Documents are uploaded to this employee's secure bucket."
+      }
+    />
+  );
+}
+
+function normalizeToDropzoneItems(
+  value: any,
+  fieldId: string,
+): FileDropzoneItem<any>[] {
+  if (!value) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .map((entry) => entry?.document || entry?.Document || entry)
+    .filter(Boolean)
+    .map((meta: any) => {
+      const id = String(meta.id || `${fieldId}-${Math.random().toString(16).slice(2)}`);
+      const name =
+        meta.name || meta.fileName || meta.path || meta.url || "Uploaded file";
+      const size =
+        typeof meta.size === "number"
+          ? meta.size
+          : typeof meta.fileSize === "number"
+            ? meta.fileSize
+            : 0;
+      const type = meta.type || meta.mimeType || "";
+      return {
+        id,
+        name,
+        size,
+        type,
+        status: "success" as const,
+        progress: 100,
+        meta,
+        previewUrl: meta.url || meta.signedUrl || undefined,
+      } satisfies FileDropzoneItem<any>;
+    });
+}
+
+function uploadEmployeeDocumentWithProgress(
+  file: File,
+  helpers: UploadHelpers,
+  context: { employeeId?: string; formName?: string; fieldLabel?: string },
+) {
+  return new Promise<any>((resolve, reject) => {
+    if (!context.employeeId) {
+      reject(new Error("Missing employee context for file upload"));
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("name", file.name);
+    formData.append(
+      "category",
+      context.fieldLabel || context.formName || "Forms",
+    );
+    formData.append("employeeId", context.employeeId);
+    formData.append("canViewAdmin", "true");
+    formData.append("canViewManager", "true");
+    formData.append("canViewEmployee", "true");
+    formData.append("requiresAck", "false");
+    formData.append("requiresSignature", "false");
+
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "/api/documents/upload-employee", true);
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        const percent = Math.round((event.loaded / event.total) * 100);
+        helpers.onProgress(percent);
+      } else {
+        helpers.onProgress(50);
+      }
+    };
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return;
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const payload = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+          const document = payload.document || payload.Document;
+          if (!document) {
+            reject(new Error("Upload failed"));
+            return;
+          }
+          resolve(document);
+        } catch (error) {
+          reject(
+            error instanceof Error ? error : new Error("Failed to parse upload response"),
+          );
+        }
+      } else {
+        reject(new Error(xhr.responseText || `Upload failed (${xhr.status})`));
+      }
+    };
+
+    xhr.onerror = () => reject(new Error("Network error during upload"));
+    xhr.onabort = () => reject(new Error("Upload cancelled"));
+
+    helpers.signal.addEventListener("abort", () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) {
+        xhr.abort();
+      }
+    });
+
+    xhr.send(formData);
+  });
 }
 
 function ListField({ field, register, watch, setValue, readOnly }: any) {

--- a/app/components/ui/FileDropzone.tsx
+++ b/app/components/ui/FileDropzone.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertCircle,
+  Check,
+  FileImage,
+  FileText,
+  Loader2,
+  UploadCloud,
+  X,
+  RefreshCw,
+} from "lucide-react";
+import Button from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+type UploadStatus = "queued" | "uploading" | "success" | "error";
+
+export interface UploadHelpers {
+  onProgress: (progress: number) => void;
+  signal: AbortSignal;
+}
+
+export interface FileDropzoneItem<TMeta = any> {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+  status: UploadStatus;
+  progress: number;
+  error?: string;
+  file?: File;
+  previewUrl?: string;
+  meta?: TMeta;
+}
+
+export interface FileDropzoneProps<TMeta = any> {
+  files: FileDropzoneItem<TMeta>[];
+  onFilesChange: (files: FileDropzoneItem<TMeta>[]) => void;
+  onUpload: (file: File, helpers: UploadHelpers) => Promise<TMeta>;
+  multiple?: boolean;
+  accept?: string | string[];
+  maxFiles?: number;
+  disabled?: boolean;
+  className?: string;
+  dropLabel?: string;
+  description?: string;
+  helperText?: string;
+}
+
+const createId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const formatFileSize = (size: number) => {
+  if (size === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(units.length - 1, Math.floor(Math.log(size) / Math.log(1024)));
+  return `${(size / Math.pow(1024, index)).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+};
+
+const isPdf = (type: string, name?: string) => {
+  if (!type && name) return name.toLowerCase().endsWith(".pdf");
+  return type === "application/pdf" || (name ? name.toLowerCase().endsWith(".pdf") : false);
+};
+
+const isImage = (type: string, name?: string) => {
+  if (type) return type.startsWith("image/");
+  if (!name) return false;
+  return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"].some((ext) =>
+    name.toLowerCase().endsWith(ext),
+  );
+};
+
+const normalizeAccept = (accept?: string | string[]) => {
+  if (!accept) return undefined;
+  if (Array.isArray(accept)) return accept.flatMap((entry) => entry.split(",")).map((entry) => entry.trim()).filter(Boolean);
+  return accept
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+};
+
+const matchesAccept = (file: File, acceptList?: string[]) => {
+  if (!acceptList || acceptList.length === 0) return true;
+  return acceptList.some((rule) => {
+    if (!rule) return true;
+    const lowerRule = rule.toLowerCase();
+    if (lowerRule === "*/*") return true;
+    if (lowerRule.endsWith("/*")) {
+      const base = lowerRule.replace(/\*$/, "");
+      return file.type.toLowerCase().startsWith(base);
+    }
+    if (lowerRule.startsWith(".")) {
+      return file.name.toLowerCase().endsWith(lowerRule);
+    }
+    return file.type.toLowerCase() === lowerRule;
+  });
+};
+
+function cleanupPreview(url?: string) {
+  if (!url) return;
+  try {
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    console.warn("Failed to revoke preview url", err);
+  }
+}
+
+export default function FileDropzone<TMeta = any>({
+  files,
+  onFilesChange,
+  onUpload,
+  multiple = true,
+  accept,
+  maxFiles,
+  disabled,
+  className,
+  dropLabel = "Drag and drop files here or click to browse",
+  description,
+  helperText,
+}: FileDropzoneProps<TMeta>) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const controllersRef = useRef<Record<string, AbortController>>({});
+  const filesRef = useRef<FileDropzoneItem<TMeta>[]>(files);
+  filesRef.current = files;
+
+  useEffect(() => {
+    return () => {
+      Object.values(controllersRef.current).forEach((controller) => {
+        controller.abort();
+      });
+      filesRef.current.forEach((item) => cleanupPreview(item.previewUrl));
+    };
+  }, []);
+
+  const acceptList = useMemo(() => normalizeAccept(accept), [accept]);
+
+  const updateFiles = (
+    updater: (current: FileDropzoneItem<TMeta>[]) => FileDropzoneItem<TMeta>[],
+  ) => {
+    const next = updater(filesRef.current);
+    filesRef.current = next;
+    onFilesChange(next);
+  };
+
+  const updateFile = (id: string, patch: Partial<FileDropzoneItem<TMeta>>) => {
+    updateFiles((current) =>
+      current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+    );
+  };
+
+  const handleFiles = (incoming: File[]) => {
+    if (!incoming.length) return;
+
+    const accepted: File[] = [];
+    const rejected: File[] = [];
+
+    incoming.forEach((file) => {
+      if (matchesAccept(file, acceptList)) accepted.push(file);
+      else rejected.push(file);
+    });
+
+    if (rejected.length) {
+      toast.error(
+        `${rejected.length} file${rejected.length > 1 ? "s" : ""} not accepted (${rejected
+          .map((file) => file.name)
+          .join(", ")}).`,
+      );
+    }
+
+    if (!accepted.length) return;
+
+    let newItems: FileDropzoneItem<TMeta>[] = [];
+
+    updateFiles((current) => {
+      const currentSuccessful = current.filter((item) => item.status !== "error");
+      if (maxFiles && currentSuccessful.length >= maxFiles) {
+        toast.warning(`Maximum of ${maxFiles} file${maxFiles > 1 ? "s" : ""} allowed.`);
+        return current;
+      }
+
+      let available = maxFiles ? maxFiles - currentSuccessful.length : accepted.length;
+      if (!multiple) available = 1;
+
+      const slice = accepted.slice(0, available);
+      if (!slice.length) return current;
+
+      if (!multiple) {
+        current.forEach((item) => {
+          cleanupPreview(item.previewUrl);
+        });
+      }
+
+      newItems = slice.map<FileDropzoneItem<TMeta>>((file) => {
+        const previewUrl = isImage(file.type, file.name)
+          ? URL.createObjectURL(file)
+          : undefined;
+        return {
+          id: createId(),
+          name: file.name,
+          size: file.size,
+          type: file.type,
+          status: "queued",
+          progress: 0,
+          file,
+          previewUrl,
+        };
+      });
+
+      return multiple ? [...current, ...newItems] : newItems;
+    });
+
+    newItems.forEach((item) => {
+      startUpload(item.id);
+    });
+  };
+
+  const startUpload = (id: string) => {
+    const item = filesRef.current.find((candidate) => candidate.id === id);
+    if (!item?.file) return;
+    const controller = new AbortController();
+    controllersRef.current[id] = controller;
+    updateFile(id, { status: "uploading", progress: 5, error: undefined });
+
+    const safeOnProgress = (progress: number) => {
+      const next = Number.isFinite(progress) ? Math.max(0, Math.min(100, progress)) : 0;
+      updateFile(id, { progress: next });
+    };
+
+    Promise.resolve(
+      onUpload(item.file!, {
+        onProgress: safeOnProgress,
+        signal: controller.signal,
+      }),
+    )
+      .then((meta) => {
+        updateFile(id, { status: "success", progress: 100, meta, file: undefined });
+        toast.success(`${item.name} uploaded successfully`);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          updateFile(id, { status: "error", error: "Upload cancelled", progress: 0 });
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+              ? error
+              : "Failed to upload file";
+        updateFile(id, { status: "error", error: message, progress: 0 });
+        toast.error(`${item.name}: ${message}`);
+      })
+      .finally(() => {
+        delete controllersRef.current[id];
+      });
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDragging(false);
+    const files = Array.from(event.dataTransfer.files || []);
+    handleFiles(files);
+  };
+
+  const handleBrowse = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const list = event.target.files;
+    if (!list) return;
+    handleFiles(Array.from(list));
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const removeFile = (id: string) => {
+    if (disabled) return;
+    const controller = controllersRef.current[id];
+    if (controller) controller.abort();
+    const item = filesRef.current.find((file) => file.id === id);
+    cleanupPreview(item?.previewUrl);
+    updateFiles((current) => current.filter((file) => file.id !== id));
+  };
+
+  const retryFile = (item: FileDropzoneItem<TMeta>) => {
+    if (disabled) return;
+    if (!item.file) {
+      toast.error("Original file not available for retry");
+      return;
+    }
+    startUpload(item.id);
+  };
+
+  const previewFor = (item: FileDropzoneItem<TMeta>) => {
+    const metaAny = item.meta as any;
+    const metaType = metaAny?.type || item.type;
+    const metaName = metaAny?.name || item.name;
+    const metaUrl = metaAny?.url || metaAny?.signedUrl || metaAny?.previewUrl;
+    const displayUrl = metaUrl || item.previewUrl;
+
+    if (displayUrl && isImage(metaType, metaName)) {
+      return (
+        <img
+          src={displayUrl}
+          alt={metaName || item.name}
+          className="h-12 w-12 rounded-md object-cover"
+        />
+      );
+    }
+
+    if (displayUrl && isPdf(metaType, metaName)) {
+      return (
+        <iframe
+          src={displayUrl}
+          title={metaName || item.name}
+          className="h-12 w-12 rounded-md"
+        />
+      );
+    }
+
+    return (
+      <div className="h-12 w-12 flex items-center justify-center rounded-md bg-muted">
+        {isImage(item.type, item.name) ? (
+          <FileImage className="h-5 w-5 text-muted-foreground" />
+        ) : (
+          <FileText className="h-5 w-5 text-muted-foreground" />
+        )}
+      </div>
+    );
+  };
+
+  const hasFiles = files.length > 0;
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div
+        className={cn(
+          "flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed p-6 text-center transition-colors",
+          isDragging ? "border-primary bg-primary/5" : "border-border",
+          disabled && "pointer-events-none opacity-60",
+        )}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          if (disabled) return;
+          setIsDragging(true);
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          if (disabled) return;
+          setIsDragging(true);
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          if (disabled) return;
+          if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+            setIsDragging(false);
+          }
+        }}
+        onDrop={disabled ? undefined : handleDrop}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        onClick={() => {
+          if (disabled) return;
+          inputRef.current?.click();
+        }}
+        onKeyDown={(event) => {
+          if (disabled) return;
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+      >
+        <UploadCloud className="h-10 w-10 text-muted-foreground" />
+        <div className="text-sm font-medium text-foreground">{dropLabel}</div>
+        {description && (
+          <div className="text-xs text-muted-foreground">{description}</div>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          multiple={multiple}
+          accept={acceptList?.join(",")}
+          onChange={handleBrowse}
+          disabled={disabled}
+        />
+      </div>
+
+      {helperText && (
+        <p className="text-xs text-muted-foreground">{helperText}</p>
+      )}
+
+      {hasFiles && (
+        <div className="space-y-3">
+          {files.map((item) => (
+            <div
+              key={item.id}
+              className={cn(
+                "flex items-center gap-3 rounded-lg border bg-card/60 p-3",
+                item.status === "error" && "border-red-200 bg-red-50",
+              )}
+            >
+              {previewFor(item)}
+              <div className="flex-1">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <span>{item.name}</span>
+                  <span className="text-xs text-muted-foreground">{formatFileSize(item.size)}</span>
+                </div>
+                <div className="mt-1 flex items-center gap-2 text-xs">
+                  {item.status === "uploading" && (
+                    <span className="flex items-center gap-1 text-blue-600">
+                      <Loader2 className="h-3 w-3 animate-spin" /> Uploading…
+                    </span>
+                  )}
+                  {item.status === "success" && (
+                    <span className="flex items-center gap-1 text-emerald-600">
+                      <Check className="h-3 w-3" /> Uploaded
+                    </span>
+                  )}
+                  {item.status === "error" && (
+                    <span className="flex items-center gap-1 text-red-600">
+                      <AlertCircle className="h-3 w-3" /> {item.error || "Failed"}
+                    </span>
+                  )}
+                </div>
+                {item.status !== "success" && (
+                  <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className={cn(
+                        "h-full rounded-full",
+                        item.status === "error" ? "bg-red-400" : "bg-primary",
+                      )}
+                      style={{ width: `${item.status === "error" ? 100 : item.progress}%` }}
+                    />
+                  </div>
+                )}
+                {item.status === "success" && (item.meta as any)?.url && (
+                  <a
+                    href={(item.meta as any).url as string}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex text-xs text-primary underline"
+                  >
+                    View document
+                  </a>
+                )}
+              </div>
+              <div className="flex flex-col items-end gap-2">
+                {!disabled && item.status === "error" && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => retryFile(item)}
+                    className="flex items-center gap-1"
+                  >
+                    <RefreshCw className="h-3 w-3" /> Retry
+                  </Button>
+                )}
+                {!disabled && (
+                  <button
+                    type="button"
+                    onClick={() => removeFile(item.id)}
+                    className="rounded-full p-1 text-muted-foreground transition hover:bg-muted"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/enhancedFormRenderer.test.ts
+++ b/tests/enhancedFormRenderer.test.ts
@@ -11,8 +11,12 @@ test("renders existing document preview for file fields", () => {
   const register = () => ({});
   const watch = (id: string) =>
     id === "f1" ? { url: "/docs/test.pdf", name: "test.pdf" } : null;
-  const html = renderToString(renderField(field, register, watch, () => {}));
-  assert.ok(html.includes("<iframe"));
+  const html = renderToString(
+    renderField(field, register, watch, () => {}, false, {
+      uploadContext: { employeeId: "emp-1", formName: "Test Form" },
+    }),
+  );
+  assert.ok(html.includes("View document"));
   assert.ok(html.includes("/docs/test.pdf"));
   assert.ok(html.includes("test.pdf"));
 });


### PR DESCRIPTION
## Summary
- introduce a reusable FileDropzone component that supports previews, progress, retry, and toast feedback
- update the news creation flow to use the dropzone for cover and attachment uploads backed by a new API route
- render the dropzone for form file fields, preserving metadata handling and extending tests accordingly
- normalize the employee search filter composition so build-time type checks succeed and order results by the related user's update time

## Testing
- npm test -- --runTestsByPath tests/enhancedFormRenderer.test.ts
- npm run lint *(fails due to pre-existing lint violations in the repository)*
- npm run build *(fails: missing DATABASE_URL environment variable for Prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68d1887bf07c8331a313fa9792adbeb5