### PR TITLE
Refactor calendar filters and inspector experience

### DIFF
--- a/app/(withSidebar)/calendar/CalendarLegend.tsx
+++ b/app/(withSidebar)/calendar/CalendarLegend.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface LegendItem {
+  label: string;
+  swatchClassName?: string;
+  swatchStyle?: React.CSSProperties;
+}
+
+interface CalendarLegendProps {
+  categories: LegendItem[];
+  showBankHoliday?: boolean;
+  bankHolidayLabel?: string | null;
+  showBlackout?: boolean;
+}
+
+export function CalendarLegend({
+  categories,
+  showBankHoliday = false,
+  bankHolidayLabel,
+  showBlackout = true,
+}: CalendarLegendProps) {
+  if (
+    categories.length === 0 &&
+    !showBankHoliday &&
+    !showBlackout
+  ) {
+    return null;
+  }
+
+  const items: LegendItem[] = [...categories];
+
+  if (showBankHoliday) {
+    items.push({
+      label: bankHolidayLabel ? `Public holiday (${bankHolidayLabel})` : "Public holiday",
+      swatchClassName: "bg-emerald-500",
+    });
+  }
+
+  if (showBlackout) {
+    items.push({
+      label: "Blackout day",
+      swatchStyle: {
+        backgroundImage:
+          "repeating-linear-gradient(45deg,#fecaca,#fecaca 4px,#ffffff 4px,#ffffff 8px)",
+        border: "1px solid rgb(248 113 113)",
+      },
+    });
+  }
+
+  return (
+    <div className="px-4 pb-2">
+      <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        {items.map((item) => (
+          <div key={item.label} className="inline-flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex h-3 w-3 shrink-0 rounded-sm border border-border",
+                item.swatchClassName,
+              )}
+              style={item.swatchStyle}
+            />
+            <span className="font-medium text-foreground/80">{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(withSidebar)/calendar/page.tsx
+++ b/app/(withSidebar)/calendar/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = "force-dynamic";
 
-import { useEffect, useState, useRef, useRef as useMutableRef } from "react";
+import { useEffect, useState, useRef, useRef as useMutableRef, useMemo } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -10,12 +10,10 @@ import listPlugin from "@fullcalendar/list";
 import { PageShell } from "@/components/ui/PageShell";
 import { Card } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { List, CalendarDays, Trash2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Copy } from "lucide-react";
-import { MultiSelect } from "@/components/ui/MultiSelect";
 import { toast } from "sonner";
 import BlockDayModal from "./BlockDayModal";
 import { EventInput, EventSourceFuncArg } from "@fullcalendar/core";
@@ -24,21 +22,65 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { Lock } from "lucide-react";
+import { FilterProvider, useFilters } from "@/components/ui/FilterProvider";
+import { FilterBar } from "@/components/ui/FilterBar";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+  SheetClose,
+} from "@/components/ui/sheet";
+import { CalendarLegend } from "./CalendarLegend";
+import {
+  resolveTenantTimeSettings,
+  formatTenantDate,
+  type TenantTimeSettings,
+} from "@/lib/calendar/timezone";
 
 interface Department {
   id: string;
   name: string;
 }
 
-export default function CalendarPage() {
+interface CalendarPageInnerProps {
+  initialView: "dayGridMonth" | "listMonth";
+}
+
+type PublicHolidayTemplate = "NZ" | "AU" | "UK" | null;
+
+const PUBLIC_HOLIDAY_REGION_LABELS: Record<string, string> = {
+  NZ: "New Zealand (National)",
+  "NZ-AUK": "Auckland Anniversary",
+  "NZ-WGN": "Wellington Anniversary",
+  "NZ-CAN": "Canterbury Anniversary",
+  "NZ-OTA": "Otago Anniversary",
+  AU: "Australia (National)",
+  "AU-NSW": "New South Wales",
+  "AU-VIC": "Victoria",
+  "AU-QLD": "Queensland",
+  "AU-SA": "South Australia",
+  "AU-WA": "Western Australia",
+  "AU-TAS": "Tasmania",
+  "AU-NT": "Northern Territory",
+  "AU-ACT": "Australian Capital Territory",
+  UK: "United Kingdom (National)",
+  "GB-ENG": "England & Wales",
+  "GB-SCT": "Scotland",
+  "GB-NIR": "Northern Ireland",
+};
+
+function CalendarPageInner({ initialView }: CalendarPageInnerProps) {
   const [departments, setDepartments] = useState<Department[]>([]);
-  const [selectedDepartment, setSelectedDepartment] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [blockModalOpen, setBlockModalOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [refreshTrigger, setRefreshTrigger] = useState(false); // 🚩 NEW: force re-render trigger
-  const [currentView, setCurrentView] = useState<"dayGridMonth" | "listMonth">("dayGridMonth");
-  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [refreshTrigger, setRefreshTrigger] = useState(false);
+  const [currentView, setCurrentView] = useState<"dayGridMonth" | "listMonth">(initialView);
+  const [tenantTimeSettings, setTenantTimeSettings] = useState<TenantTimeSettings>(() =>
+    resolveTenantTimeSettings(null, null),
+  );
   const [dailyCounts, setDailyCounts] = useState<Record<string, number>>({});
   const [thresholds, setThresholds] = useState<{ defaultMaxConcurrent?: number } | null>(null);
   const [presentCategories, setPresentCategories] = useState<string[]>([]);
@@ -46,17 +88,16 @@ export default function CalendarPage() {
   const [inspectorDate, setInspectorDate] = useState<Date | null>(null);
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [bankHolidaysOn, setBankHolidaysOn] = useState(false);
+  const [bankHolidaysAvailable, setBankHolidaysAvailable] = useState(false);
   const [templateLabel, setTemplateLabel] = useState<string | null>(null);
   const [currentTitle, setCurrentTitle] = useState("");
   const bankHolidayCacheRef = useRef<any | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
   const initializedFromUrl = useMutableRef(false);
-  const [categoryOptions, setCategoryOptions] = useState<{label: string; value: string}[]>([]);
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [nameQuery, setNameQuery] = useState("");
-  const [locationOptions, setLocationOptions] = useState<{label: string; value: string}[]>([]);
-  const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+  const { filters, updateFilter } = useFilters();
+  const [categoryOptions, setCategoryOptions] = useState<{ label: string; value: string }[]>([]);
+  const [locationOptions, setLocationOptions] = useState<{ label: string; value: string }[]>([]);
   const [blackoutDateKeys, setBlackoutDateKeys] = useState<Set<string>>(new Set());
   const [blackoutIdsByDay, setBlackoutIdsByDay] = useState<Record<string, string[]>>({});
   const calendarRef = useRef<FullCalendar | null>(null);
@@ -138,22 +179,37 @@ export default function CalendarPage() {
     if (initializedFromUrl.current) return;
     if (!searchParams) return;
     const dep = searchParams.get("department") || "";
-    const view = (searchParams.get("view") as any) || "";
-    if (dep) setSelectedDepartment(dep);
+    const view = searchParams.get("view") || "";
+    const query = searchParams.get("q") || "";
+    updateFilter("departments", dep ? [dep] : []);
+    updateFilter("search", query);
     if (view === "list") setCurrentView("listMonth");
     initializedFromUrl.current = true;
-  }, [searchParams]);
+  }, [searchParams, updateFilter]);
 
   useEffect(() => {
     if (!initializedFromUrl.current) return;
     try {
       const url = new URL(window.location.href);
-      if (selectedDepartment) url.searchParams.set("department", selectedDepartment);
+      const departmentParam = filters.departments[0];
+      if (departmentParam) url.searchParams.set("department", departmentParam);
       else url.searchParams.delete("department");
+      if (filters.search) url.searchParams.set("q", filters.search);
+      else url.searchParams.delete("q");
       url.searchParams.set("view", currentView === "listMonth" ? "list" : "month");
       router.replace(url.pathname + "?" + url.searchParams.toString(), { scroll: false });
     } catch (_err) {}
-  }, [selectedDepartment, currentView, router]);
+  }, [filters.departments.join(","), filters.search, currentView, router]);
+
+  useEffect(() => {
+    if (!calendarRef.current) return;
+    calendarRef.current.getApi().refetchEvents();
+  }, [
+    filters.departments.join(","),
+    filters.categories.join(","),
+    filters.locations.join(","),
+    filters.search,
+  ]);
 
   const fetchLeaveEvents = async (
     fetchInfo: EventSourceFuncArg,
@@ -161,11 +217,12 @@ export default function CalendarPage() {
     failureCallback: (error: any) => void,
   ) => {
     try {
+      const departmentFilter = filters.departments[0] || "";
       const params = new URLSearchParams({
         from: fetchInfo.startStr,
         to: fetchInfo.endStr,
       });
-      if (selectedDepartment) params.set("department", selectedDepartment);
+      if (departmentFilter) params.set("department", departmentFilter);
       const res = await fetch(`/api/calendar-events?${params.toString()}`);
       if (!res.ok) {
         console.warn("Leave events fetch non-OK status", res.status);
@@ -174,16 +231,16 @@ export default function CalendarPage() {
       }
       let data = await res.json();
       // Client-side filtering by category and name (optional)
-      if (selectedCategories.length > 0) {
-        const selectedSet = new Set(selectedCategories);
+      if (filters.categories.length > 0) {
+        const selectedSet = new Set(filters.categories);
         data = (data as any[]).filter((e) => e.eventCategoryId ? selectedSet.has(e.eventCategoryId) : true);
       }
-      if (selectedLocations.length > 0) {
-        const locSet = new Set(selectedLocations);
+      if (filters.locations.length > 0) {
+        const locSet = new Set(filters.locations);
         data = (data as any[]).filter((e) => e.employee?.locationId ? locSet.has(e.employee.locationId) : true);
       }
-      if (nameQuery.trim().length > 0) {
-        const q = nameQuery.trim().toLowerCase();
+      if (filters.search.trim().length > 0) {
+        const q = filters.search.trim().toLowerCase();
         data = (data as any[]).filter((e) => (e.employee?.name || e.title || "").toLowerCase().includes(q));
       }
       setLeaveEventsInRange(data);
@@ -278,7 +335,7 @@ export default function CalendarPage() {
     failureCallback: (error: any) => void,
   ) => {
     try {
-      if (!bankHolidaysOn) {
+      if (!bankHolidaysOn || !bankHolidaysAvailable) {
         successCallback([]);
         return;
       }
@@ -309,14 +366,35 @@ export default function CalendarPage() {
     (async () => {
       try {
         const res = await fetch("/api/settings/public-holidays");
-        if (res.ok) {
-          const data = await res.json();
-          const t = data?.template as string | null;
-          const r = data?.region as string | null;
-          const base = t ? (t === 'NZ' ? 'New Zealand' : t === 'AU' ? 'Australia' : 'United Kingdom') : null;
-          setTemplateLabel(base ? (r ? `${base} — ${r}` : base) : null);
+        if (!res.ok) {
+          setBankHolidaysAvailable(false);
+          setTenantTimeSettings(resolveTenantTimeSettings(null, null));
+          setTemplateLabel(null);
+          return;
         }
-      } catch {}
+        const data = await res.json();
+        const template = (data?.template ?? null) as PublicHolidayTemplate;
+        const region = (data?.region ?? null) as string | null;
+        setBankHolidaysAvailable(Boolean(template));
+        const templateName =
+          template === "NZ"
+            ? "New Zealand"
+            : template === "AU"
+              ? "Australia"
+              : template === "UK"
+                ? "United Kingdom"
+                : null;
+        const regionLabel = region ? PUBLIC_HOLIDAY_REGION_LABELS[region] || region : null;
+        setTemplateLabel(
+          templateName ? (regionLabel ? `${templateName} — ${regionLabel}` : templateName) : null,
+        );
+        setTenantTimeSettings(resolveTenantTimeSettings(template, region));
+      } catch (error) {
+        console.error(error);
+        setBankHolidaysAvailable(false);
+        setTenantTimeSettings(resolveTenantTimeSettings(null, null));
+        setTemplateLabel(null);
+      }
     })();
   }, []);
 
@@ -423,7 +501,9 @@ export default function CalendarPage() {
           <div className="mt-3 space-y-1">
             {categoryName ? <Badge className="!text-[10px] !px-1.5 !py-0">{categoryName}</Badge> : null}
             <div className="text-xs text-gray-600">
-              {new Date(content.event.start!).toLocaleDateString()} – {new Date((content.event.end as any) || content.event.start!).toLocaleDateString()}
+              {formatTenantDate(content.event.start!, tenantTimeSettings, "d MMM yyyy")} –
+              {" "}
+              {formatTenantDate((content.event.end as any) || content.event.start!, tenantTimeSettings, "d MMM yyyy")}
             </div>
             {content.event.extendedProps?.reason ? (
               <div className="text-xs text-gray-700">{String(content.event.extendedProps.reason)}</div>
@@ -457,10 +537,10 @@ export default function CalendarPage() {
     return 'bg-blue-500';
   };
 
-  const handleDepartmentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    setSelectedDepartment(value);
-    calendarRef.current?.getApi().refetchEvents();
+  const formatEventRange = (start: string, end?: string) => {
+    const startLabel = formatTenantDate(start, tenantTimeSettings, "d MMM yyyy");
+    const endLabel = formatTenantDate(end ?? start, tenantTimeSettings, "d MMM yyyy");
+    return startLabel === endLabel ? startLabel : `${startLabel} – ${endLabel}`;
   };
 
   const handleChangeView = (viewName: "dayGridMonth" | "listMonth") => {
@@ -521,102 +601,131 @@ export default function CalendarPage() {
     }
   };
 
+  const legendCategories = useMemo(
+    () =>
+      presentCategories.map((cat) => ({
+        label: cat,
+        swatchClassName: getCategoryColor(cat),
+      })),
+    [presentCategories],
+  );
+
   return (
     <PageShell title="Calendar">
       <Card title="Company Calendar">
-        <div className="p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-2">
-            <Button
-              variant={currentView === "dayGridMonth" ? "primary" : "secondary"}
-              size="sm"
-              onClick={() => handleChangeView("dayGridMonth")}
-            >
-              <CalendarDays className="h-4 w-4 mr-2" /> Month
-            </Button>
-            <Button
-              variant={currentView === "listMonth" ? "primary" : "secondary"}
-              size="sm"
-              onClick={() => handleChangeView("listMonth")}
-            >
-              <List className="h-4 w-4 mr-2" /> List
-            </Button>
-            <div className="ml-2 text-sm text-gray-700 font-medium">{currentTitle}</div>
-            <div className="ml-2 flex items-center gap-2">
+        <div className="space-y-4 p-4">
+          <FilterBar
+            config={{
+              searchPlaceholder: "Search people or leave...",
+              showDepartmentFilter: departments.length > 0,
+              showCategoryFilter: categoryOptions.length > 0,
+              showLocationFilter: locationOptions.length > 0,
+            }}
+            departmentOptions={departments.map((dept) => ({ label: dept.name, value: dept.name }))}
+            categoryOptions={categoryOptions}
+            locationOptions={locationOptions}
+          />
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex overflow-hidden rounded-2xl border border-border bg-background/60 backdrop-blur">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={currentView === "dayGridMonth" ? "primary" : "ghost"}
+                  className="rounded-none"
+                  aria-pressed={currentView === "dayGridMonth"}
+                  onClick={() => handleChangeView("dayGridMonth")}
+                >
+                  <CalendarDays className="mr-2 h-4 w-4" />
+                  Month
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={currentView === "listMonth" ? "primary" : "ghost"}
+                  className="rounded-none"
+                  aria-pressed={currentView === "listMonth"}
+                  onClick={() => handleChangeView("listMonth")}
+                >
+                  <List className="mr-2 h-4 w-4" />
+                  List
+                </Button>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    calendarRef.current?.getApi().today();
+                  }}
+                >
+                  Today
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    calendarRef.current?.getApi().prev();
+                  }}
+                  aria-label="Previous period"
+                >
+                  Prev
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    calendarRef.current?.getApi().next();
+                  }}
+                  aria-label="Next period"
+                >
+                  Next
+                </Button>
+              </div>
+              <span className="text-sm font-medium text-muted-foreground">{currentTitle}</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Show public holidays</span>
+                <Switch
+                  checked={bankHolidaysOn && bankHolidaysAvailable}
+                  disabled={!bankHolidaysAvailable}
+                  onChange={(checked) => {
+                    if (!bankHolidaysAvailable) return;
+                    setBankHolidaysOn(checked);
+                    calendarRef.current?.getApi().refetchEvents();
+                  }}
+                />
+                {bankHolidaysAvailable && templateLabel ? (
+                  <span className="text-xs text-muted-foreground">({templateLabel})</span>
+                ) : null}
+                {!bankHolidaysAvailable ? (
+                  <span className="text-xs text-muted-foreground">No feed configured</span>
+                ) : null}
+              </div>
               <Button
-                variant="secondary"
+                variant="outline"
                 size="sm"
-                onClick={() => { calendarRef.current?.getApi().today(); }}
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(window.location.href);
+                    toast.success("Link copied");
+                  } catch {
+                    toast.error("Failed to copy link");
+                  }
+                }}
               >
-                Today
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => { calendarRef.current?.getApi().prev(); }}
-              >
-                Prev
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => { calendarRef.current?.getApi().next(); }}
-              >
-                Next
+                <Copy className="mr-2 h-4 w-4" />
+                Copy link
               </Button>
             </div>
-          </div>
-          <div className="flex items-center gap-3">
-            <div>
-              <label className="block mb-2 font-medium">Department</label>
-              <select
-                value={selectedDepartment}
-                onChange={handleDepartmentChange}
-                className="border rounded p-2 w-full md:w-64"
-              >
-                <option value="">All Departments</option>
-                {departments.map((dept) => (
-                  <option key={dept.id} value={dept.name}>
-                    {dept.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <Button variant="secondary" size="sm" onClick={() => setFiltersOpen(true)}>
-              Filters
-            </Button>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">Show public holidays</span>
-              <Switch checked={bankHolidaysOn} onChange={(v) => { setBankHolidaysOn(v); calendarRef.current?.getApi().refetchEvents(); }} />
-              {bankHolidaysOn && templateLabel && (
-                <span className="text-xs text-gray-500">({templateLabel})</span>
-              )}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(window.location.href);
-                  toast.success("Link copied");
-                } catch {
-                  toast.error("Failed to copy link");
-                }
-              }}
-            >
-              <Copy className="h-4 w-4 mr-2" /> Copy link
-            </Button>
           </div>
         </div>
-        {presentCategories.length > 0 && (
-          <div className="px-4 pb-2 flex flex-wrap gap-2">
-            {presentCategories.map((cat) => (
-              <div key={cat} className="inline-flex items-center gap-2 mr-2 mb-1">
-                <span className={`inline-block w-3 h-3 rounded-sm ${getCategoryColor(cat)}`}></span>
-                <span className="text-xs text-gray-600">{cat}</span>
-              </div>
-            ))}
-          </div>
-        )}
+        <CalendarLegend
+          categories={legendCategories}
+          showBankHoliday={bankHolidaysAvailable && bankHolidaysOn}
+          bankHolidayLabel={templateLabel}
+        />
         <div className="bg-white rounded-xl overflow-hidden">
           {loading ? (
             <p className="p-4">Loading...</p>
@@ -624,7 +733,7 @@ export default function CalendarPage() {
             <FullCalendar
               ref={calendarRef}
               plugins={[dayGridPlugin, interactionPlugin, listPlugin]}
-              initialView="dayGridMonth"
+              initialView={initialView}
               headerToolbar={false}
               datesSet={(arg: any) => {
                 setCurrentTitle(arg.view?.title || "");
@@ -644,116 +753,104 @@ export default function CalendarPage() {
               eventContent={renderEventContent}
               dayCellDidMount={dayCellDidMount}
               height="auto"
-              key={refreshTrigger ? "refresh-on" : "refresh-off"} // 🚩 forces rerender on refresh
-              timeZone="Europe/London" // 🚩 added for BST stability
+              key={`${tenantTimeSettings.timeZone}-${refreshTrigger ? "refresh-on" : "refresh-off"}`}
+              timeZone={tenantTimeSettings.timeZone}
             />
           )}
         </div>
       </Card>
-      {inspectorDate && (
-        <div className="fixed right-0 top-0 h-full w-full sm:w-[380px] bg-white shadow-2xl border-l z-40 p-4 overflow-y-auto">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <div className="text-sm text-gray-500">Day summary</div>
-              <div className="text-lg font-semibold">{inspectorDate.toDateString()}</div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => {
+      <Sheet
+        open={Boolean(inspectorDate)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setInspectorDate(null);
+            setSelectedDay(null);
+          }
+        }}
+      >
+        <SheetContent side="right" className="flex h-full flex-col gap-6 overflow-y-auto">
+          <SheetHeader className="space-y-2">
+            <SheetTitle>Day summary</SheetTitle>
+            <p className="text-sm text-muted-foreground">
+              {inspectorDate
+                ? formatTenantDate(inspectorDate, tenantTimeSettings, "EEEE, d MMMM yyyy")
+                : ""}
+            </p>
+          </SheetHeader>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                if (inspectorDate) {
                   setSelectedDate(inspectorDate);
                   setBlockModalOpen(true);
-                }}
-              >
-                Block day
-              </Button>
-              {(() => {
-                const key = `${inspectorDate.getFullYear()}-${String(inspectorDate.getMonth()+1).padStart(2,'0')}-${String(inspectorDate.getDate()).padStart(2,'0')}`;
-                const hasBlackout = blackoutDateKeys.has(key);
-                return hasBlackout ? (
-                  <Button
-                    size="sm"
-                    variant="danger"
-                    onClick={() => deleteBlackoutForDate(inspectorDate)}
-                    aria-label="Delete blackout day"
-                  >
-                    <Trash2 className="h-4 w-4 mr-1" /> Delete blackout
-                  </Button>
-                ) : null;
-              })()}
-              <Button size="sm" variant="ghost" onClick={() => setInspectorDate(null)}>Close</Button>
-            </div>
+                }
+              }}
+            >
+              Block day
+            </Button>
+            {inspectorDate
+              ? (() => {
+                  const key = `${inspectorDate.getFullYear()}-${String(inspectorDate.getMonth()+1).padStart(2,'0')}-${String(inspectorDate.getDate()).padStart(2,'0')}`;
+                  const hasBlackout = blackoutDateKeys.has(key);
+                  return hasBlackout ? (
+                    <Button
+                      size="sm"
+                      variant="danger"
+                      onClick={() => deleteBlackoutForDate(inspectorDate)}
+                      aria-label="Delete blackout day"
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" /> Delete blackout
+                    </Button>
+                  ) : null;
+                })()
+              : null}
           </div>
           <div className="space-y-3">
-            <div className="text-sm text-gray-600">People off</div>
+            <div className="text-sm font-medium text-muted-foreground">People off</div>
             <div className="space-y-2">
-              {leaveEventsInRange.filter((ev: any) => {
-                const d = inspectorDate;
-                const start = new Date(ev.start);
-                const end = new Date(ev.end || ev.start);
-                start.setHours(0,0,0,0);
-                end.setHours(0,0,0,0);
-                const target = new Date(d);
-                target.setHours(0,0,0,0);
-                return target >= start && target <= end;
-              }).map((ev: any) => (
-                <div key={ev.id} className="flex items-center gap-3 p-2 rounded border">
-                  <Avatar src={ev.employee?.profileImageUrl ?? null} name={ev.employee?.name ?? null} size={28} />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium truncate">{ev.employee?.name || ev.title}</div>
-                    <div className="text-xs text-gray-600 truncate">{ev.employee?.department ?? ""}</div>
+              {leaveEventsInRange
+                .filter((ev: any) => {
+                  if (!inspectorDate) return false;
+                  const start = new Date(ev.start);
+                  const end = new Date(ev.end || ev.start);
+                  start.setHours(0, 0, 0, 0);
+                  end.setHours(0, 0, 0, 0);
+                  const target = new Date(inspectorDate);
+                  target.setHours(0, 0, 0, 0);
+                  return target >= start && target <= end;
+                })
+                .map((ev: any) => (
+                  <div key={ev.id} className="flex items-start gap-3 rounded border p-3">
+                    <Avatar src={ev.employee?.profileImageUrl ?? null} name={ev.employee?.name ?? null} size={28} />
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="text-sm font-medium truncate">{ev.employee?.name || ev.title}</div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {formatEventRange(ev.start, ev.end)}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {ev.employee?.department ?? ""}
+                      </div>
+                    </div>
+                    {ev.categoryName ? (
+                      <span className={`text-[10px] text-white px-1.5 py-0.5 rounded ${getCategoryColor(ev.categoryName)}`}>
+                        {ev.categoryName}
+                      </span>
+                    ) : null}
                   </div>
-                  {ev.categoryName ? (
-                    <span className={`text-[10px] text-white px-1.5 py-0.5 rounded ${getCategoryColor(ev.categoryName)}`}>{ev.categoryName}</span>
-                  ) : null}
-                </div>
-              ))}
+                ))}
             </div>
           </div>
-        </div>
-      )}
-      <Dialog open={filtersOpen} onOpenChange={setFiltersOpen}>
-        <DialogContent title="Filters">
-          <DialogHeader>
-            <DialogTitle>Filters</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div>
-              <label className="block mb-2 text-sm font-medium">Categories</label>
-              <MultiSelect
-                options={categoryOptions}
-                selected={selectedCategories}
-                onChange={setSelectedCategories}
-                placeholder="Select categories"
-              />
-            </div>
-            <div>
-              <label className="block mb-2 text-sm font-medium">Locations</label>
-              <MultiSelect
-                options={locationOptions}
-                selected={selectedLocations}
-                onChange={setSelectedLocations}
-                placeholder="Select locations"
-              />
-            </div>
-            <div>
-              <label className="block mb-2 text-sm font-medium">Search by name</label>
-              <input
-                type="text"
-                value={nameQuery}
-                onChange={(e) => setNameQuery(e.target.value)}
-                placeholder="Search employees..."
-                className="w-full border rounded-md p-2"
-              />
-            </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <Button variant="outline" size="sm" onClick={() => { setSelectedCategories([]); setSelectedLocations([]); setNameQuery(""); }}>Clear</Button>
-              <Button size="sm" onClick={() => setFiltersOpen(false)}>Done</Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+          <SheetFooter className="justify-end">
+            <SheetClose asChild>
+              <Button variant="ghost" size="sm">
+                Close
+              </Button>
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
       {selectedDate && (
         <BlockDayModal
           open={blockModalOpen}
@@ -763,5 +860,27 @@ export default function CalendarPage() {
         />
       )}
     </PageShell>
+  );
+}
+
+export default function CalendarPage() {
+  const searchParams = useSearchParams();
+  const departmentParam = searchParams?.get("department") || "";
+  const queryParam = searchParams?.get("q") || "";
+  const viewParam = searchParams?.get("view") || "";
+  const initialView = viewParam === "list" ? "listMonth" : "dayGridMonth";
+
+  const initialFilters = useMemo(
+    () => ({
+      departments: departmentParam ? [departmentParam] : [],
+      search: queryParam,
+    }),
+    [departmentParam, queryParam],
+  );
+
+  return (
+    <FilterProvider initialFilters={initialFilters}>
+      <CalendarPageInner initialView={initialView} />
+    </FilterProvider>
   );
 }

--- a/app/components/ui/FilterBar.tsx
+++ b/app/components/ui/FilterBar.tsx
@@ -22,6 +22,7 @@ interface FilterBarProps {
   departmentOptions?: FilterOption[];
   jobRoleOptions?: FilterOption[];
   statusOptions?: FilterOption[];
+  locationOptions?: FilterOption[];
   documentTypeOptions?: FilterOption[];
   authorOptions?: FilterOption[];
   categoryOptions?: FilterOption[];
@@ -41,6 +42,7 @@ export function FilterBar({
   departmentOptions = [],
   jobRoleOptions = [],
   statusOptions = [],
+  locationOptions = [],
   documentTypeOptions = [],
   authorOptions = [],
   categoryOptions = [],
@@ -79,6 +81,7 @@ export function FilterBar({
       config.showDepartmentFilter ||
       config.showJobRoleFilter ||
       config.showStatusFilter ||
+      config.showLocationFilter ||
       config.showDateRangeFilter ||
       config.showDocumentTypeFilter ||
       config.showAuthorFilter ||
@@ -277,6 +280,26 @@ export function FilterBar({
             );
           })}
 
+          {filters.locations.map((val) => {
+            const label = locationOptions.find((o) => o.value === val)?.label || val;
+            return (
+              <Button
+                key={`location-${val}`}
+                variant="secondary"
+                size="sm"
+                className="rounded-full px-3"
+                onClick={() =>
+                  updateFilter(
+                    "locations",
+                    filters.locations.filter((v) => v !== val),
+                  )
+                }
+              >
+                Location: {label} <span className="ml-2">×</span>
+              </Button>
+            );
+          })}
+
           {filters.documentTypes.map((val) => {
             const label = documentTypeOptions.find((o) => o.value === val)?.label || val;
             return (
@@ -369,6 +392,21 @@ export function FilterBar({
                   selected={filters.status}
                   onChange={(values) => updateFilter("status", values)}
                   placeholder="Select status..."
+                />
+              </div>
+            )}
+
+            {/* Location Filter */}
+            {config.showLocationFilter && locationOptions.length > 0 && (
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-2">
+                  Location
+                </label>
+                <MultiSelect
+                  options={locationOptions}
+                  selected={filters.locations}
+                  onChange={(values) => updateFilter("locations", values)}
+                  placeholder="Select locations..."
                 />
               </div>
             )}

--- a/app/components/ui/FilterProvider.tsx
+++ b/app/components/ui/FilterProvider.tsx
@@ -14,6 +14,7 @@ const initialFilterState: FilterState = {
   departments: [],
   jobRoles: [],
   status: [],
+  locations: [],
   dateRange: {},
   documentTypes: [],
   authors: [],
@@ -94,6 +95,7 @@ export function FilterProvider({
       filters.departments.length > 0 ||
       filters.jobRoles.length > 0 ||
       filters.status.length > 0 ||
+      filters.locations.length > 0 ||
       filters.documentTypes.length > 0 ||
       filters.authors.length > 0 ||
       filters.categories.length > 0 ||

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = ({ children }: { children: React.ReactNode }) => (
+  <DialogPrimitive.Portal>{children}</DialogPrimitive.Portal>
+);
+SheetPortal.displayName = DialogPrimitive.Portal.displayName;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+type SheetContentProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> & {
+  side?: "top" | "bottom" | "left" | "right";
+};
+
+const sideClasses: Record<NonNullable<SheetContentProps["side"]>, string> = {
+  top: "inset-x-0 top-0 w-full border-b",
+  bottom: "inset-x-0 bottom-0 w-full border-t",
+  left: "inset-y-0 left-0 h-full w-3/4 sm:w-96 border-r",
+  right: "inset-y-0 right-0 h-full w-full sm:w-[380px] border-l",
+};
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ className, children, side = "right", ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 bg-background p-6 shadow-xl transition-transform ease-in-out",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=open]:fade-in data-[state=closed]:fade-out",
+        side === "right" &&
+          "data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+        side === "left" &&
+          "data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+        side === "top" &&
+          "data-[state=open]:slide-in-from-top data-[state=closed]:slide-out-to-top",
+        side === "bottom" &&
+          "data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+        sideClasses[side],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("space-y-1.5 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/app/lib/calendar/timezone.ts
+++ b/app/lib/calendar/timezone.ts
@@ -1,0 +1,103 @@
+import type { Locale } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+import { enNZ, enGB, enAU } from "date-fns/locale";
+
+type Template = "NZ" | "AU" | "UK" | null;
+
+type RegionCode =
+  | "NZ"
+  | "NZ-AUK"
+  | "NZ-WGN"
+  | "NZ-CAN"
+  | "NZ-OTA"
+  | "AU"
+  | "AU-NSW"
+  | "AU-VIC"
+  | "AU-QLD"
+  | "AU-SA"
+  | "AU-WA"
+  | "AU-TAS"
+  | "AU-NT"
+  | "AU-ACT"
+  | "GB-ENG"
+  | "GB-SCT"
+  | "GB-NIR"
+  | string
+  | null;
+
+const TEMPLATE_TIMEZONE_MAP: Record<Exclude<Template, null>, string> = {
+  NZ: "Pacific/Auckland",
+  AU: "Australia/Sydney",
+  UK: "Europe/London",
+};
+
+const REGION_TIMEZONE_MAP: Record<string, string> = {
+  NZ: "Pacific/Auckland",
+  "NZ-AUK": "Pacific/Auckland",
+  "NZ-WGN": "Pacific/Auckland",
+  "NZ-CAN": "Pacific/Auckland",
+  "NZ-OTA": "Pacific/Auckland",
+  AU: "Australia/Sydney",
+  "AU-NSW": "Australia/Sydney",
+  "AU-VIC": "Australia/Sydney",
+  "AU-QLD": "Australia/Brisbane",
+  "AU-SA": "Australia/Adelaide",
+  "AU-WA": "Australia/Perth",
+  "AU-TAS": "Australia/Hobart",
+  "AU-NT": "Australia/Darwin",
+  "AU-ACT": "Australia/Sydney",
+  "GB-ENG": "Europe/London",
+  "GB-SCT": "Europe/London",
+  "GB-NIR": "Europe/London",
+};
+
+const TEMPLATE_LOCALE_MAP: Record<Exclude<Template, null>, string> = {
+  NZ: "en-NZ",
+  AU: "en-AU",
+  UK: "en-GB",
+};
+
+const TEMPLATE_LOCALE_OBJECT_MAP: Partial<Record<Exclude<Template, null>, Locale>> = {
+  NZ: enNZ,
+  AU: enAU,
+  UK: enGB,
+};
+
+export interface TenantTimeSettings {
+  timeZone: string;
+  locale: string;
+  template: Template;
+}
+
+export function resolveTenantTimeSettings(
+  template: Template,
+  region: RegionCode,
+): TenantTimeSettings {
+  if (!template) {
+    return {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+      locale: "en-NZ",
+      template: null,
+    };
+  }
+
+  const regionTimeZone = region ? REGION_TIMEZONE_MAP[region] : undefined;
+  const timeZone = regionTimeZone || TEMPLATE_TIMEZONE_MAP[template] || "UTC";
+  const locale = TEMPLATE_LOCALE_MAP[template] || "en-NZ";
+
+  return { timeZone, locale, template };
+}
+
+export function formatTenantDate(
+  date: Date | string,
+  { timeZone, template }: TenantTimeSettings,
+  formatString: string,
+): string {
+  const value = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(value.getTime())) return "";
+  const localeObject = template ? TEMPLATE_LOCALE_OBJECT_MAP[template] : undefined;
+  return formatInTimeZone(value, timeZone, formatString, {
+    locale: localeObject ?? undefined,
+  });
+}
+

--- a/app/types/filter.ts
+++ b/app/types/filter.ts
@@ -15,6 +15,7 @@ export interface FilterState {
   departments: string[];
   jobRoles: string[];
   status: string[];
+  locations: string[];
   dateRange: DateRangeFilter;
   documentTypes: string[];
   authors: string[];
@@ -28,6 +29,7 @@ export interface FilterConfig {
   showDepartmentFilter?: boolean;
   showJobRoleFilter?: boolean;
   showStatusFilter?: boolean;
+  showLocationFilter?: boolean;
   showDateRangeFilter?: boolean;
   showDocumentTypeFilter?: boolean;
   showAuthorFilter?: boolean;


### PR DESCRIPTION
## Summary
- replace the calendar toolbar with FilterBar filters, segmented view controls, and a reusable legend component
- add a sheet-based inspector that respects the tenant time zone and formats day/event details accordingly
- extend shared filtering utilities and add a tenant time zone helper plus sheet UI primitives

## Testing
- npm run lint *(fails: repository already contains pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d188cf0de4833189b3e63b7a4e4e06