### PR TITLE
Protect tenant scoped category routes

### DIFF
--- a/app/api/event-categories/[id]/route.ts
+++ b/app/api/event-categories/[id]/route.ts
@@ -19,12 +19,24 @@ export async function GET(
   req: Request,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.companyId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
   try {
     const { id } = params;
 
-    const category = await prisma.eventCategory.findUnique({
-      where: { id },
-      include: { EventSubcategory: true },
+    const category = await prisma.eventCategory.findFirst({
+      where: { id, companyId: session.user.companyId },
+      include: {
+        EventSubcategory: {
+          where: { companyId: session.user.companyId },
+        },
+      },
     });
 
     if (!category) {
@@ -52,7 +64,7 @@ export async function PATCH(
   { params }: { params: { id: string } },
 ) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 403 },
@@ -63,8 +75,18 @@ export async function PATCH(
     const { id } = params;
 
     // Prevent edits on system-defined categories
-    const category = await prisma.eventCategory.findUnique({ where: { id } });
-    if (category?.systemDefined) {
+    const category = await prisma.eventCategory.findFirst({
+      where: { id, companyId: session.user.companyId },
+    });
+
+    if (!category) {
+      return NextResponse.json(
+        { success: false, error: "Event category not found." },
+        { status: 404 },
+      );
+    }
+
+    if (category.systemDefined) {
       return NextResponse.json(
         { success: false, error: "Cannot edit system-defined categories." },
         { status: 400 },
@@ -81,10 +103,28 @@ export async function PATCH(
       );
     }
 
-    const updatedCategory = await prisma.eventCategory.update({
-      where: { id },
+    const updateResult = await prisma.eventCategory.updateMany({
+      where: { id, companyId: session.user.companyId },
       data: parse.data,
     });
+
+    if (updateResult.count === 0) {
+      return NextResponse.json(
+        { success: false, error: "Event category not found." },
+        { status: 404 },
+      );
+    }
+
+    const updatedCategory = await prisma.eventCategory.findFirst({
+      where: { id, companyId: session.user.companyId },
+    });
+
+    if (!updatedCategory) {
+      return NextResponse.json(
+        { success: false, error: "Event category not found." },
+        { status: 404 },
+      );
+    }
 
     console.log("[Event Categories PATCH] Updated:", updatedCategory);
 
@@ -112,7 +152,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 403 },
@@ -123,7 +163,9 @@ export async function DELETE(
     const { id } = params;
 
     // Prevent deletion on system-defined categories
-    const category = await prisma.eventCategory.findUnique({ where: { id } });
+    const category = await prisma.eventCategory.findFirst({
+      where: { id, companyId: session.user.companyId },
+    });
     if (!category) {
       return NextResponse.json(
         { success: false, error: "Event category not found." },
@@ -138,10 +180,28 @@ export async function DELETE(
       );
     }
 
-    const archivedCategory = await prisma.eventCategory.update({
-      where: { id },
+    const updateResult = await prisma.eventCategory.updateMany({
+      where: { id, companyId: session.user.companyId },
       data: { isActive: false },
     });
+
+    if (updateResult.count === 0) {
+      return NextResponse.json(
+        { success: false, error: "Event category not found." },
+        { status: 404 },
+      );
+    }
+
+    const archivedCategory = await prisma.eventCategory.findFirst({
+      where: { id, companyId: session.user.companyId },
+    });
+
+    if (!archivedCategory) {
+      return NextResponse.json(
+        { success: false, error: "Event category not found." },
+        { status: 404 },
+      );
+    }
 
     return NextResponse.json({ success: true, data: archivedCategory });
   } catch (error: any) {

--- a/app/api/event-subcategories/[id]/route.ts
+++ b/app/api/event-subcategories/[id]/route.ts
@@ -18,11 +18,23 @@ export async function GET(
   req: Request,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.companyId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
   try {
     const { id } = params;
 
-    const subcategory = await prisma.eventSubcategory.findUnique({
-      where: { id },
+    const subcategory = await prisma.eventSubcategory.findFirst({
+      where: {
+        id,
+        companyId: session.user.companyId,
+        EventCategory: { companyId: session.user.companyId },
+      },
       include: { EventCategory: true },
     });
 
@@ -51,7 +63,7 @@ export async function PATCH(
   { params }: { params: { id: string } },
 ) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 403 },
@@ -60,6 +72,22 @@ export async function PATCH(
 
   try {
     const { id } = params;
+
+    const existingSubcategory = await prisma.eventSubcategory.findFirst({
+      where: {
+        id,
+        companyId: session.user.companyId,
+        EventCategory: { companyId: session.user.companyId },
+      },
+    });
+
+    if (!existingSubcategory) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
+
     const json = await req.json();
     const parse = UpdateSubcategorySchema.safeParse(json);
 
@@ -70,10 +98,32 @@ export async function PATCH(
       );
     }
 
-    const updatedSubcategory = await prisma.eventSubcategory.update({
-      where: { id },
+    const updateResult = await prisma.eventSubcategory.updateMany({
+      where: { id, companyId: session.user.companyId },
       data: parse.data,
     });
+
+    if (updateResult.count === 0) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
+
+    const updatedSubcategory = await prisma.eventSubcategory.findFirst({
+      where: {
+        id,
+        companyId: session.user.companyId,
+        EventCategory: { companyId: session.user.companyId },
+      },
+    });
+
+    if (!updatedSubcategory) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
 
     console.log("[Event Subcategories PATCH] Updated:", updatedSubcategory);
 
@@ -101,7 +151,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   const session = await getServerSession(authOptions);
-  if (!session?.user || session.user.role !== "ADMIN") {
+  if (!session?.user || session.user.role !== "ADMIN" || !session.user.companyId) {
     return NextResponse.json(
       { success: false, error: "Unauthorized" },
       { status: 403 },
@@ -111,12 +161,47 @@ export async function DELETE(
   try {
     const { id } = params;
 
-    const archivedSubcategory = await prisma.eventSubcategory.update({
-      where: { id },
-      data: {
-        isActive: false,
+    const existingSubcategory = await prisma.eventSubcategory.findFirst({
+      where: {
+        id,
+        companyId: session.user.companyId,
+        EventCategory: { companyId: session.user.companyId },
       },
     });
+
+    if (!existingSubcategory) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
+
+    const updateResult = await prisma.eventSubcategory.updateMany({
+      where: { id, companyId: session.user.companyId },
+      data: { isActive: false },
+    });
+
+    if (updateResult.count === 0) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
+
+    const archivedSubcategory = await prisma.eventSubcategory.findFirst({
+      where: {
+        id,
+        companyId: session.user.companyId,
+        EventCategory: { companyId: session.user.companyId },
+      },
+    });
+
+    if (!archivedSubcategory) {
+      return NextResponse.json(
+        { success: false, error: "Event subcategory not found." },
+        { status: 404 },
+      );
+    }
 
     return NextResponse.json({ success: true, data: archivedSubcategory });
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- require an authenticated company-scoped session before returning an event category and constrain queries to the tenant
- guard event category updates and archives with tenant-aware lookups and composite filters to avoid cross-company writes
- apply the same tenant and parent-category ownership checks to event subcategory read/update/archive handlers

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d28e3c15f88331a00e86725ff67ea1