### PR TITLE
Refine report builder UI and notifications

### DIFF
--- a/app/components/reports/ReportWizard.tsx
+++ b/app/components/reports/ReportWizard.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
-import { ChevronLeftIcon, ChevronRightIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { Check, ChevronLeft, ChevronRight, X } from "lucide-react";
 import Button from "@/components/ui/Button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/Card";
 import { hrReportTemplates, ReportTemplate } from "@/lib/hrReportFields";
 import FieldSelection from "./FieldSelection";
 import FilterConfiguration, { ReportFilter, SortConfig } from "./FilterConfiguration";
+import { cn } from "@/lib/utils";
 
 export type WizardStep = "template" | "fields" | "filters" | "preview";
 
@@ -96,149 +105,132 @@ export default function ReportWizard({ onComplete, onCancel }: ReportWizardProps
   const canMoveForward = canProceed();
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col">
-        {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-gray-900">
-                Create New Report
-              </h2>
-              <p className="text-sm text-gray-500 mt-1">
-                {steps[currentStepIndex].description}
-              </p>
-            </div>
-            <button
-              onClick={onCancel}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
-            >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+      <Card className="flex w-full max-w-5xl max-h-[90vh] flex-col overflow-hidden">
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <CardTitle className="text-2xl">Create New Report</CardTitle>
+            <CardDescription>{steps[currentStepIndex].description}</CardDescription>
           </div>
-        </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            aria-label="Close report wizard"
+            className="self-end sm:self-auto"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </CardHeader>
 
-        {/* Progress Steps */}
-        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
-          <nav aria-label="Progress">
-            <ol className="flex items-center justify-between">
-              {steps.map((step, index) => {
-                const isActive = step.id === currentStep;
-                const isCompleted = index < currentStepIndex;
-                const isUpcoming = index > currentStepIndex;
+        <CardContent className="flex flex-1 flex-col space-y-0 p-0">
+          <div className="border-b border-glass bg-muted/40 px-6 py-4">
+            <nav aria-label="Progress">
+              <ol className="flex flex-wrap gap-4">
+                {steps.map((step, index) => {
+                  const isActive = step.id === currentStep;
+                  const isCompleted = index < currentStepIndex;
 
-                return (
-                  <li key={step.id} className="flex items-center">
-                    <div className="flex items-center">
+                  return (
+                    <li key={step.id} className="flex items-center gap-3">
                       <div
-                        className={`
-                          flex items-center justify-center w-8 h-8 rounded-full border-2 transition-colors
-                          ${isActive
-                            ? "border-blue-600 bg-blue-600 text-white"
+                        className={cn(
+                          "flex h-9 w-9 items-center justify-center rounded-full border-2 text-sm font-semibold transition",
+                          isActive
+                            ? "border-primary bg-primary text-primary-foreground shadow-warm"
                             : isCompleted
-                            ? "border-green-600 bg-green-600 text-white"
-                            : "border-gray-300 bg-white text-gray-500"
-                          }
-                        `}
-                      >
-                        {isCompleted ? (
-                          <CheckIcon className="w-4 h-4" />
-                        ) : (
-                          <span className="text-sm font-medium">{index + 1}</span>
+                            ? "border-emerald-500 bg-emerald-500 text-white"
+                            : "border-glass text-muted-foreground",
                         )}
+                      >
+                        {isCompleted ? <Check className="h-4 w-4" /> : index + 1}
                       </div>
-                      <div className="ml-3">
+                      <div className="min-w-[120px] space-y-1">
                         <p
-                          className={`text-sm font-medium ${
-                            isActive ? "text-blue-600" : isCompleted ? "text-green-600" : "text-gray-500"
-                          }`}
+                          className={cn(
+                            "text-sm font-semibold",
+                            isActive
+                              ? "text-primary"
+                              : isCompleted
+                              ? "text-emerald-600"
+                              : "text-foreground/70",
+                          )}
                         >
                           {step.title}
                         </p>
+                        <p className="hidden text-xs text-muted-foreground sm:block">
+                          {step.description}
+                        </p>
                       </div>
-                    </div>
-                    {index < steps.length - 1 && (
-                      <div
-                        className={`ml-4 w-16 h-0.5 ${
-                          isCompleted ? "bg-green-600" : "bg-gray-300"
-                        }`}
-                      />
-                    )}
-                  </li>
-                );
-              })}
-            </ol>
-          </nav>
-        </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            </nav>
+          </div>
 
-        {/* Step Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {currentStep === "template" && (
-            <TemplateSelection
-              selectedTemplate={config.template}
-              onSelectTemplate={(template) => {
-                updateConfig({
-                  template,
-                  selectedFields: template?.defaultFields || [],
-                  filters: template?.suggestedFilters?.map((f, index) => ({
-                    id: `filter_${index}`,
-                    field: f.field,
-                    operator: f.operator as any,
-                    value: f.value,
-                  })) || [],
-                });
-              }}
-            />
-          )}
-          
-          {currentStep === "fields" && (
-            <FieldSelection
-              selectedFields={config.selectedFields}
-              onUpdateFields={(selectedFields) => updateConfig({ selectedFields })}
-            />
-          )}
-          
-          {currentStep === "filters" && (
-            <FilterConfiguration
-              filters={config.filters}
-              sort={config.sort}
-              selectedFields={config.selectedFields}
-              onUpdateFilters={(filters) => updateConfig({ filters })}
-              onUpdateSort={(sort) => updateConfig({ sort })}
-            />
-          )}
-          
-          {currentStep === "preview" && (
-            <ReportPreview
-              config={config}
-              onUpdateName={(name) => updateConfig({ name })}
-            />
-          )}
-        </div>
+          <div className="flex-1 overflow-y-auto px-6 py-6">
+            {currentStep === "template" && (
+              <TemplateSelection
+                selectedTemplate={config.template}
+                onSelectTemplate={(template) => {
+                  updateConfig({
+                    template,
+                    selectedFields: template?.defaultFields || [],
+                    filters:
+                      template?.suggestedFilters?.map((f, index) => ({
+                        id: `filter_${index}`,
+                        field: f.field,
+                        operator: f.operator as any,
+                        value: f.value,
+                      })) || [],
+                  });
+                }}
+              />
+            )}
 
-        {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 flex justify-between">
-          <Button
-            variant="outline"
-            onClick={handleBack}
-            className="flex items-center"
-          >
-            <ChevronLeftIcon className="w-4 h-4 mr-2" />
+            {currentStep === "fields" && (
+              <FieldSelection
+                selectedFields={config.selectedFields}
+                onUpdateFields={(selectedFields) => updateConfig({ selectedFields })}
+              />
+            )}
+
+            {currentStep === "filters" && (
+              <FilterConfiguration
+                filters={config.filters}
+                sort={config.sort}
+                selectedFields={config.selectedFields}
+                onUpdateFilters={(filters) => updateConfig({ filters })}
+                onUpdateSort={(sort) => updateConfig({ sort })}
+              />
+            )}
+
+            {currentStep === "preview" && (
+              <ReportPreview
+                config={config}
+                onUpdateName={(name) => updateConfig({ name })}
+              />
+            )}
+          </div>
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Button variant="ghost" onClick={handleBack} className="flex items-center gap-2">
+            <ChevronLeft className="h-4 w-4" />
             {isFirstStep ? "Cancel" : "Back"}
           </Button>
-          
+
           <Button
             onClick={handleNext}
             disabled={!canMoveForward}
-            className="flex items-center"
+            className="flex items-center gap-2"
           >
             {isLastStep ? "Create Report" : "Next"}
-            {!isLastStep && <ChevronRightIcon className="w-4 h-4 ml-2" />}
+            {!isLastStep && <ChevronRight className="h-4 w-4" />}
           </Button>
-        </div>
-      </div>
+        </CardFooter>
+      </Card>
     </div>
   );
 }
@@ -253,59 +245,55 @@ function TemplateSelection({
 }) {
   return (
     <div className="space-y-6">
-      <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-2">
-          Choose a Report Template
-        </h3>
-        <p className="text-gray-600">
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-foreground">Choose a Report Template</h3>
+        <p className="text-sm text-muted-foreground">
           Start with a pre-built template or create a custom report from scratch.
         </p>
       </div>
 
-      {/* Custom Report Option */}
       <div
-        className={`
-          border-2 rounded-lg p-4 cursor-pointer transition-all hover:border-blue-300
-          ${!selectedTemplate ? "border-blue-500 bg-blue-50" : "border-gray-200"}
-        `}
+        className={cn(
+          "cursor-pointer rounded-2xl border border-glass bg-background/80 p-5 transition hover:border-primary/40 hover:shadow-glass",
+          !selectedTemplate && "border-primary bg-primary/10",
+        )}
         onClick={() => onSelectTemplate(undefined)}
       >
-        <div className="flex items-center">
-          <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center mr-4">
+        <div className="flex items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
             <span className="text-2xl">⚡</span>
           </div>
-          <div>
-            <h4 className="font-medium text-gray-900">Custom Report</h4>
-            <p className="text-sm text-gray-600">
+          <div className="space-y-1">
+            <h4 className="text-sm font-semibold text-foreground">Custom Report</h4>
+            <p className="text-sm text-muted-foreground">
               Build a report from scratch with your own field selection
             </p>
           </div>
         </div>
       </div>
 
-      {/* Template Options */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {hrReportTemplates.map((template) => (
           <div
             key={template.id}
-            className={`
-              border-2 rounded-lg p-4 cursor-pointer transition-all hover:border-blue-300
-              ${selectedTemplate?.id === template.id ? "border-blue-500 bg-blue-50" : "border-gray-200"}
-            `}
+            className={cn(
+              "cursor-pointer rounded-2xl border border-glass bg-background/80 p-5 transition hover:border-primary/40 hover:shadow-glass",
+              selectedTemplate?.id === template.id && "border-primary bg-primary/10",
+            )}
             onClick={() => onSelectTemplate(template)}
           >
-            <div className="flex items-start">
-              <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center mr-4 flex-shrink-0">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-muted">
                 <span className="text-2xl">{template.icon}</span>
               </div>
-              <div className="flex-1">
-                <h4 className="font-medium text-gray-900 mb-1">
+              <div className="flex-1 space-y-2">
+                <h4 className="text-sm font-semibold text-foreground">
                   {template.name}
                 </h4>
-                <p className="text-sm text-gray-600 mb-2">
+                <p className="text-sm text-muted-foreground">
                   {template.description}
                 </p>
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-muted-foreground">
                   {template.defaultFields.length} fields included
                 </div>
               </div>
@@ -326,20 +314,18 @@ function ReportPreview({
   config: ReportConfig;
   onUpdateName: (name: string) => void;
 }) {
-  console.log("🔍 ReportPreview config:", config);
-  
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium text-gray-900">
+      <h3 className="text-lg font-semibold text-foreground">
         Preview & Save Report
       </h3>
-      <p className="text-gray-600">
+      <p className="text-sm text-muted-foreground">
         Review your report configuration and give it a name.
       </p>
-      
+
       <div className="space-y-4">
         <div>
-          <label htmlFor="report-name" className="block text-sm font-medium text-gray-700 mb-2">
+          <label htmlFor="report-name" className="mb-2 block text-sm font-semibold text-foreground">
             Report Name *
           </label>
           <input
@@ -348,35 +334,35 @@ function ReportPreview({
             value={config.name || ""}
             onChange={(e) => onUpdateName(e.target.value)}
             placeholder="Enter a name for your report"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-2xl border border-glass bg-background px-4 py-3 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary"
             required
           />
         </div>
-        
-        <div className="bg-gray-50 rounded-lg p-4">
-          <h4 className="font-medium text-gray-900 mb-2">Report Summary</h4>
-          <div className="space-y-2 text-sm text-gray-600">
-            <div>
-              <span className="font-medium">Template:</span>{" "}
+
+        <div className="rounded-2xl border border-glass bg-muted/40 p-4">
+          <h4 className="mb-2 text-sm font-semibold text-foreground">Report Summary</h4>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="font-semibold text-foreground">Template:</span>
               {config.template?.name || "Custom Report"}
             </div>
-            <div>
-              <span className="font-medium">Fields:</span>{" "}
+            <div className="space-y-1">
+              <span className="font-semibold text-foreground">Fields:</span>{" "}
               {config.selectedFields.length} selected
               {config.selectedFields.length > 0 && (
-                <div className="mt-1 text-xs">
+                <div className="text-xs text-muted-foreground">
                   {config.selectedFields.slice(0, 3).join(", ")}
                   {config.selectedFields.length > 3 && ` and ${config.selectedFields.length - 3} more`}
                 </div>
               )}
             </div>
-            <div>
-              <span className="font-medium">Filters:</span>{" "}
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="font-semibold text-foreground">Filters:</span>
               {config.filters.length} applied
             </div>
             {config.sort && (
-              <div>
-                <span className="font-medium">Sorting:</span>{" "}
+              <div className="flex flex-wrap items-center gap-1">
+                <span className="font-semibold text-foreground">Sorting:</span>
                 {config.sort.field} ({config.sort.direction})
               </div>
             )}

--- a/app/reports/builder-new/page.tsx
+++ b/app/reports/builder-new/page.tsx
@@ -1,45 +1,115 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { BarChart3, FileText, Plus, SortAsc, SortDesc } from "lucide-react";
 import ReportWizard, { ReportConfig } from "@/components/reports/ReportWizard";
 import Button from "@/components/ui/Button";
-import { PlusIcon, ChartBarIcon } from "@heroicons/react/24/outline";
+import { PageShell } from "@/components/ui/PageShell";
+import { Card, CardContent } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { useBreadcrumbs } from "@/hooks/useBreadcrumbs";
+import { formatLondon } from "@/lib/time";
+import type { BreadcrumbConfig } from "@/types/breadcrumb";
 
 interface RecentReport {
-	id: number;
-	name: string;
-	category: string;
-	createdAt: string;
-	createdBy: { email: string };
-	fields?: string[];
+        id: number;
+        name: string;
+        category: string;
+        createdAt: string;
+        createdBy: { email: string };
+        fields?: string[];
 }
 
 export default function NewReportBuilderPage() {
-	const router = useRouter();
-	const [showWizard, setShowWizard] = useState(false);
-	const [recentReports, setRecentReports] = useState<RecentReport[]>([]);
-	const [loadingReports, setLoadingReports] = useState<boolean>(true);
+        const router = useRouter();
+        const { toast } = useToast();
+        const [showWizard, setShowWizard] = useState(false);
+        const [recentReports, setRecentReports] = useState<RecentReport[]>([]);
+        const [loadingReports, setLoadingReports] = useState<boolean>(true);
+        const [categoryFilter, setCategoryFilter] = useState<string>("all");
+        const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
-	useEffect(() => {
-		const fetchReports = async () => {
-			try {
-				const res = await fetch("/api/reports", { cache: "no-store" });
-				if (!res.ok) throw new Error("Failed to load reports");
-				const data = await res.json();
-				setRecentReports(Array.isArray(data) ? data.slice(0, 5) : []);
-			} catch (e) {
-				console.error("Failed to fetch recent reports", e);
-			} finally {
-				setLoadingReports(false);
-			}
-		};
-		fetchReports();
-	}, []);
+        const breadcrumbs = useBreadcrumbs(
+                undefined,
+                {
+                        items: [
+                                { label: "Reports", href: "/reports" },
+                                { label: "New Builder", isCurrentPage: true },
+                        ],
+                } satisfies BreadcrumbConfig,
+        );
 
-	const handleCreateReport = async (config: ReportConfig) => {
-		try {
-			console.log("🚀 Saving report with config:", config);
+        const fetchRecentReports = useCallback(async () => {
+                setLoadingReports(true);
+                try {
+                        const res = await fetch("/api/reports", { cache: "no-store" });
+                        if (!res.ok) throw new Error("Failed to load reports");
+                        const data = await res.json();
+                        setRecentReports(Array.isArray(data) ? data.slice(0, 5) : []);
+                } catch (error) {
+                        console.error("Failed to fetch recent reports", error);
+                        toast({
+                                title: "Unable to load reports",
+                                description:
+                                        error instanceof Error
+                                                ? error.message
+                                                : "Something went wrong while loading recent reports.",
+                                variant: "destructive",
+                        });
+                } finally {
+                        setLoadingReports(false);
+                }
+        }, [toast]);
+
+        useEffect(() => {
+                void fetchRecentReports();
+        }, [fetchRecentReports]);
+
+        useEffect(() => {
+                if (categoryFilter === "all") return;
+                const categories = new Set(
+                        recentReports
+                                .map((report) => report.category)
+                                .filter((category): category is string => Boolean(category)),
+                );
+
+                if (!categories.has(categoryFilter)) {
+                        setCategoryFilter("all");
+                }
+        }, [categoryFilter, recentReports]);
+
+        const categoryOptions = useMemo(() => {
+                const unique = new Set<string>();
+                recentReports.forEach((report) => {
+                        if (report.category) {
+                                unique.add(report.category);
+                        }
+                });
+                return Array.from(unique).sort((a, b) => a.localeCompare(b));
+        }, [recentReports]);
+
+        const filteredReports = useMemo(() => {
+                let results = [...recentReports];
+
+                if (categoryFilter !== "all") {
+                        results = results.filter((report) => report.category === categoryFilter);
+                }
+
+                results.sort((a, b) => {
+                        const first = new Date(a.createdAt).getTime();
+                        const second = new Date(b.createdAt).getTime();
+                        return sortOrder === "desc" ? second - first : first - second;
+                });
+
+                return results;
+        }, [categoryFilter, recentReports, sortOrder]);
+
+        const handleCreateReport = async (config: ReportConfig) => {
+                try {
+                        console.log("🚀 Saving report with config:", config);
 			const requestBody = {
 				name: config.name,
 				category: config.template?.category || "custom",
@@ -48,99 +118,204 @@ export default function NewReportBuilderPage() {
 				sort: config.sort,
 				templateId: config.template?.id,
 			};
-			const response = await fetch("/api/reports/save", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(requestBody),
-			});
-			const result = await response.json();
-			if (response.ok && result.success) {
-				const reportId = result.id || result.data?.id;
-				if (reportId) router.push(`/reports/preview?reportId=${reportId}`);
-				else router.push(`/reports/preview?fields=${config.selectedFields.join(",")}`);
-			} else {
-				alert(`Failed to save report: ${result.error || result.details || "Unknown error"}`);
-			}
-		} catch (error) {
-			console.error("💥 Error saving report:", error);
-			alert(`Error saving report: ${error instanceof Error ? error.message : "Network error"}`);
-		}
-		setShowWizard(false);
-	};
+                        const response = await fetch("/api/reports/save", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify(requestBody),
+                        });
+                        const result = await response.json();
+                        if (response.ok && result.success) {
+                                toast({
+                                        title: "Report saved",
+                                        description: "Your new report has been saved successfully.",
+                                });
+                                const reportId = result.id || result.data?.id;
+                                if (reportId) router.push(`/reports/preview?reportId=${reportId}`);
+                                else router.push(`/reports/preview?fields=${config.selectedFields.join(",")}`);
+                                void fetchRecentReports();
+                        } else {
+                                toast({
+                                        title: "Failed to save report",
+                                        description: result.error || result.details || "Unknown error",
+                                        variant: "destructive",
+                                });
+                        }
+                } catch (error) {
+                        console.error("💥 Error saving report:", error);
+                        toast({
+                                title: "Error saving report",
+                                description:
+                                        error instanceof Error
+                                                ? error.message
+                                                : "An unexpected error occurred while saving the report.",
+                                variant: "destructive",
+                        });
+                }
+                setShowWizard(false);
+        };
 
-	const handleCancelWizard = () => setShowWizard(false);
+        const handleCancelWizard = () => setShowWizard(false);
 
-	if (showWizard) {
-		return (
-			<ReportWizard onComplete={handleCreateReport} onCancel={handleCancelWizard} />
-		);
-	}
+        if (showWizard) {
+                return (
+                        <ReportWizard onComplete={handleCreateReport} onCancel={handleCancelWizard} />
+                );
+        }
 
-	return (
-		<div className="min-h-screen bg-gray-50">
-			{/* Header */}
-			<div className="bg-white shadow-sm border-b border-gray-200">
-				<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-					<div className="flex items-center justify-between h-16">
-						<div className="flex items-center">
-							<ChartBarIcon className="h-8 w-8 text-blue-600 mr-3" />
-							<div>
-								<h1 className="text-xl font-semibold text-gray-900">HR Report Builder</h1>
-								<p className="text-sm text-gray-600">Create insightful reports from your HR data</p>
-							</div>
-						</div>
-						<Button onClick={() => setShowWizard(true)} className="flex items-center">
-							<PlusIcon className="w-4 h-4 mr-2" />
-							Create Report
-						</Button>
-					</div>
-				</div>
-			</div>
+        return (
+                <PageShell
+                        title="HR Report Builder"
+                        description="Create insightful reports from your HR data"
+                        icon={<BarChart3 className="h-6 w-6" />}
+                        breadcrumbs={breadcrumbs}
+                        action={
+                                <Button
+                                        onClick={() => setShowWizard(true)}
+                                        className="flex items-center gap-2"
+                                >
+                                        <Plus className="h-4 w-4" />
+                                        Create report
+                                </Button>
+                        }
+                >
+                        <div className="grid gap-6">
+                                <Card>
+                                        <CardContent className="p-0">
+                                                <EmptyState
+                                                        icon={BarChart3}
+                                                        title="Welcome to the HR Report Builder"
+                                                        description="Create powerful, customised reports from your HR data. Our intuitive wizard guides you through selecting fields, applying filters, and configuring the perfect insights in just a few steps."
+                                                        action={{
+                                                                label: "Start a new report",
+                                                                onClick: () => setShowWizard(true),
+                                                        }}
+                                                        className="py-12"
+                                                />
+                                        </CardContent>
+                                </Card>
 
-			{/* Main Content */}
-			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-				{/* Welcome Section */}
-				<div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
-					<div className="mx-auto w-24 h-24 bg-blue-100 rounded-full flex items-center justify-center mb-6">
-						<ChartBarIcon className="w-12 h-12 text-blue-600" />
-					</div>
-					<h2 className="text-2xl font-bold text-gray-900 mb-4">Welcome to the HR Report Builder</h2>
-					<p className="text-gray-600 mb-8 max-w-2xl mx-auto">
-						Create powerful, customized reports from your HR data. Our intuitive wizard guides you through
-						selecting fields, applying filters, and configuring your perfect report in just a few steps.
-					</p>
-					<Button onClick={() => setShowWizard(true)} size="lg" className="flex items-center mx-auto">
-						<PlusIcon className="w-5 h-5 mr-2" />
-						Create Report
-					</Button>
-				</div>
+                                <Card
+                                        title="Recent reports"
+                                        action={
+                                                <div className="flex items-center gap-2">
+                                                        <Button
+                                                                size="sm"
+                                                                variant={sortOrder === "desc" ? "secondary" : "ghost"}
+                                                                className="flex items-center gap-1"
+                                                                onClick={() => setSortOrder("desc")}
+                                                        >
+                                                                <SortDesc className="h-4 w-4" />
+                                                                Newest
+                                                        </Button>
+                                                        <Button
+                                                                size="sm"
+                                                                variant={sortOrder === "asc" ? "secondary" : "ghost"}
+                                                                className="flex items-center gap-1"
+                                                                onClick={() => setSortOrder("asc")}
+                                                        >
+                                                                <SortAsc className="h-4 w-4" />
+                                                                Oldest
+                                                        </Button>
+                                                </div>
+                                        }
+                                >
+                                        <CardContent className="space-y-6">
+                                                {categoryOptions.length > 1 && (
+                                                        <div className="flex flex-wrap gap-2">
+                                                                <Button
+                                                                        size="sm"
+                                                                        variant={categoryFilter === "all" ? "secondary" : "ghost"}
+                                                                        onClick={() => setCategoryFilter("all")}
+                                                                >
+                                                                        All categories
+                                                                </Button>
+                                                                {categoryOptions.map((category) => (
+                                                                        <Button
+                                                                                key={category}
+                                                                                size="sm"
+                                                                                variant={categoryFilter === category ? "secondary" : "ghost"}
+                                                                                onClick={() => setCategoryFilter(category)}
+                                                                        >
+                                                                                {category}
+                                                                        </Button>
+                                                                ))}
+                                                        </div>
+                                                )}
 
-				{/* Recent Reports Section */}
-				<div className="mt-8">
-					<h3 className="text-lg font-medium text-gray-900 mb-4">Recent Reports</h3>
-					<div className="bg-white rounded-lg shadow-sm border border-gray-200">
-						{loadingReports ? (
-							<div className="p-6 text-center text-gray-500">Loading...</div>
-						) : recentReports.length === 0 ? (
-							<div className="p-6 text-center text-gray-500">No reports yet. Create your first one.</div>
-						) : (
-							<ul className="divide-y divide-gray-200">
-								{recentReports.map((r) => (
-									<li key={r.id} className="p-4 flex items-center justify-between hover:bg-gray-50">
-										<div>
-											<div className="font-medium text-gray-900">{r.name}</div>
-											<div className="text-sm text-gray-500">{new Date(r.createdAt).toLocaleString()} • {r.category}</div>
-										</div>
-										<div className="flex items-center gap-2">
-											<Button variant="outline" onClick={() => router.push(`/reports/preview?reportId=${r.id}`)}>Open</Button>
-										</div>
-									</li>
-								))}
-							</ul>
-						)}
-					</div>
-				</div>
-			</div>
-		</div>
-	);
+                                                {loadingReports ? (
+                                                        <RecentReportsSkeleton />
+                                                ) : recentReports.length === 0 ? (
+                                                        <EmptyState
+                                                                icon={FileText}
+                                                                title="No reports yet"
+                                                                description="Create your first report to see it listed here."
+                                                                action={{
+                                                                        label: "Create report",
+                                                                        onClick: () => setShowWizard(true),
+                                                                }}
+                                                        />
+                                                ) : filteredReports.length === 0 ? (
+                                                        <EmptyState
+                                                                icon={FileText}
+                                                                title="No reports match the filters"
+                                                                description="Try adjusting the category filter or sorting to see more saved reports."
+                                                        />
+                                                ) : (
+                                                        <ul className="space-y-3">
+                                                                {filteredReports.map((report) => {
+                                                                        const createdBy = report.createdBy?.email || "Unknown";
+                                                                        const formattedDate = formatLondon(report.createdAt, "dd MMM yyyy, HH:mm");
+                                                                        return (
+                                                                                <li
+                                                                                        key={report.id}
+                                                                                        className="flex items-center justify-between gap-4 rounded-2xl border border-glass p-4 transition hover:border-primary/40 hover:shadow-glass"
+                                                                                >
+                                                                                        <div className="flex-1">
+                                                                                                <p className="text-sm font-semibold text-foreground">
+                                                                                                        {report.name}
+                                                                                                </p>
+                                                                                                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                                                                                        <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-primary">
+                                                                                                                {report.category}
+                                                                                                        </span>
+                                                                                                        <span>Created by {createdBy}</span>
+                                                                                                        <span>on {formattedDate}</span>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                        <Button
+                                                                                                variant="secondary"
+                                                                                                size="sm"
+                                                                                                onClick={() => router.push(`/reports/preview?reportId=${report.id}`)}
+                                                                                        >
+                                                                                                Open
+                                                                                        </Button>
+                                                                                </li>
+                                                                        );
+                                                                })}
+                                                        </ul>
+                                                )}
+                                        </CardContent>
+                                </Card>
+                        </div>
+                </PageShell>
+        );
+}
+
+function RecentReportsSkeleton() {
+        return (
+                <div className="space-y-3">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                                <div
+                                        key={index}
+                                        className="flex items-center justify-between gap-4 rounded-2xl border border-dashed border-glass/70 p-4"
+                                >
+                                        <div className="flex-1 space-y-2">
+                                                <Skeleton className="h-4 w-1/3" />
+                                                <Skeleton className="h-3 w-1/4" />
+                                        </div>
+                                        <Skeleton className="h-9 w-24 rounded-2xl" />
+                                </div>
+                        ))}
+                </div>
+        );
 }

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -213,7 +213,11 @@ export default function ReportsPage() {
                       console.log("🧪 Raw report.fields:", report.fields);
 
                       if (!report.fields) {
-                        alert("No fields found in this report.");
+                        toast({
+                          title: "Unable to open report",
+                          description: "No fields were saved with this report configuration.",
+                          variant: "destructive",
+                        });
                         return;
                       }
 
@@ -222,7 +226,11 @@ export default function ReportsPage() {
                         : JSON.parse(report.fields || "[]");
 
                       if (!fieldArray.length) {
-                        alert("This report has no fields.");
+                        toast({
+                          title: "Unable to open report",
+                          description: "This report does not contain any fields yet.",
+                          variant: "destructive",
+                        });
                         return;
                       }
 

--- a/app/reports/preview/ReportsPreviewClient.tsx
+++ b/app/reports/preview/ReportsPreviewClient.tsx
@@ -397,7 +397,11 @@ export default function ReportsPreviewClient() {
       logAndToastPII(combined.length);
     } catch (error) {
       console.error("❌ Error exporting full report:", error);
-      alert("Failed to export full report. Please try again.");
+      toast({
+        title: "Export failed",
+        description: "We couldn't export the full report. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setExportingFull(false);
     }
@@ -417,11 +421,21 @@ export default function ReportsPreviewClient() {
         }),
       });
       if (!res.ok) throw new Error("Failed to save report");
-      alert("Report saved!");
+      toast({
+        title: "Report saved",
+        description: "Your report has been saved successfully.",
+      });
       router.push("/reports");
     } catch (err) {
       console.error(err);
-      alert("Error saving report.");
+      toast({
+        title: "Error saving report",
+        description:
+          err instanceof Error
+            ? err.message
+            : "Something went wrong while saving your report.",
+        variant: "destructive",
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- restructure the new report builder page around PageShell, Card, EmptyState, and tenant-aware utilities with quick filters, sorting, and skeleton loading states
- polish the ReportWizard overlay with cohesive card styling and refined preview controls
- replace alert calls in report flows with useToast notifications for consistent messaging

## Testing
- npm run lint *(fails: existing lint errors in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d188dd84cc833188bb0d5301e3524d