### PR TITLE
Enforce tenant isolation for offboarding APIs

### DIFF
--- a/app/api/offboarding/[employeeId]/exit-interview/route.ts
+++ b/app/api/offboarding/[employeeId]/exit-interview/route.ts
@@ -14,7 +14,7 @@ export async function POST(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -25,11 +25,13 @@ export async function POST(
     }
 
     const employeeId = params.employeeId;
+    const companyId = session.user.companyId;
     const data = parsed.data;
 
     // Find the offboarding record for this employee
     const offboarding = await prisma.employeeOffboarding.findUnique({
       where: { employeeId },
+      include: { Employee: true },
     });
 
     if (!offboarding) {
@@ -37,6 +39,10 @@ export async function POST(
         { error: "Offboarding not found" },
         { status: 404 },
       );
+    }
+
+    if (offboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // Update the main offboarding record with exit interview details
@@ -52,9 +58,12 @@ export async function POST(
       try {
         const interviewer = await prisma.user.findUnique({
           where: { id: data.interviewerId },
-          select: { id: true },
+          select: { id: true, companyId: true },
         });
         if (interviewer) {
+          if (interviewer.companyId !== companyId) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
           validInterviewerId = data.interviewerId;
         } else {
           console.warn(
@@ -117,12 +126,16 @@ export async function POST(
         }
         const template = await prisma.exitInterviewFormTemplate.findUnique({
           where: { id: data.formTemplateId },
+          select: { id: true, companyId: true },
         });
         if (!template) {
           return NextResponse.json(
             { error: "Form template not found" },
             { status: 400 },
           );
+        }
+        if (template.companyId && template.companyId !== companyId) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
         }
       }
 
@@ -159,10 +172,20 @@ export async function POST(
 
     let interviewer = null;
     if (validInterviewerId) {
-      interviewer = await prisma.user.findUnique({
+      const interviewerRecord = await prisma.user.findUnique({
         where: { id: validInterviewerId },
-        select: { id: true, firstName: true, lastName: true, email: true },
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          companyId: true,
+        },
       });
+      if (interviewerRecord?.companyId === companyId) {
+        const { companyId: _interviewerCompanyId, ...rest } = interviewerRecord;
+        interviewer = rest;
+      }
     }
 
     // Send calendar invite if interview is scheduled

--- a/app/api/offboarding/[employeeId]/route.ts
+++ b/app/api/offboarding/[employeeId]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -22,6 +22,7 @@ export async function GET(
     }
 
     const { employeeId } = params;
+    const companyId = session.user.companyId;
 
     // Get offboarding record with all related data
     const offboarding = await prisma.employeeOffboarding.findUnique({
@@ -72,6 +73,10 @@ export async function GET(
         { error: "Offboarding record not found" },
         { status: 404 },
       );
+    }
+
+    if (offboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // Format the response
@@ -209,7 +214,7 @@ export async function PATCH(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -220,15 +225,29 @@ export async function PATCH(
       );
     }
 
+    const companyId = session.user.companyId;
     const { assetsToReturn } = await req.json();
     if (!Array.isArray(assetsToReturn)) {
       return NextResponse.json({ error: "Invalid assets" }, { status: 400 });
     }
 
+    const offboarding = await prisma.employeeOffboarding.findUnique({
+      where: { employeeId: params.employeeId },
+      include: { Employee: true },
+    });
+
+    if (!offboarding) {
+      return NextResponse.json({ error: "Offboarding record not found" }, { status: 404 });
+    }
+
+    if (offboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const allReturned = assetsToReturn.every((a: any) => a.returned);
 
     await prisma.employeeOffboarding.update({
-      where: { employeeId: params.employeeId },
+      where: { id: offboarding.id },
       data: {
         assetsToReturn,
         assetsReturned: allReturned,

--- a/app/api/offboarding/initiate/route.ts
+++ b/app/api/offboarding/initiate/route.ts
@@ -36,7 +36,7 @@ const initiateSchema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -66,6 +66,8 @@ export async function POST(req: NextRequest) {
       formTiming,
     } = validatedData;
 
+    const companyId = session.user.companyId;
+
     // Check if employee exists
     const employee = await prisma.employee.findUnique({
       where: { id: employeeId },
@@ -77,6 +79,10 @@ export async function POST(req: NextRequest) {
         { error: "Employee not found" },
         { status: 404 },
       );
+    }
+
+    if (employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (employee.EmployeeOffboarding) {
@@ -94,12 +100,22 @@ export async function POST(req: NextRequest) {
     if (interviewerUserId) {
       const interviewer = await prisma.user.findUnique({
         where: { id: interviewerUserId },
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          companyId: true,
+        },
       });
       if (!interviewer) {
         return NextResponse.json(
           { error: "Interviewer not found" },
           { status: 400 },
         );
+      }
+      if (interviewer.companyId !== companyId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
       interviewerNameValid = `${interviewer.firstName} ${interviewer.lastName}`;
       interviewerEmailValid = interviewer.email;
@@ -129,12 +145,16 @@ export async function POST(req: NextRequest) {
     if (sendForm && formTemplateId) {
       const template = await prisma.exitInterviewFormTemplate.findUnique({
         where: { id: formTemplateId },
+        select: { id: true, isActive: true, companyId: true },
       });
       if (!template || !template.isActive) {
         return NextResponse.json(
           { error: "Invalid or inactive form template" },
           { status: 400 },
         );
+      }
+      if (template.companyId && template.companyId !== companyId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
     }
 

--- a/app/api/offboarding/route.ts
+++ b/app/api/offboarding/route.ts
@@ -18,7 +18,7 @@ function isAssignmentEmailEnabled(): boolean {
 export async function GET(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -28,7 +28,13 @@ export async function GET(req: NextRequest) {
     const limit = parseInt(searchParams.get("limit") || "10");
     const skip = (page - 1) * limit;
 
-    const where: any = {};
+    const companyId = session.user.companyId;
+
+    const where: any = {
+      Employee: {
+        companyId,
+      },
+    };
 
     if (statusParam && statusParam !== "all") {
       const statuses = statusParam
@@ -139,10 +145,11 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const companyId = session.user.companyId;
     const body = await req.json();
     const {
       offboardingId,
@@ -197,9 +204,18 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (offboardingRecord.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     // Get the highest order for new task placement
     const lastTask = await prisma.offboardingTask.findFirst({
-      where: { offboardingId },
+      where: {
+        offboardingId,
+        EmployeeOffboarding: {
+          is: { Employee: { companyId } },
+        },
+      },
       orderBy: { order: "desc" },
     });
 
@@ -229,6 +245,7 @@ export async function POST(req: NextRequest) {
             lastName: true,
             email: true,
             phone: true,
+            companyId: true,
           },
         })
       : null;
@@ -240,9 +257,18 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (assignedUserDetails && assignedUserDetails.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { companyId: _assignedUserCompanyId, ...assignedUserProfile } =
+      assignedUserDetails ?? ({} as typeof assignedUserDetails);
+
     const enrichedTask = {
       ...task,
-      User_OffboardingTask_assignedToToUser: assignedUserDetails,
+      User_OffboardingTask_assignedToToUser: assignedUserDetails
+        ? assignedUserProfile
+        : null,
     };
 
     const assignmentEmailsEnabled = isAssignmentEmailEnabled();

--- a/app/api/offboarding/send-form-invite/route.ts
+++ b/app/api/offboarding/send-form-invite/route.ts
@@ -12,7 +12,7 @@ const sendFormInviteSchema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -26,6 +26,7 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     const { offboardingId } = sendFormInviteSchema.parse(body);
+    const companyId = session.user.companyId;
 
     // Get offboarding record
     const offboarding = await prisma.employeeOffboarding.findUnique({
@@ -43,6 +44,10 @@ export async function POST(req: NextRequest) {
         { error: "Offboarding record not found" },
         { status: 404 },
       );
+    }
+
+    if (offboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (!offboarding.sendForm) {

--- a/app/api/offboarding/send-invites/route.ts
+++ b/app/api/offboarding/send-invites/route.ts
@@ -12,7 +12,7 @@ const sendInvitesSchema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -26,6 +26,7 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     const { offboardingId } = sendInvitesSchema.parse(body);
+    const companyId = session.user.companyId;
 
     // Get offboarding record
     const offboarding = await prisma.employeeOffboarding.findUnique({
@@ -43,6 +44,10 @@ export async function POST(req: NextRequest) {
         { error: "Offboarding record not found" },
         { status: 404 },
       );
+    }
+
+    if (offboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (!offboarding.exitInterviewDate) {

--- a/app/api/offboarding/tasks/[id]/route.ts
+++ b/app/api/offboarding/tasks/[id]/route.ts
@@ -10,7 +10,7 @@ export async function PATCH(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -20,11 +20,17 @@ export async function PATCH(
 
     const task = await prisma.offboardingTask.findUnique({
       where: { id: taskId },
-      include: { EmployeeOffboarding: true },
+      include: { EmployeeOffboarding: { include: { Employee: true } } },
     });
 
     if (!task) {
       return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    const companyId = session.user.companyId;
+
+    if (task.EmployeeOffboarding.Employee.companyId !== companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const updateData: any = {
@@ -41,6 +47,21 @@ export async function PATCH(
     }
 
     if (assignedTo !== undefined) {
+      if (assignedTo) {
+        const assignee = await prisma.user.findUnique({
+          where: { id: assignedTo },
+          select: { id: true, companyId: true },
+        });
+        if (!assignee) {
+          return NextResponse.json(
+            { error: "Assigned user not found" },
+            { status: 400 },
+          );
+        }
+        if (assignee.companyId !== companyId) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+      }
       updateData.assignedTo = assignedTo;
     }
 
@@ -70,7 +91,10 @@ export async function PATCH(
     // Check if all required tasks are completed to update offboarding status
     if (completed) {
       const allTasks = await prisma.offboardingTask.findMany({
-        where: { offboardingId: task.offboardingId },
+        where: {
+          offboardingId: task.offboardingId,
+          EmployeeOffboarding: { is: { Employee: { companyId } } },
+        },
       });
 
       const allRequiredTasksCompleted = allTasks
@@ -117,7 +141,7 @@ export async function DELETE(
 ) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    if (!session?.user?.id || !session.user.companyId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -125,10 +149,15 @@ export async function DELETE(
 
     const task = await prisma.offboardingTask.findUnique({
       where: { id: taskId },
+      include: { EmployeeOffboarding: { include: { Employee: true } } },
     });
 
     if (!task) {
       return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    if (task.EmployeeOffboarding.Employee.companyId !== session.user.companyId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // Don't allow deletion of required tasks

--- a/tests/offboardingTenancyGuards.test.ts
+++ b/tests/offboardingTenancyGuards.test.ts
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Module from "module";
+
+const originalLoad = (Module as any)._load;
+
+async function withMockedModules(
+  mocks: {
+    prisma: Record<string, any>;
+    session?: any;
+  },
+  callback: () => Promise<void>,
+) {
+  const session =
+    mocks.session ?? {
+      user: { id: "user-1", role: "ADMIN", companyId: "tenant-1" },
+    };
+
+  (Module as any)._load = function (request: string, parent: any, isMain: boolean) {
+    if (request === "@/lib/prisma") {
+      return { prisma: mocks.prisma };
+    }
+    if (request === "@/lib/auth-options") {
+      return { authOptions: {} };
+    }
+    if (request === "next-auth") {
+      return {
+        getServerSession: async () => session,
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    await callback();
+  } finally {
+    (Module as any)._load = originalLoad;
+  }
+}
+
+test("offboarding tenant isolation guards", async (t) => {
+  await t.test("POST /api/offboarding/initiate rejects cross-tenant employee", async () => {
+    const prisma = {
+      employee: {
+        findUnique: async () => ({
+          id: "emp-other",
+          companyId: "other-company",
+          EmployeeOffboarding: null,
+          User: {},
+        }),
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const { POST } = await import(
+        `../app/api/offboarding/initiate/route?test=${Math.random()}`
+      );
+      const res = await POST({
+        json: async () => ({ employeeId: "emp-other" }),
+      } as any);
+      assert.equal(res.status, 403);
+    });
+  });
+
+  await t.test("GET and PATCH /api/offboarding/[employeeId] reject cross-tenant access", async () => {
+    const prisma = {
+      employeeOffboarding: {
+        findUnique: async () => ({
+          id: "off-other",
+          employeeId: "emp-other",
+          Employee: {
+            companyId: "other-company",
+          },
+        }),
+        update: async () => {
+          throw new Error("should not update");
+        },
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const module = await import(
+        `../app/api/offboarding/[employeeId]/route?test=${Math.random()}`
+      );
+      const resGet = await module.GET({} as any, {
+        params: { employeeId: "emp-other" },
+      });
+      assert.equal(resGet.status, 403);
+
+      const resPatch = await module.PATCH(
+        {
+          json: async () => ({ assetsToReturn: [] }),
+        } as any,
+        { params: { employeeId: "emp-other" } },
+      );
+      assert.equal(resPatch.status, 403);
+    });
+  });
+
+  await t.test("POST /api/offboarding/[employeeId]/exit-interview rejects cross-tenant offboarding", async () => {
+    const prisma = {
+      employeeOffboarding: {
+        findUnique: async () => ({
+          id: "off-other",
+          Employee: { companyId: "other-company" },
+        }),
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const { POST } = await import(
+        `../app/api/offboarding/[employeeId]/exit-interview/route?test=${Math.random()}`
+      );
+      const res = await POST(
+        {
+          json: async () => ({}),
+        } as any,
+        { params: { employeeId: "emp-other" } },
+      );
+      assert.equal(res.status, 403);
+    });
+  });
+
+  await t.test("POST /api/offboarding rejects cross-tenant task creation", async () => {
+    const prisma = {
+      employeeOffboarding: {
+        findUnique: async () => ({
+          id: "off-other",
+          employeeId: "emp-other",
+          Employee: {
+            companyId: "other-company",
+            User: null,
+            Department: null,
+            JobRole: null,
+          },
+        }),
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const { POST } = await import(
+        `../app/api/offboarding/route?test=${Math.random()}`
+      );
+      const res = await POST({
+        json: async () => ({
+          offboardingId: "off-other",
+          title: "Task",
+          category: "OTHER",
+        }),
+      } as any);
+      assert.equal(res.status, 403);
+    });
+  });
+
+  await t.test("PATCH and DELETE /api/offboarding/tasks/[id] reject cross-tenant operations", async () => {
+    const prisma = {
+      offboardingTask: {
+        findUnique: async () => ({
+          id: "task-other",
+          offboardingId: "off-other",
+          EmployeeOffboarding: {
+            employeeId: "emp-other",
+            Employee: { companyId: "other-company" },
+          },
+        }),
+        findMany: async () => {
+          throw new Error("should not list");
+        },
+        delete: async () => {
+          throw new Error("should not delete");
+        },
+        update: async () => {
+          throw new Error("should not update");
+        },
+      },
+      employeeOffboarding: {
+        update: async () => {
+          throw new Error("should not update");
+        },
+      },
+      employee: {
+        update: async () => {
+          throw new Error("should not update");
+        },
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const module = await import(
+        `../app/api/offboarding/tasks/[id]/route?test=${Math.random()}`
+      );
+      const resPatch = await module.PATCH(
+        {
+          json: async () => ({}),
+        } as any,
+        { params: { id: "task-other" } },
+      );
+      assert.equal(resPatch.status, 403);
+
+      const resDelete = await module.DELETE({} as any, {
+        params: { id: "task-other" },
+      });
+      assert.equal(resDelete.status, 403);
+    });
+  });
+
+  await t.test("POST /api/offboarding/send-invites rejects cross-tenant offboarding", async () => {
+    const prisma = {
+      employeeOffboarding: {
+        findUnique: async () => ({
+          id: "off-other",
+          Employee: { companyId: "other-company" },
+        }),
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const { POST } = await import(
+        `../app/api/offboarding/send-invites/route?test=${Math.random()}`
+      );
+      const res = await POST({
+        json: async () => ({ offboardingId: "off-other" }),
+      } as any);
+      assert.equal(res.status, 403);
+    });
+  });
+
+  await t.test("POST /api/offboarding/send-form-invite rejects cross-tenant offboarding", async () => {
+    const prisma = {
+      employeeOffboarding: {
+        findUnique: async () => ({
+          id: "off-other",
+          Employee: { companyId: "other-company" },
+          sendForm: true,
+          completionStatus: "PENDING",
+          formTiming: "NOW",
+        }),
+      },
+    };
+
+    await withMockedModules({ prisma }, async () => {
+      const { POST } = await import(
+        `../app/api/offboarding/send-form-invite/route?test=${Math.random()}`
+      );
+      const res = await POST({
+        json: async () => ({ offboardingId: "off-other" }),
+      } as any);
+      assert.equal(res.status, 403);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- gate all offboarding API handlers on the authenticated tenant and return 403 for cross-company access
- update Prisma queries and mutations to apply company scoping or ownership validation
- add regression tests that cover cross-tenant access attempts across offboarding endpoints

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d29b669b64833186221e9de6bcccb6