### PR TITLE
Integrate shared filters into offboarding and permissions pages

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -198,6 +198,15 @@ This implementation successfully delivers all requested features with zero regre
 ### API Validation:
 
 - ✅ Input validation on all endpoints
+
+## 🗂️ List Page Filter Patterns
+
+- ✅ Wrap list-centric pages in `<FilterProvider>` so shared filter state (search, status, department, role, sort) can be consumed by tables, empty states, and server fetches.
+- ✅ Use `<FilterBar>` with the relevant configuration flags:
+  - `showStatusFilter`, `showDepartmentFilter`, and `showJobRoleFilter` enable the shared multi-select drawers for each dimension.
+  - Supply option arrays via `statusOptions`, `departmentOptions`, `jobRoleOptions`, and `sortOptions` to keep labels consistent with API IDs.
+  - Saved views are available out of the box: pass `savedViewsEnabled`, `savedViews`, and the callbacks (`onSaveView`, `onSelectView`, `onDeleteView`) to allow users to capture reusable filter presets on any future list page.
+- ✅ For consistent UX, pair data regions with the shared `FilteredListLoading` and `FilteredListEmpty` helpers (from `@/components/ui/FilteredListState`). They render active-filter summaries, contextual messaging, and a one-click clear action without duplicating logic.
 - ✅ Company isolation and security
 - ✅ Proper error handling and messaging
 - ✅ Relationship integrity checks

--- a/app/(withSidebar)/offboarding/page.tsx
+++ b/app/(withSidebar)/offboarding/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { PageShell } from "@/components/ui/PageShell";
-import Button from "@/components/ui/Button";
 import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
-import { PageLoader } from "@/components/ui/LoadingSpinner";
 import { Badge } from "@/components/ui/Badge";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -15,7 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/Card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   UserX,
   Clock,
@@ -26,6 +23,13 @@ import {
 } from "lucide-react";
 import { format } from "date-fns";
 import Link from "next/link";
+import { FilterProvider, useFilters } from "@/components/ui/FilterProvider";
+import { FilterBar } from "@/components/ui/FilterBar";
+import { FilterOption } from "@/types/filter";
+import {
+  FilteredListEmpty,
+  FilteredListLoading,
+} from "@/components/ui/FilteredListState";
 
 interface OffboardingRecord {
   id: string;
@@ -61,6 +65,16 @@ interface OffboardingRecord {
   };
 }
 
+interface DepartmentOption {
+  id: string;
+  name: string;
+}
+
+interface JobRoleOption {
+  id: string;
+  name: string;
+}
+
 const statusColors = {
   IN_PROGRESS: "bg-blue-100 text-blue-800",
   COMPLETED: "bg-green-100 text-green-800",
@@ -76,31 +90,203 @@ const typeColors = {
   OTHER: "bg-gray-100 text-gray-800",
 };
 
-export default function OffboardingPage() {
-  const { data: session } = useSession();
-  const [records, setRecords] = useState<OffboardingRecord[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState("all");
+function OffboardingContent() {
   const breadcrumbs = useBreadcrumbs();
+  const { filters, updateFilter, clearFilters, isFiltered } = useFilters();
+
+  const [records, setRecords] = useState<OffboardingRecord[]>([]);
+  const [totalRecords, setTotalRecords] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [departments, setDepartments] = useState<DepartmentOption[]>([]);
+  const [jobRoles, setJobRoles] = useState<JobRoleOption[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    const loadReferenceData = async () => {
+      try {
+        const [deptRes, roleRes] = await Promise.all([
+          fetch("/api/departments"),
+          fetch("/api/job-roles"),
+        ]);
+
+        if (!active) return;
+
+        if (deptRes.ok) {
+          const data = await deptRes.json();
+          const list = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.departments)
+              ? data.departments
+              : [];
+          setDepartments(
+            list.map((dept: any) => ({
+              id: dept.id,
+              name: dept.name,
+            })),
+          );
+        }
+
+        if (roleRes.ok) {
+          const data = await roleRes.json();
+          const list = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.jobRoles)
+              ? data.jobRoles
+              : [];
+          setJobRoles(
+            list.map((role: any) => ({
+              id: role.id,
+              name: role.name,
+            })),
+          );
+        }
+      } catch (error) {
+        console.error("Error loading filter metadata", error);
+      }
+    };
+
+    loadReferenceData();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const statusOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Statuses", value: "all" },
+      { label: "In Progress", value: "IN_PROGRESS" },
+      { label: "Completed", value: "COMPLETED" },
+      { label: "Cancelled", value: "CANCELLED" },
+    ],
+    [],
+  );
+
+  const departmentOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Departments", value: "all" },
+      ...departments.map((dept) => ({
+        label: dept.name,
+        value: dept.id,
+      })),
+    ],
+    [departments],
+  );
+
+  const jobRoleOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Roles", value: "all" },
+      ...jobRoles.map((role) => ({
+        label: role.name,
+        value: role.id,
+      })),
+    ],
+    [jobRoles],
+  );
+
+  const selectedStatuses = useMemo(
+    () => filters.status.filter((value) => value.toLowerCase() !== "all"),
+    [filters.status],
+  );
+
+  const statusKey = useMemo(() => selectedStatuses.join(","), [selectedStatuses]);
+
+  const fetchOffboardingRecords = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ limit: "50" });
+      if (statusKey) {
+        params.set("status", statusKey);
+      }
+
+      const response = await fetch(`/api/offboarding?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch offboarding records");
+      }
+
+      const data = await response.json();
+      setRecords(Array.isArray(data.records) ? data.records : []);
+      setTotalRecords(data.pagination?.total ?? data.records?.length ?? 0);
+    } catch (error) {
+      console.error("Error fetching offboarding records:", error);
+      setRecords([]);
+      setTotalRecords(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusKey]);
 
   useEffect(() => {
     fetchOffboardingRecords();
-  }, [activeTab]);
+  }, [fetchOffboardingRecords]);
 
-  const fetchOffboardingRecords = async () => {
-    try {
-      setLoading(true);
-      const response = await fetch(
-        `/api/offboarding?status=${activeTab}&limit=50`,
-      );
-      if (response.ok) {
-        const data = await response.json();
-        setRecords(data.records || []);
-      }
-    } catch (error) {
-      console.error("Error fetching offboarding records:", error);
-    } finally {
-      setLoading(false);
+  const filteredRecords = useMemo(() => {
+    let results = [...records];
+    const query = filters.search.trim().toLowerCase();
+    const selectedDepartments = filters.departments.filter(
+      (value) => value !== "all",
+    );
+    const selectedJobRoles = filters.jobRoles.filter((value) => value !== "all");
+
+    if (query) {
+      results = results.filter((record) => {
+        const employeeName = `${record.employee.user.firstName} ${record.employee.user.lastName}`.toLowerCase();
+        const departmentName = record.employee.department?.name?.toLowerCase() ?? "";
+        const jobRoleName = record.employee.jobRole?.name?.toLowerCase() ?? "";
+        const initiatedBy = `${record.initiatedBy.firstName} ${record.initiatedBy.lastName}`.toLowerCase();
+        return (
+          employeeName.includes(query) ||
+          record.employee.user.email.toLowerCase().includes(query) ||
+          departmentName.includes(query) ||
+          jobRoleName.includes(query) ||
+          initiatedBy.includes(query) ||
+          record.offboardingType.toLowerCase().includes(query)
+        );
+      });
+    }
+
+    if (selectedStatuses.length > 0) {
+      const allowed = new Set(selectedStatuses);
+      results = results.filter((record) => allowed.has(record.status));
+    }
+
+    if (selectedDepartments.length > 0) {
+      const allowed = new Set(selectedDepartments);
+      results = results.filter((record) => {
+        const deptId = record.employee.department?.id;
+        return deptId ? allowed.has(deptId) : false;
+      });
+    }
+
+    if (selectedJobRoles.length > 0) {
+      const allowed = new Set(selectedJobRoles);
+      results = results.filter((record) => {
+        const jobRoleId = record.employee.jobRole?.id;
+        return jobRoleId ? allowed.has(jobRoleId) : false;
+      });
+    }
+
+    return results;
+  }, [records, filters, selectedStatuses]);
+
+  const totalCount = totalRecords || records.length;
+
+  const statusCounts = useMemo(
+    () => ({
+      ALL: totalCount,
+      IN_PROGRESS: records.filter((record) => record.status === "IN_PROGRESS").length,
+      COMPLETED: records.filter((record) => record.status === "COMPLETED").length,
+      CANCELLED: records.filter((record) => record.status === "CANCELLED").length,
+    }),
+    [records, totalCount],
+  );
+
+  const activeTab = selectedStatuses.length === 1 ? selectedStatuses[0] : "ALL";
+
+  const handleStatusTabChange = (value: string) => {
+    if (value === "ALL") {
+      updateFilter("status", []);
+    } else {
+      updateFilter("status", [value]);
     }
   };
 
@@ -117,24 +303,6 @@ export default function OffboardingPage() {
     }
   };
 
-  const filteredRecords = records.filter((record) => {
-    if (activeTab === "all") return true;
-    return record.status === activeTab.toUpperCase();
-  });
-
-  if (loading) {
-    return (
-      <PageShell
-        title="Offboarding Management"
-        description="Track and manage employee offboarding processes"
-        icon={<UserX className="w-6 h-6" />}
-        breadcrumbs={breadcrumbs}
-      >
-        <PageLoader text="Loading offboarding records..." />
-      </PageShell>
-    );
-  }
-
   return (
     <PageShell
       title="Offboarding Management"
@@ -142,199 +310,214 @@ export default function OffboardingPage() {
       icon={<UserX className="w-6 h-6" />}
       breadcrumbs={breadcrumbs}
     >
-      {/* Status Tabs */}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="mb-6">
-        <TabsList className="grid w-full max-w-md grid-cols-4">
-          <TabsTrigger value="all">All ({records.length})</TabsTrigger>
-          <TabsTrigger value="in_progress">
-            In Progress (
-            {records.filter((r) => r.status === "IN_PROGRESS").length})
-          </TabsTrigger>
-          <TabsTrigger value="completed">
-            Completed ({records.filter((r) => r.status === "COMPLETED").length})
-          </TabsTrigger>
-          <TabsTrigger value="cancelled">
-            Cancelled ({records.filter((r) => r.status === "CANCELLED").length})
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
+      <div className="space-y-6">
+        <FilterBar
+          config={{
+            searchPlaceholder: "Search by employee, department, or initiator...",
+            showStatusFilter: true,
+            showDepartmentFilter: true,
+            showJobRoleFilter: true,
+          }}
+          statusOptions={statusOptions}
+          departmentOptions={departmentOptions}
+          jobRoleOptions={jobRoleOptions}
+        />
 
-      {/* Statistics Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Total Offboardings
-            </CardTitle>
-            <UserX className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{records.length}</div>
-          </CardContent>
-        </Card>
+        <Tabs value={activeTab} onValueChange={handleStatusTabChange} className="mb-2">
+          <TabsList className="grid w-full max-w-xl grid-cols-4">
+            <TabsTrigger value="ALL">All ({statusCounts.ALL})</TabsTrigger>
+            <TabsTrigger value="IN_PROGRESS">
+              In Progress ({statusCounts.IN_PROGRESS})
+            </TabsTrigger>
+            <TabsTrigger value="COMPLETED">
+              Completed ({statusCounts.COMPLETED})
+            </TabsTrigger>
+            <TabsTrigger value="CANCELLED">
+              Cancelled ({statusCounts.CANCELLED})
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">In Progress</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
-              {records.filter((r) => r.status === "IN_PROGRESS").length}
-            </div>
-          </CardContent>
-        </Card>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Total Offboardings</CardTitle>
+              <UserX className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{totalCount}</div>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Completed</CardTitle>
-            <CheckCircle className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-green-600">
-              {records.filter((r) => r.status === "COMPLETED").length}
-            </div>
-          </CardContent>
-        </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">In Progress</CardTitle>
+              <Clock className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-blue-600">
+                {statusCounts.IN_PROGRESS}
+              </div>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Avg. Completion
-            </CardTitle>
-            <AlertCircle className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              {records.length > 0
-                ? Math.round(
-                    records.reduce(
-                      (sum, r) => sum + r.completionPercentage,
-                      0,
-                    ) / records.length,
-                  )
-                : 0}
-              %
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Completed</CardTitle>
+              <CheckCircle className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-green-600">
+                {statusCounts.COMPLETED}
+              </div>
+            </CardContent>
+          </Card>
 
-      {/* Offboarding Records */}
-      <div className="space-y-4">
-        {loading ? (
-          <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-            <p className="mt-2 text-muted-foreground">
-              Loading offboarding records...
-            </p>
-          </div>
-        ) : filteredRecords.length === 0 ? (
-          <div className="text-center py-8">
-            <UserX className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-            <p className="text-muted-foreground">
-              No offboarding records found.
-            </p>
-          </div>
-        ) : (
-          filteredRecords.map((record) => (
-            <Card key={record.id} className="hover:shadow-md transition-shadow">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex items-center space-x-2">
-                      {getStatusIcon(record.status)}
-                      <div>
-                        <CardTitle className="text-lg">
-                          <Link
-                            href={`/employees/${record.employee.id}/overview`}
-                            className="hover:text-primary transition-colors"
-                          >
-                            {record.employee.user.firstName}{" "}
-                            {record.employee.user.lastName}
-                          </Link>
-                        </CardTitle>
-                        <CardDescription>
-                          {record.employee.jobRole?.name} •{" "}
-                          {record.employee.department?.name}
-                        </CardDescription>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Avg. Completion</CardTitle>
+              <AlertCircle className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+                {records.length > 0
+                  ? Math.round(
+                      records.reduce(
+                        (sum, record) => sum + record.completionPercentage,
+                        0,
+                      ) / records.length,
+                    )
+                  : 0}
+                %
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          {loading ? (
+            <FilteredListLoading
+              resourceName="Offboarding records"
+              filters={filters}
+              statusOptions={statusOptions}
+              departmentOptions={departmentOptions}
+              jobRoleOptions={jobRoleOptions}
+            />
+          ) : filteredRecords.length === 0 ? (
+            <FilteredListEmpty
+              resourceName="Offboarding records"
+              filters={filters}
+              isFiltered={isFiltered}
+              onClearFilters={isFiltered ? clearFilters : undefined}
+              statusOptions={statusOptions}
+              departmentOptions={departmentOptions}
+              jobRoleOptions={jobRoleOptions}
+            />
+          ) : (
+            filteredRecords.map((record) => (
+              <Card key={record.id} className="transition-shadow hover:shadow-md">
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                      <div className="flex items-center space-x-2">
+                        {getStatusIcon(record.status)}
+                        <div>
+                          <CardTitle className="text-lg">
+                            <Link
+                              href={`/employees/${record.employee.id}/overview`}
+                              className="transition-colors hover:text-primary"
+                            >
+                              {record.employee.user.firstName}{" "}
+                              {record.employee.user.lastName}
+                            </Link>
+                          </CardTitle>
+                          <CardDescription>
+                            {record.employee.jobRole?.name || "No role"} •{" "}
+                            {record.employee.department?.name || "No department"}
+                          </CardDescription>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Badge
-                      className={
-                        statusColors[record.status as keyof typeof statusColors]
-                      }
-                    >
-                      {record.status.replace("_", " ")}
-                    </Badge>
-                    <Badge
-                      variant="outline"
-                      className={
-                        typeColors[
-                          record.offboardingType as keyof typeof typeColors
-                        ]
-                      }
-                    >
-                      {record.offboardingType.replace("_", " ")}
-                    </Badge>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2 text-sm text-muted-foreground">
-                      <Calendar className="w-4 h-4" />
-                      <span>Last Working Date</span>
+                    <div className="flex items-center space-x-2">
+                      <Badge
+                        className={
+                          statusColors[record.status as keyof typeof statusColors]
+                        }
+                      >
+                        {record.status.replaceAll("_", " ")}
+                      </Badge>
+                      <Badge
+                        variant="outline"
+                        className={
+                          typeColors[
+                            record.offboardingType as keyof typeof typeColors
+                          ]
+                        }
+                      >
+                        {record.offboardingType.replaceAll("_", " ")}
+                      </Badge>
                     </div>
-                    <p className="font-medium">
-                      {format(new Date(record.lastWorkingDate), "MMM dd, yyyy")}
-                    </p>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                    <div className="space-y-2">
+                      <div className="flex items-center space-x-2 text-sm text-muted-foreground">
+                        <Calendar className="w-4 h-4" />
+                        <span>Last Working Date</span>
+                      </div>
+                      <p className="font-medium">
+                        {format(new Date(record.lastWorkingDate), "MMM dd, yyyy")}
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center space-x-2 text-sm text-muted-foreground">
+                        <User className="w-4 h-4" />
+                        <span>Initiated By</span>
+                      </div>
+                      <p className="font-medium">
+                        {record.initiatedBy.firstName}{" "}
+                        {record.initiatedBy.lastName}
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-sm text-muted-foreground">
+                        <span>Progress</span>
+                        <span>
+                          {record.completedTasks}/{record.totalTasks} tasks
+                        </span>
+                      </div>
+                      <Progress value={record.completionPercentage} className="w-full" />
+                    </div>
                   </div>
 
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2 text-sm text-muted-foreground">
-                      <User className="w-4 h-4" />
-                      <span>Initiated By</span>
+                  {record.status === "COMPLETED" && record.completedAt && (
+                    <div className="mt-4 border-t pt-4">
+                      <p className="text-sm text-muted-foreground">
+                        Completed on{" "}
+                        {format(
+                          new Date(record.completedAt),
+                          "MMM dd, yyyy 'at' h:mm a",
+                        )}
+                      </p>
                     </div>
-                    <p className="font-medium">
-                      {record.initiatedBy.firstName}{" "}
-                      {record.initiatedBy.lastName}
-                    </p>
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm text-muted-foreground">
-                      <span>Progress</span>
-                      <span>
-                        {record.completedTasks}/{record.totalTasks} tasks
-                      </span>
-                    </div>
-                    <Progress
-                      value={record.completionPercentage}
-                      className="w-full"
-                    />
-                  </div>
-                </div>
-
-                {record.status === "COMPLETED" && record.completedAt && (
-                  <div className="mt-4 pt-4 border-t">
-                    <p className="text-sm text-muted-foreground">
-                      Completed on{" "}
-                      {format(
-                        new Date(record.completedAt),
-                        "MMM dd, yyyy 'at' h:mm a",
-                      )}
-                    </p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          ))
-        )}
+                  )}
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
       </div>
     </PageShell>
+  );
+}
+
+export default function OffboardingPage() {
+  return (
+    <FilterProvider>
+      <OffboardingContent />
+    </FilterProvider>
   );
 }

--- a/app/(withSidebar)/settings/permissions/page.tsx
+++ b/app/(withSidebar)/settings/permissions/page.tsx
@@ -1,21 +1,51 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import Button from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
-import { Badge } from "@/components/ui/Badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/Table";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/Select";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuItem } from "@/components/ui/dropdown-menu";
-import { Plus, Search, MoreHorizontal, Edit, Trash2, Copy, Shield, Users } from "lucide-react";
+import {
+  Plus,
+  MoreHorizontal,
+  Edit,
+  Trash2,
+  Copy,
+  Shield,
+  Users,
+} from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
-import { getScreenDisplayName } from "@/lib/permissions";
 import { PageShell } from "@/components/ui/PageShell";
 import { breadcrumbConfigs } from "@/components/ui/Breadcrumb";
+import { FilterProvider, useFilters } from "@/components/ui/FilterProvider";
+import { FilterBar } from "@/components/ui/FilterBar";
+import { FilterOption } from "@/types/filter";
+import {
+  FilteredListEmpty,
+  FilteredListLoading,
+} from "@/components/ui/FilteredListState";
 
 interface PermissionProfile {
   id: string;
@@ -25,6 +55,10 @@ interface PermissionProfile {
   builtIn: boolean;
   createdAt: string;
   updatedAt: string;
+  constraints?: {
+    departmentIds?: string[];
+    jobRoles?: string[];
+  } | null;
   _count?: {
     users: number;
   };
@@ -40,53 +74,186 @@ interface ProfilesResponse {
   };
 }
 
-export default function PermissionsPage() {
-  const { data: session } = useSession();
+interface SimpleOption {
+  id: string;
+  name: string;
+}
+
+function PermissionsContent() {
+  const { filters, clearFilters, isFiltered } = useFilters();
+
   const [profiles, setProfiles] = useState<PermissionProfile[]>([]);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [limit] = useState(10);
   const [total, setTotal] = useState(0);
-  const [filterType, setFilterType] = useState<"all" | "builtin" | "custom">(
-    "all",
-  );
-  const [sortBy, setSortBy] = useState<"name" | "createdAt" | "users">("name");
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [profileToDelete, setProfileToDelete] =
     useState<PermissionProfile | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [departments, setDepartments] = useState<SimpleOption[]>([]);
+  const [jobRoles, setJobRoles] = useState<SimpleOption[]>([]);
 
   useEffect(() => {
-    fetchProfiles();
-  }, [search, page, filterType, sortBy, sortOrder]);
+    let active = true;
+    const loadMetadata = async () => {
+      try {
+        const [deptRes, roleRes] = await Promise.all([
+          fetch("/api/departments"),
+          fetch("/api/job-roles"),
+        ]);
 
-  const fetchProfiles = async () => {
+        if (!active) return;
+
+        if (deptRes.ok) {
+          const data = await deptRes.json();
+          const list = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.departments)
+              ? data.departments
+              : [];
+          setDepartments(
+            list.map((dept: any) => ({ id: dept.id, name: dept.name })),
+          );
+        }
+
+        if (roleRes.ok) {
+          const data = await roleRes.json();
+          const list = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.jobRoles)
+              ? data.jobRoles
+              : [];
+          setJobRoles(
+            list.map((role: any) => ({ id: role.id, name: role.name })),
+          );
+        }
+      } catch (error) {
+        console.error("Failed to load filter metadata", error);
+      }
+    };
+
+    loadMetadata();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const statusOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Types", value: "all" },
+      { label: "Built-in", value: "builtin" },
+      { label: "Custom", value: "custom" },
+    ],
+    [],
+  );
+
+  const departmentOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Departments", value: "all" },
+      ...departments.map((dept) => ({ label: dept.name, value: dept.id })),
+    ],
+    [departments],
+  );
+
+  const jobRoleOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "All Roles", value: "all" },
+      ...jobRoles.map((role) => ({ label: role.name, value: role.id })),
+    ],
+    [jobRoles],
+  );
+
+  const sortOptions: FilterOption[] = useMemo(
+    () => [
+      { label: "Name", value: "name" },
+      { label: "Created Date", value: "createdAt" },
+      { label: "Users Assigned", value: "users" },
+    ],
+    [],
+  );
+
+  const selectedStatus = useMemo(
+    () => filters.status.filter((value) => value !== "all"),
+    [filters.status],
+  );
+
+  const statusKey = useMemo(() => selectedStatus.join(","), [selectedStatus]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filters.search, statusKey, filters.sortBy, filters.sortOrder]);
+
+  const fetchProfiles = useCallback(async () => {
     try {
       setLoading(true);
       const params = new URLSearchParams({
-        search,
         page: page.toString(),
         limit: limit.toString(),
-        filterType,
-        sortBy,
-        sortOrder,
+        sortBy: filters.sortBy || "name",
+        sortOrder: filters.sortOrder || "asc",
       });
 
-      const response = await fetch(`/api/permissions?${params}`);
-      if (!response.ok) throw new Error("Failed to fetch profiles");
+      const searchTerm = filters.search.trim();
+      if (searchTerm) {
+        params.set("search", searchTerm);
+      }
+
+      if (selectedStatus.length === 1) {
+        params.set("filterType", selectedStatus[0]);
+      } else {
+        params.set("filterType", "all");
+      }
+
+      const response = await fetch(`/api/permissions?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch profiles");
+      }
 
       const data: ProfilesResponse = await response.json();
-      setProfiles(data.profiles);
-      setTotal(data.pagination.total);
+      setProfiles(Array.isArray(data.profiles) ? data.profiles : []);
+      setTotal(data.pagination?.total ?? 0);
     } catch (error) {
       console.error("Error fetching profiles:", error);
       toast.error("Failed to load permission profiles");
+      setProfiles([]);
+      setTotal(0);
     } finally {
       setLoading(false);
     }
-  };
+  }, [filters.search, filters.sortBy, filters.sortOrder, statusKey, page, limit, selectedStatus]);
+
+  useEffect(() => {
+    fetchProfiles();
+  }, [fetchProfiles]);
+
+  const filteredProfiles = useMemo(() => {
+    let results = [...profiles];
+    const selectedDepartments = filters.departments.filter(
+      (value) => value !== "all",
+    );
+    const selectedJobRoles = filters.jobRoles.filter((value) => value !== "all");
+
+    if (selectedDepartments.length > 0) {
+      const allowed = new Set(selectedDepartments);
+      results = results.filter((profile) => {
+        const deptIds = profile.constraints?.departmentIds ?? [];
+        if (deptIds.length === 0) return false;
+        return deptIds.some((id) => allowed.has(id));
+      });
+    }
+
+    if (selectedJobRoles.length > 0) {
+      const allowed = new Set(selectedJobRoles);
+      results = results.filter((profile) => {
+        const roleIds = profile.constraints?.jobRoles ?? [];
+        if (roleIds.length === 0) return false;
+        return roleIds.some((id) => allowed.has(id));
+      });
+    }
+
+    return results;
+  }, [profiles, filters.departments, filters.jobRoles]);
 
   const handleClone = async (profile: PermissionProfile) => {
     try {
@@ -100,8 +267,6 @@ export default function PermissionsPage() {
       }
 
       const clonedProfile = await response.json();
-
-      // Add the cloned profile to the list and refresh
       fetchProfiles();
       toast.success(`Profile cloned as "${clonedProfile.name}"`);
     } catch (error) {
@@ -147,16 +312,21 @@ export default function PermissionsPage() {
 
   const getTotalPermissions = (permissions: Record<string, string[]>) => {
     return Object.values(permissions).reduce(
-      (total, actions) => total + actions.length,
+      (count, actions) => count + actions.length,
       0,
     );
   };
+
+  const paginationStart = (page - 1) * limit + 1;
+  const paginationEnd = Math.min(page * limit, total);
+
+  const displayedCount = isFiltered ? filteredProfiles.length : total;
 
   return (
     <PageShell
       title="Permission Profiles"
       description="Manage permission profiles for different user roles"
-      breadcrumbs={breadcrumbConfigs.settingsSection('Permission Profiles')}
+      breadcrumbs={breadcrumbConfigs.settingsSection("Permission Profiles")}
       action={
         <Link href="/settings/permissions/new">
           <Button>
@@ -168,229 +338,206 @@ export default function PermissionsPage() {
       showHomeIcon={false}
     >
       <div className="space-y-6">
-      {/* Search and Filters */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Search & Filter</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div className="md:col-span-2">
-              <Input
-                placeholder="Search profiles by name or description..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="w-full"
-              />
-            </div>
-            <Select
-              value={filterType}
-              onValueChange={(value: any) => setFilterType(value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Filter by type" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Profiles</SelectItem>
-                <SelectItem value="builtin">Built-in Only</SelectItem>
-                <SelectItem value="custom">Custom Only</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select
-              value={`${sortBy}-${sortOrder}`}
-              onValueChange={(value) => {
-                const [field, order] = value.split("-") as [
-                  typeof sortBy,
-                  typeof sortOrder,
-                ];
-                setSortBy(field);
-                setSortOrder(order);
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Sort by" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="name-asc">Name (A-Z)</SelectItem>
-                <SelectItem value="name-desc">Name (Z-A)</SelectItem>
-                <SelectItem value="createdAt-desc">Newest First</SelectItem>
-                <SelectItem value="createdAt-asc">Oldest First</SelectItem>
-                <SelectItem value="users-desc">Most Users</SelectItem>
-                <SelectItem value="users-asc">Least Users</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
+        <FilterBar
+          config={{
+            searchPlaceholder: "Search profiles by name or description...",
+            showStatusFilter: true,
+            showDepartmentFilter: true,
+            showJobRoleFilter: true,
+          }}
+          statusOptions={statusOptions}
+          departmentOptions={departmentOptions}
+          jobRoleOptions={jobRoleOptions}
+          sortOptions={sortOptions}
+        />
 
-      {/* Profiles Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg flex items-center gap-2">
-            <Shield className="h-5 w-5" />
-            Permission Profiles ({total})
-          </CardTitle>
-          <CardDescription>
-            Configure access levels for different user types
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {loading ? (
-            <div className="text-center py-8">Loading profiles...</div>
-          ) : profiles.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              No permission profiles found
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Screens</TableHead>
-                  <TableHead>Permissions</TableHead>
-                  <TableHead>Users</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead className="w-[50px]">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {profiles.map((profile) => (
-                  <TableRow key={profile.id}>
-                    <TableCell className="font-medium">
-                      {profile.name}
-                    </TableCell>
-                    <TableCell className="max-w-xs truncate">
-                      {profile.description || "No description"}
-                    </TableCell>
-                    <TableCell>
-                      {getTotalScreens(profile.permissions)}
-                    </TableCell>
-                    <TableCell>
-                      {getTotalPermissions(profile.permissions)}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1">
-                        <Users className="h-4 w-4 text-gray-500" />
-                        {profile._count?.users || 0}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      {profile.builtIn ? (
-                        <Badge variant="secondary">Built-in</Badge>
-                      ) : (
-                        <Badge variant="outline">Custom</Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <DropdownMenu
-                        trigger={
-                          <Button variant="ghost" size="sm">
-                            <MoreHorizontal className="h-4 w-4" />
-                          </Button>
-                        }
-                        align="right"
-                      >
-                        <DropdownMenuItem asChild>
-                          <Link
-                            href={`/settings/permissions/${profile.id}/edit`}
-                          >
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Shield className="h-5 w-5" />
+              Permission Profiles ({displayedCount}
+              {isFiltered ? ` of ${total}` : ""})
+            </CardTitle>
+            <CardDescription>
+              Configure access levels for different user types
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <FilteredListLoading
+                resourceName="Permission profiles"
+                filters={filters}
+                statusOptions={statusOptions}
+                departmentOptions={departmentOptions}
+                jobRoleOptions={jobRoleOptions}
+              />
+            ) : filteredProfiles.length === 0 ? (
+              <FilteredListEmpty
+                resourceName="Permission profiles"
+                filters={filters}
+                isFiltered={isFiltered}
+                onClearFilters={isFiltered ? clearFilters : undefined}
+                statusOptions={statusOptions}
+                departmentOptions={departmentOptions}
+                jobRoleOptions={jobRoleOptions}
+              />
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Screens</TableHead>
+                    <TableHead>Permissions</TableHead>
+                    <TableHead>Users</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="w-[50px]">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredProfiles.map((profile) => (
+                    <TableRow key={profile.id}>
+                      <TableCell className="font-medium">
+                        {profile.name}
+                      </TableCell>
+                      <TableCell className="max-w-xs truncate">
+                        {profile.description || "No description"}
+                      </TableCell>
+                      <TableCell>
+                        {getTotalScreens(profile.permissions)}
+                      </TableCell>
+                      <TableCell>
+                        {getTotalPermissions(profile.permissions)}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Users className="h-4 w-4 text-gray-500" />
+                          {profile._count?.users || 0}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {profile.builtIn ? (
+                          <span className="rounded-full bg-muted px-2 py-1 text-xs font-medium">
+                            Built-in
+                          </span>
+                        ) : (
+                          <span className="rounded-full border px-2 py-1 text-xs font-medium">
+                            Custom
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <DropdownMenu
+                          trigger={
+                            <Button variant="ghost" size="sm">
+                              <MoreHorizontal className="h-4 w-4" />
+                            </Button>
+                          }
+                          align="right"
+                        >
+                          <DropdownMenuItem asChild>
+                            <Link href={`/settings/permissions/${profile.id}/edit`}>
+                              <div className="flex items-center">
+                                <Edit className="h-4 w-4 mr-2" />
+                                Edit
+                              </div>
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleClone(profile)}>
                             <div className="flex items-center">
-                              <Edit className="h-4 w-4 mr-2" />
-                              Edit
-                            </div>
-                          </Link>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleClone(profile)}>
-                          <div className="flex items-center">
-                            <Copy className="h-4 w-4 mr-2" />
-                            Clone
-                          </div>
-                        </DropdownMenuItem>
-                        {!profile.builtIn && (
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setProfileToDelete(profile);
-                              setShowDeleteDialog(true);
-                            }}
-                          >
-                            <div className="flex items-center text-red-600">
-                              <Trash2 className="h-4 w-4 mr-2" />
-                              Delete
+                              <Copy className="h-4 w-4 mr-2" />
+                              Clone
                             </div>
                           </DropdownMenuItem>
-                        )}
-                      </DropdownMenu>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
+                          {!profile.builtIn && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setProfileToDelete(profile);
+                                setShowDeleteDialog(true);
+                              }}
+                            >
+                              <div className="flex items-center text-red-600">
+                                <Trash2 className="h-4 w-4 mr-2" />
+                                Delete
+                              </div>
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenu>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
 
-          {/* Pagination */}
-          {total > limit && (
-            <div className="flex items-center justify-between mt-4">
-              <div className="text-sm text-gray-500">
-                Showing {(page - 1) * limit + 1} to{" "}
-                {Math.min(page * limit, total)} of {total} profiles
+            {!loading && filteredProfiles.length > 0 && total > limit && (
+              <div className="mt-4 flex items-center justify-between">
+                <div className="text-sm text-gray-500">
+                  Showing {paginationStart} to {paginationEnd} of {total} profiles
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                    disabled={page === 1}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((prev) => prev + 1)}
+                    disabled={page * limit >= total}
+                  >
+                    Next
+                  </Button>
+                </div>
               </div>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setPage(page - 1)}
-                  disabled={page === 1}
-                >
-                  Previous
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setPage(page + 1)}
-                  disabled={page * limit >= total}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            )}
+          </CardContent>
+        </Card>
 
-      {/* Delete Confirmation Dialog */}
-      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Permission Profile</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete "{profileToDelete?.name}"? This
-              action cannot be undone.
-              {profileToDelete?._count?.users &&
-                profileToDelete._count.users > 0 && (
-                  <span className="block mt-2 text-red-600 font-medium">
-                    Warning: This profile is currently assigned to{" "}
-                    {profileToDelete._count.users} user(s). They will lose their
-                    custom permissions and fall back to role-based permissions.
-                  </span>
-                )}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setShowDeleteDialog(false)}
-              disabled={deleting}
-            >
-              Cancel
-            </Button>
-            <Button variant="danger" onClick={handleDelete} disabled={deleting}>
-              {deleting ? "Deleting..." : "Delete Profile"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete Permission Profile</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete "{profileToDelete?.name}"? This
+                action cannot be undone.
+                {profileToDelete?._count?.users &&
+                  profileToDelete._count.users > 0 && (
+                    <span className="mt-2 block text-red-600 font-medium">
+                      Warning: This profile is currently assigned to {" "}
+                      {profileToDelete._count.users} user(s). They will lose their
+                      custom permissions and fall back to role-based permissions.
+                    </span>
+                  )}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteDialog(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button variant="danger" onClick={handleDelete} disabled={deleting}>
+                {deleting ? "Deleting..." : "Delete Profile"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </PageShell>
+  );
+}
+
+export default function PermissionsPage() {
+  return (
+    <FilterProvider>
+      <PermissionsContent />
+    </FilterProvider>
   );
 }

--- a/app/api/offboarding/route.ts
+++ b/app/api/offboarding/route.ts
@@ -23,15 +23,24 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url);
-    const status = searchParams.get("status");
+    const statusParam = searchParams.get("status");
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "10");
     const skip = (page - 1) * limit;
 
     const where: any = {};
 
-    if (status && status !== "all") {
-      where.status = status;
+    if (statusParam && statusParam !== "all") {
+      const statuses = statusParam
+        .split(",")
+        .map((value) => value.trim().toUpperCase())
+        .filter(Boolean);
+
+      if (statuses.length === 1) {
+        where.status = statuses[0];
+      } else if (statuses.length > 1) {
+        where.status = { in: statuses };
+      }
     }
 
     const [offboardingRecords, total] = await Promise.all([

--- a/app/components/ui/FilteredListState.tsx
+++ b/app/components/ui/FilteredListState.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { FilterState, FilterOption } from "@/types/filter";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Badge } from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+import { SearchX, Inbox } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const EXCLUDED_VALUES = new Set(["all"]);
+
+function getOptionLabel(value: string, options: FilterOption[] = []): string {
+  return options.find((option) => option.value === value)?.label || value;
+}
+
+function formatValueList(values: string[]): string {
+  if (values.length === 0) return "";
+  if (values.length === 1) return values[0];
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, and ${values[values.length - 1]}`;
+}
+
+function buildFilterSummaries(
+  filters: FilterState,
+  options: {
+    departmentOptions?: FilterOption[];
+    jobRoleOptions?: FilterOption[];
+    statusOptions?: FilterOption[];
+  },
+) {
+  const segments: string[] = [];
+  const badges: string[] = [];
+
+  if (filters.search.trim()) {
+    const searchLabel = `Search \"${filters.search.trim()}\"`;
+    segments.push(searchLabel.toLowerCase());
+    badges.push(searchLabel);
+  }
+
+  const statusValues = filters.status.filter((value) => !EXCLUDED_VALUES.has(value));
+  if (statusValues.length > 0) {
+    const labels = statusValues.map((value) =>
+      getOptionLabel(value, options.statusOptions),
+    );
+    const joined = formatValueList(labels);
+    segments.push(`status ${joined.toLowerCase()}`);
+    badges.push(`Status: ${joined}`);
+  }
+
+  const departmentValues = filters.departments.filter(
+    (value) => !EXCLUDED_VALUES.has(value),
+  );
+  if (departmentValues.length > 0) {
+    const labels = departmentValues.map((value) =>
+      getOptionLabel(value, options.departmentOptions),
+    );
+    const joined = formatValueList(labels);
+    segments.push(`department ${joined.toLowerCase()}`);
+    badges.push(`Department: ${joined}`);
+  }
+
+  const jobRoleValues = filters.jobRoles.filter(
+    (value) => !EXCLUDED_VALUES.has(value),
+  );
+  if (jobRoleValues.length > 0) {
+    const labels = jobRoleValues.map((value) =>
+      getOptionLabel(value, options.jobRoleOptions),
+    );
+    const joined = formatValueList(labels);
+    segments.push(`role ${joined.toLowerCase()}`);
+    badges.push(`Role: ${joined}`);
+  }
+
+  return { segments, badges };
+}
+
+interface FilteredListLoadingProps {
+  resourceName: string;
+  filters: FilterState;
+  departmentOptions?: FilterOption[];
+  jobRoleOptions?: FilterOption[];
+  statusOptions?: FilterOption[];
+  className?: string;
+}
+
+export function FilteredListLoading({
+  resourceName,
+  filters,
+  departmentOptions,
+  jobRoleOptions,
+  statusOptions,
+  className,
+}: FilteredListLoadingProps) {
+  const { segments } = buildFilterSummaries(filters, {
+    departmentOptions,
+    jobRoleOptions,
+    statusOptions,
+  });
+
+  const summary = segments.length
+    ? ` for ${segments.join(", ")}`
+    : "";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 text-center space-y-4",
+        className,
+      )}
+    >
+      <LoadingSpinner size="lg" showText text={`Loading ${resourceName}${summary}...`} />
+      {segments.length > 0 && (
+        <p className="text-sm text-muted-foreground max-w-xl">
+          Hang tight — we\'re fetching {resourceName.toLowerCase()} that match your
+          selected filters.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface FilteredListEmptyProps {
+  resourceName: string;
+  filters: FilterState;
+  isFiltered: boolean;
+  onClearFilters?: () => void;
+  departmentOptions?: FilterOption[];
+  jobRoleOptions?: FilterOption[];
+  statusOptions?: FilterOption[];
+  className?: string;
+}
+
+export function FilteredListEmpty({
+  resourceName,
+  filters,
+  isFiltered,
+  onClearFilters,
+  departmentOptions,
+  jobRoleOptions,
+  statusOptions,
+  className,
+}: FilteredListEmptyProps) {
+  const { badges, segments } = buildFilterSummaries(filters, {
+    departmentOptions,
+    jobRoleOptions,
+    statusOptions,
+  });
+
+  const Icon = isFiltered ? SearchX : Inbox;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center text-center space-y-4 py-16",
+        className,
+      )}
+    >
+      <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+        <Icon className="w-8 h-8 text-muted-foreground" />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-foreground">
+          {isFiltered
+            ? `No ${resourceName.toLowerCase()} match your filters`
+            : `No ${resourceName.toLowerCase()} yet`}
+        </h3>
+        <p className="text-sm text-muted-foreground max-w-xl">
+          {isFiltered
+            ? "Try adjusting or clearing your filters to see more results."
+            : `Add new ${resourceName.toLowerCase()} to get started.`}
+        </p>
+      </div>
+
+      {isFiltered && badges.length > 0 && (
+        <div className="flex flex-wrap items-center justify-center gap-2 max-w-2xl">
+          {badges.map((badge) => (
+            <Badge key={badge} variant="outline" className="px-3 py-1 text-sm">
+              {badge}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {isFiltered && onClearFilters && (
+        <Button variant="outline" onClick={onClearFilters} className="mt-2">
+          Clear filters
+        </Button>
+      )}
+
+      {!isFiltered && segments.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Tip: apply filters to focus on specific {resourceName.toLowerCase()}.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the offboarding and permission profile list pages in the shared FilterProvider and drive search/status/department/role filters via FilterBar
- add a reusable FilteredListState helper for filter-aware loading and empty states and extend the offboarding API to accept multi-status queries
- document the filter configuration pattern so future list pages can enable saved views and consistent UI feedback

## Testing
- npm run lint *(fails: repository already contains unused variable errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d188ec87188331a23ceb054698537e