### PR TITLE
Add autosave drafts for news creation and data screens

### DIFF
--- a/app/(withSidebar)/news/create/page.tsx
+++ b/app/(withSidebar)/news/create/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = "force-dynamic";
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { Input } from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import { Switch } from "@/components/ui/switch";
@@ -16,7 +17,6 @@ import { motion } from "framer-motion";
 import { toast } from "sonner";
 import {
   ArrowLeft,
-  Save,
   Send,
   Upload,
   Image,
@@ -29,10 +29,59 @@ import {
   Eye,
   Clock,
   AlertCircle,
+  Trash2,
 } from "lucide-react";
+
+interface NewsDraftPayload {
+  title: string;
+  content: any;
+  coverImage: string;
+  videoUrl: string;
+  tags: string[];
+  pinned: boolean;
+  featured: boolean;
+  sendEmail: boolean;
+  audience: {
+    type?: "all" | "custom";
+    departments?: string[];
+    roles?: string[];
+    locations?: string[];
+  };
+  isDraft: boolean;
+}
+
+const hasMeaningfulDraft = (
+  draft: NewsDraftPayload | null | undefined,
+) => {
+  if (!draft) return false;
+  const hasContent = (() => {
+    const value = draft.content;
+    if (!value) return false;
+    if (typeof value === "string") return value.trim().length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === "object") return Object.keys(value).length > 0;
+    return true;
+  })();
+  return (
+    Boolean(draft.title?.trim()) ||
+    hasContent ||
+    Boolean(draft.coverImage?.trim()) ||
+    Boolean(draft.videoUrl?.trim()) ||
+    (Array.isArray(draft.tags) && draft.tags.length > 0) ||
+    draft.pinned ||
+    draft.featured ||
+    draft.sendEmail ||
+    (draft.audience &&
+      ((draft.audience.departments || []).length > 0 ||
+        (draft.audience.roles || []).length > 0 ||
+        (draft.audience.locations || []).length > 0 ||
+        draft.audience.type === "custom"))
+  );
+};
 
 export default function CreateNewsPostPage() {
   const router = useRouter();
+  const { data: session } = useSession();
   const [title, setTitle] = useState("");
   const [content, setContent] = useState<any>(null);
   const [coverImage, setCoverImage] = useState("");
@@ -55,6 +104,60 @@ export default function CreateNewsPostPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const coverFileInputRef = useRef<HTMLInputElement | null>(null);
+  const latestDraftRef = useRef<NewsDraftPayload>({
+    title: "",
+    content: null,
+    coverImage: "",
+    videoUrl: "",
+    tags: [],
+    pinned: false,
+    featured: false,
+    sendEmail: false,
+    audience: { type: "all" },
+    isDraft: false,
+  });
+  const restorePromptedRef = useRef(false);
+
+  const autosaveKey = session?.user
+    ? `news:create:${session.user.companyId}:${session.user.id}`
+    : null;
+
+  const clearDraftStorage = (resetState = false) => {
+    if (typeof window !== "undefined" && autosaveKey) {
+      try {
+        window.localStorage.removeItem(autosaveKey);
+      } catch (error) {
+        console.error("Failed to clear news draft", error);
+      }
+    }
+    if (resetState) {
+      setTitle("");
+      setContent(null);
+      setCoverImage("");
+      setVideoUrl("");
+      setAttachments([]);
+      setTags([]);
+      setTagInput("");
+      setPinned(false);
+      setFeatured(false);
+      setIsDraft(false);
+      setSendEmail(false);
+      setAudience({ type: "all" });
+      setShowPreview(false);
+      if (coverFileInputRef.current) coverFileInputRef.current.value = "";
+    }
+  };
+
+  const handleDiscardDraft = () => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(
+        "Discard the autosaved draft? This cannot be undone.",
+      );
+      if (!confirmed) return;
+    }
+    clearDraftStorage(true);
+    toast.success("Draft discarded");
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -133,6 +236,7 @@ export default function CreateNewsPostPage() {
 
     if (!validateForm()) return;
 
+    setIsDraft(asDraft);
     setIsSubmitting(true);
 
     try {
@@ -167,6 +271,7 @@ export default function CreateNewsPostPage() {
             ? "Draft saved successfully!"
             : "News post published successfully!"
         );
+        clearDraftStorage(false);
         router.push("/news");
       } else {
         const error = await res.text();
@@ -198,6 +303,108 @@ export default function CreateNewsPostPage() {
   };
 
   useEffect(() => {
+    latestDraftRef.current = {
+      title,
+      content,
+      coverImage,
+      videoUrl,
+      tags,
+      pinned,
+      featured,
+      sendEmail,
+      audience,
+      isDraft,
+    };
+  }, [title, content, coverImage, videoUrl, tags, pinned, featured, sendEmail, audience, isDraft]);
+
+  useEffect(() => {
+    restorePromptedRef.current = false;
+  }, [autosaveKey]);
+
+  useEffect(() => {
+    if (!autosaveKey) return;
+    if (typeof window === "undefined") return;
+
+    const interval = window.setInterval(() => {
+      const draft = latestDraftRef.current;
+      if (!hasMeaningfulDraft(draft)) {
+        try {
+          window.localStorage.removeItem(autosaveKey);
+        } catch (error) {
+          console.error("Failed to prune empty news draft", error);
+        }
+        return;
+      }
+
+      try {
+        window.localStorage.setItem(
+          autosaveKey,
+          JSON.stringify({
+            ...draft,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+      } catch (error) {
+        console.error("Failed to persist news draft", error);
+      }
+    }, 5000);
+
+    return () => window.clearInterval(interval);
+  }, [autosaveKey]);
+
+  useEffect(() => {
+    if (!autosaveKey) return;
+    if (restorePromptedRef.current) return;
+    if (typeof window === "undefined") return;
+
+    const stored = window.localStorage.getItem(autosaveKey);
+    if (!stored) {
+      restorePromptedRef.current = true;
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as Partial<NewsDraftPayload> & {
+        updatedAt?: string;
+      };
+      if (!hasMeaningfulDraft(parsed as NewsDraftPayload)) {
+        window.localStorage.removeItem(autosaveKey);
+        restorePromptedRef.current = true;
+        return;
+      }
+
+      const restoreMessage = parsed?.updatedAt
+        ? `A locally saved draft from ${new Date(parsed.updatedAt).toLocaleString()} was found. Restore it?`
+        : "A locally saved draft was found. Restore it?";
+      const shouldRestore = window.confirm(restoreMessage);
+      if (shouldRestore) {
+        setTitle(parsed?.title || "");
+        setContent(parsed?.content ?? null);
+        setCoverImage(parsed?.coverImage || "");
+        setVideoUrl(parsed?.videoUrl || "");
+        setTags(parsed?.tags || []);
+        setPinned(Boolean(parsed?.pinned));
+        setFeatured(Boolean(parsed?.featured));
+        setSendEmail(Boolean(parsed?.sendEmail));
+        setAudience(parsed?.audience || { type: "all" });
+        setIsDraft(Boolean(parsed?.isDraft));
+        setAttachments([]);
+        setTagInput("");
+        setShowPreview(false);
+        if (coverFileInputRef.current) coverFileInputRef.current.value = "";
+        toast.info("Draft restored from this device");
+      } else {
+        window.localStorage.removeItem(autosaveKey);
+      }
+    } catch (error) {
+      console.error("Failed to restore news draft", error);
+      window.localStorage.removeItem(autosaveKey);
+    } finally {
+      restorePromptedRef.current = true;
+    }
+  }, [autosaveKey]);
+
+  useEffect(() => {
     handleAudienceRefresh();
   }, []);
 
@@ -224,6 +431,17 @@ export default function CreateNewsPostPage() {
             </div>
 
             <div className="flex items-center gap-3">
+              <button
+                onClick={handleDiscardDraft}
+                className={cn(
+                  "flex items-center gap-2 px-4 py-2 rounded-lg transition-all",
+                  "border border-destructive/60 text-destructive hover:bg-destructive/10",
+                )}
+                type="button"
+              >
+                <Trash2 className="w-4 h-4" />
+                <span>Discard Draft</span>
+              </button>
               <button
                 onClick={() => setShowPreview(!showPreview)}
                 className={cn(

--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useSession } from "next-auth/react";
 import Button from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,6 +12,34 @@ import { FormField, TableColumn, AnyFormSchema, normalizeToPages, FormPage, Form
 import { PageLoader } from "@/components/ui/LoadingSpinner";
 import HistoryButton from "@/components/audit/HistoryButton";
 import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+
+const isSerializableValue = (value: unknown) => {
+  if (value === undefined) return false;
+  if (typeof value === "function" || typeof value === "symbol") return false;
+  if (typeof File !== "undefined" && value instanceof File) return false;
+  if (typeof FileList !== "undefined" && value instanceof FileList) return false;
+  return true;
+};
+
+const isMeaningfulValue = (value: unknown) => {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return !Number.isNaN(value);
+  if (typeof value === "boolean") return value === true;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value instanceof Date) return true;
+  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
+  return true;
+};
+
+const serialiseDraftValues = (values: Record<string, any>) => {
+  const serialised: Record<string, any> = {};
+  Object.entries(values || {}).forEach(([key, value]) => {
+    if (!isSerializableValue(value)) return;
+    serialised[key] = value;
+  });
+  return serialised;
+};
 
 interface EnhancedFormRendererProps {
   formId: string;
@@ -45,6 +74,16 @@ export function EnhancedFormRenderer({
   const [pendingPayload, setPendingPayload] = useState<Record<string, any> | null>(null);
 
   const { register, handleSubmit, setValue, watch, reset } = useForm();
+  const { data: session } = useSession();
+  const watchedValues = watch();
+  const latestValuesRef = useRef<Record<string, any>>({});
+  const [draftChecked, setDraftChecked] = useState(false);
+  const isDataScreen = formData?.form?.formType === "DATA_SCREEN";
+  const draftStorageKey =
+    session?.user && isDataScreen
+      ? `form:draft:${session.user.companyId}:${session.user.id}:${formId}:${employeeId}`
+      : null;
+  const isReadOnly = Boolean(formData?.readOnly);
 
   const evaluateCondition = (cond: any): boolean => {
     if (!cond) return true;
@@ -86,6 +125,16 @@ export function EnhancedFormRenderer({
     return andOk && orOk;
   };
 
+  const clearFormDraftStorage = useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (!draftStorageKey) return;
+    try {
+      window.localStorage.removeItem(draftStorageKey);
+    } catch (error) {
+      console.error("Failed to clear form draft", error);
+    }
+  }, [draftStorageKey]);
+
   useEffect(() => {
     const loadFormData = async () => {
       if (!formId || !employeeId) {
@@ -112,6 +161,103 @@ export function EnhancedFormRenderer({
     loadFormData();
   }, [formId, employeeId, setValue]);
 
+  useEffect(() => {
+    if (!isDataScreen) {
+      latestValuesRef.current = {};
+      return;
+    }
+    latestValuesRef.current = serialiseDraftValues(watchedValues || {});
+  }, [watchedValues, isDataScreen]);
+
+  useEffect(() => {
+    setDraftChecked(false);
+  }, [draftStorageKey]);
+
+  useEffect(() => {
+    if (!draftStorageKey || !isDataScreen || isReadOnly) return;
+    if (typeof window === "undefined") return;
+
+    const interval = window.setInterval(() => {
+      const values = latestValuesRef.current || {};
+      const hasContent =
+        Object.keys(values).length > 0 && Object.values(values).some(isMeaningfulValue);
+      if (!hasContent) {
+        try {
+          window.localStorage.removeItem(draftStorageKey);
+        } catch (error) {
+          console.error("Failed to prune empty form draft", error);
+        }
+        return;
+      }
+
+      try {
+        window.localStorage.setItem(
+          draftStorageKey,
+          JSON.stringify({
+            values,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+      } catch (error) {
+        console.error("Failed to persist form draft", error);
+      }
+    }, 5000);
+
+    return () => window.clearInterval(interval);
+  }, [draftStorageKey, isDataScreen, isReadOnly]);
+
+  useEffect(() => {
+    if (!draftStorageKey || !isDataScreen) return;
+    const existingData = formData?.data;
+    if (existingData && Object.keys(existingData || {}).length > 0) {
+      clearFormDraftStorage();
+    }
+  }, [draftStorageKey, formData, isDataScreen, clearFormDraftStorage]);
+
+  useEffect(() => {
+    if (draftChecked) return;
+    if (!draftStorageKey || !isDataScreen) return;
+    if (loading) return;
+    if (!formData) return;
+    if (formData.data && Object.keys(formData.data || {}).length > 0) {
+      setDraftChecked(true);
+      return;
+    }
+    if (typeof window === "undefined") return;
+
+    const raw = window.localStorage.getItem(draftStorageKey);
+    if (!raw) {
+      setDraftChecked(true);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as {
+        values?: Record<string, any>;
+        updatedAt?: string;
+      };
+      const serialised = serialiseDraftValues(parsed?.values || {});
+      const hasContent =
+        Object.keys(serialised).length > 0 &&
+        Object.values(serialised).some(isMeaningfulValue);
+      if (!hasContent) {
+        window.localStorage.removeItem(draftStorageKey);
+      } else {
+        reset(serialised);
+        toast.info(
+          parsed?.updatedAt
+            ? `Restored a local draft from ${new Date(parsed.updatedAt).toLocaleString()}.`
+            : "Restored a local draft from this device.",
+        );
+      }
+    } catch (error) {
+      console.error("Failed to restore form draft", error);
+      window.localStorage.removeItem(draftStorageKey);
+    } finally {
+      setDraftChecked(true);
+    }
+  }, [draftChecked, draftStorageKey, formData, isDataScreen, loading, reset]);
+
   const saveData = async (data: Record<string, any>, reasons?: Record<string, string>) => {
     setSaving(true);
     try {
@@ -122,6 +268,7 @@ export function EnhancedFormRenderer({
       });
       if (res.ok) {
         toast.success("Data saved successfully");
+        clearFormDraftStorage();
         onDataChange?.(data);
         const r = await fetch(
           `/api/forms/${formId}/data?employeeId=${employeeId}`,
@@ -149,6 +296,7 @@ export function EnhancedFormRenderer({
       if (res.ok) {
         toast.success("Form submitted successfully");
         reset();
+        clearFormDraftStorage();
         onDataChange?.(data);
       } else {
         const errText = await res.text().catch(() => "");
@@ -272,8 +420,6 @@ export function EnhancedFormRenderer({
       </div>
     );
   }
-
-  const isReadOnly = Boolean(formData?.readOnly);
 
   // Normalize schema to pages/sections for rendering
   const pages: FormPage[] = normalizeToPages(formData.form.schema as any);


### PR DESCRIPTION
## Summary
- persist the news creation form to local storage for each tenant/user with restore prompts and a discard control
- add local draft handling for DATA_SCREEN forms, restoring unsaved values and clearing saved drafts on submit

## Testing
- npm run lint *(fails: repository already contains numerous lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d188e470bc8331b4442f111751d9c7