### PR TITLE
Ensure news post mutations are tenant scoped

### DIFF
--- a/app/api/news/[slug]/route.ts
+++ b/app/api/news/[slug]/route.ts
@@ -46,8 +46,14 @@ export async function PUT(req: NextRequest, { params }: Params) {
 
   const { slug } = params;
 
-  const existing = await prisma.newsPost.findUnique({
-    where: { slug },
+  const companyId = session.user.companyId;
+
+  if (!companyId) {
+    return NextResponse.json({ error: "Company context missing" }, { status: 400 });
+  }
+
+  const existing = await prisma.newsPost.findFirst({
+    where: { slug, companyId },
   });
 
   if (!existing) {
@@ -65,7 +71,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
   const body = await req.json();
 
   const updated = await prisma.newsPost.update({
-    where: { slug },
+    where: { id: existing.id },
     data: {
       title: body.title,
       content: body.content,
@@ -80,7 +86,10 @@ export async function PUT(req: NextRequest, { params }: Params) {
 
   if (body.sendEmail) {
     const recipients = await prisma.user.findMany({
-      where: { email: { not: "" } },
+      where: {
+        companyId: existing.companyId,
+        email: { not: "" },
+      },
       select: { email: true },
     });
 
@@ -104,8 +113,14 @@ export async function DELETE(req: NextRequest, { params }: Params) {
 
   const { slug } = params;
 
-  const existing = await prisma.newsPost.findUnique({
-    where: { slug },
+  const companyId = session.user.companyId;
+
+  if (!companyId) {
+    return NextResponse.json({ error: "Company context missing" }, { status: 400 });
+  }
+
+  const existing = await prisma.newsPost.findFirst({
+    where: { slug, companyId },
   });
 
   if (!existing) {
@@ -121,7 +136,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   }
 
   await prisma.newsPost.delete({
-    where: { slug },
+    where: { id: existing.id },
   });
 
   return new Response(null, { status: 204 });


### PR DESCRIPTION
## Summary
- validate the targeted news post against the caller's company before allowing updates or deletions
- scope update/delete mutations to the verified record and restrict email recipients to the post's company

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d28e4e55388331ac413213d97d9d02