### PR TITLE
Adjust change reason requirements

### DIFF
--- a/app/(withSidebar)/employees/[id]/emergency-contacts/page.tsx
+++ b/app/(withSidebar)/employees/[id]/emergency-contacts/page.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import { toast } from "sonner";
 import HeaderWithHistory from "@/components/audit/HeaderWithHistory";
-import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import ChangeReasonModal, { ChangeInfo, changeRequiresReason } from "@/components/audit/ChangeReasonModal";
 
 type Contact = {
   id: string;
@@ -64,7 +64,7 @@ export default function EmergencyContactsPage({
     setIsReasonOpen(true);
   };
 
-  const openReasonForUpdate = (contact: Contact) => {
+  const openReasonForUpdate = async (contact: Contact) => {
     const original = originalContacts.find((c) => c.id === contact.id);
     if (!original) {
       toast.error("Original contact not found");
@@ -81,6 +81,19 @@ export default function EmergencyContactsPage({
     }
     if (changes.length === 0) {
       toast.success("No changes to save");
+      return;
+    }
+    if (!changes.some(changeRequiresReason)) {
+      const res = await fetch(`/api/employees/${params.id}/emergency-contacts`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...contact, reasons: {} }),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to update");
+      }
+      toast.success("Saved");
+      await load();
       return;
     }
     setPendingAction("update");
@@ -105,7 +118,7 @@ export default function EmergencyContactsPage({
       if (contact.id.startsWith("__new__")) {
         openReasonForCreate(contact);
       } else {
-        openReasonForUpdate(contact);
+        await openReasonForUpdate(contact);
       }
     } catch (e: any) {
       toast.error(e?.message || "Save failed");

--- a/app/api/employees/[id]/bank-payroll/route.ts
+++ b/app/api/employees/[id]/bank-payroll/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason } from "@/lib/audit-helpers";
 import {
   formatBankAccountNumber,
   isValidIrdNumber,
@@ -126,23 +126,22 @@ export async function PATCH(
     // Compute diffs before update
     const diffs = computeDiffs(employee, { ...employee, ...updates }, allowed);
     
-    // Check if reasons are required and provided
-    if (diffs.some(diff => diff.newValue)) {
-      if (!reasons) {
+    if (diffs.length > 0) {
+      const requiresReasons = diffs.some(diffRequiresReason);
+      if (requiresReasons && !reasons) {
         return NextResponse.json(
           { error: "Reasons required for changes" },
           { status: 400 }
         );
       }
-      
-      // Validate reasons (will throw if missing)
+
       try {
         await createAuditLogs({
           companyId: session.user.companyId!,
           employeeId: employee.id,
           section: "bank-payroll",
           diffs,
-          reasons: reasons as Record<string, string>,
+          reasons: (reasons as Record<string, string>) || {},
           changedById: session.user.id,
         });
       } catch (error: any) {

--- a/app/api/employees/[id]/emergency-contacts/route.ts
+++ b/app/api/employees/[id]/emergency-contacts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason } from "@/lib/audit-helpers";
 
 export async function GET(
   _req: Request,
@@ -159,23 +159,22 @@ export async function PATCH(
     // Compute diffs
     const diffs = computeDiffs(existingContact, { ...existingContact, ...updates }, allowed);
     
-    // Check if reasons are required and provided
-    if (diffs.some(diff => diff.newValue)) {
-      if (!reasons) {
+    if (diffs.length > 0) {
+      const requiresReasons = diffs.some(diffRequiresReason);
+      if (requiresReasons && !reasons) {
         return NextResponse.json(
           { error: "Reasons required for changes" },
           { status: 400 }
         );
       }
-      
-      // Validate reasons
+
       try {
         await createAuditLogs({
           companyId: session.user.companyId!,
           employeeId: employee.id,
           section: "emergency-contacts",
           diffs,
-          reasons,
+          reasons: reasons || {},
           changedById: session.user.id,
         });
       } catch (error: any) {

--- a/app/api/employees/[id]/employment-details/route.ts
+++ b/app/api/employees/[id]/employment-details/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason } from "@/lib/audit-helpers";
 
 export async function GET(
   _req: Request,
@@ -99,8 +99,9 @@ export async function PATCH(
       allowed,
     );
 
-    if (diffs.some((d) => d.newValue)) {
-      if (!reasons) {
+    if (diffs.length > 0) {
+      const requiresReasons = diffs.some(diffRequiresReason);
+      if (requiresReasons && !reasons) {
         return NextResponse.json(
           { error: "Reasons required for changes" },
           { status: 400 },
@@ -112,7 +113,7 @@ export async function PATCH(
           employeeId: employee.id,
           section: "employment-details",
           diffs,
-          reasons,
+          reasons: reasons || {},
           changedById: session.user.id,
         });
       } catch (err: any) {

--- a/app/api/employees/[id]/personal-info/route.ts
+++ b/app/api/employees/[id]/personal-info/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { computeDiffs, createAuditLogs, serialize } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason, serialize } from "@/lib/audit-helpers";
 
 export async function PATCH(
   req: Request,
@@ -59,22 +59,22 @@ export async function PATCH(
     const diffs = computeDiffs(before, { ...before, ...updates }, allowed);
     
     // Check if reasons are required and provided
-    if (diffs.some(diff => diff.newValue)) {
-      if (!reasons) {
+    if (diffs.length > 0) {
+      const requiresReasons = diffs.some(diffRequiresReason);
+      if (requiresReasons && !reasons) {
         return NextResponse.json(
           { error: "Reasons required for changes" },
           { status: 400 }
         );
       }
-      
-      // Validate reasons (will throw if missing)
+
       try {
         await createAuditLogs({
           companyId: session.user.companyId!,
           employeeId: employee.id,
           section: "personal-info",
           diffs,
-          reasons: reasons as Record<string, string>,
+          reasons: (reasons as Record<string, string>) || {},
           changedById: session.user.id,
         });
       } catch (error: any) {

--- a/app/api/employment-checks/[id]/route.ts
+++ b/app/api/employment-checks/[id]/route.ts
@@ -6,7 +6,7 @@ import supabase from "@/lib/supabase-admin";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { randomUUID } from "crypto";
-import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason } from "@/lib/audit-helpers";
 
 export async function PATCH(
   req: NextRequest,
@@ -102,8 +102,9 @@ export async function PATCH(
         { ...existing, typeOfCheck, documentNumber, dateOfIssue: new Date(dateOfIssue), expiryDate: new Date(expiryDate), ...(documentUrl && { documentUrl }) },
         ["typeOfCheck", "documentNumber", "dateOfIssue", "expiryDate", "documentUrl"] as const,
       );
-      if (diffs.some((d) => d.newValue)) {
-        if (!reasons) {
+      if (diffs.length > 0) {
+        const requiresReasons = diffs.some(diffRequiresReason);
+        if (requiresReasons && !reasons) {
           return NextResponse.json({ error: "Reasons required" }, { status: 400 });
         }
         await createAuditLogs({
@@ -111,7 +112,7 @@ export async function PATCH(
           employeeId: existing.employeeId,
           section: "employment-checks",
           diffs,
-          reasons,
+          reasons: reasons || {},
           changedById: session.user.id,
         });
       }

--- a/app/api/training-records/[id]/route.ts
+++ b/app/api/training-records/[id]/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import supabase from "@/lib/supabase-admin";
-import { computeDiffs, createAuditLogs } from "@/lib/audit-helpers";
+import { computeDiffs, createAuditLogs, diffRequiresReason } from "@/lib/audit-helpers";
 
 export async function PUT(
   req: Request,
@@ -127,8 +127,9 @@ export async function PUT(
         },
         ["courseId", "providerId", "dateCompleted", "expiryDate", "documentId"] as const,
       );
-      if (diffs.some((d) => d.newValue)) {
-        if (!reasons) {
+      if (diffs.length > 0) {
+        const requiresReasons = diffs.some(diffRequiresReason);
+        if (requiresReasons && !reasons) {
           return NextResponse.json({ error: "Reasons required" }, { status: 400 });
         }
         await createAuditLogs({
@@ -136,7 +137,7 @@ export async function PUT(
           employeeId: existing.employeeId,
           section: "training",
           diffs,
-          reasons,
+          reasons: reasons || {},
           changedById: session.user.id,
         });
       }

--- a/app/components/audit/ChangeReasonModal.tsx
+++ b/app/components/audit/ChangeReasonModal.tsx
@@ -14,6 +14,25 @@ export interface ChangeInfo {
   newValue: string;
 }
 
+function hasMeaningfulValue(value: string): boolean {
+  if (!value) return false;
+  if (typeof value.trim === "function") {
+    return value.trim() !== "";
+  }
+  return Boolean(value);
+}
+
+export function changeRequiresReason(change: ChangeInfo): boolean {
+  if (change.field === "__create__" || change.field === "__delete__") {
+    return true;
+  }
+
+  const hasOldValue = hasMeaningfulValue(change.oldValue);
+  const hasNewValue = hasMeaningfulValue(change.newValue);
+
+  return hasOldValue && hasNewValue;
+}
+
 interface ChangeReasonModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -43,8 +62,7 @@ export default function ChangeReasonModal({
     const missingReasons: string[] = [];
     
     for (const change of changes) {
-      // Only require reason if new value is non-empty
-      const requiresReason = Boolean(change.newValue);
+      const requiresReason = changeRequiresReason(change);
       if (requiresReason && (!reasons[change.field] || reasons[change.field].trim() === "")) {
         missingReasons.push(labelForField(change.field));
       }
@@ -58,9 +76,11 @@ export default function ChangeReasonModal({
     onSubmit(reasons);
   };
 
-  const allReasonsProvided = changes.every(change => 
-    !change.newValue || (reasons[change.field] && reasons[change.field].trim() !== "")
-  );
+  const allReasonsProvided = changes.every(change => {
+    if (!changeRequiresReason(change)) return true;
+    const reason = reasons[change.field];
+    return Boolean(reason && reason.trim() !== "");
+  });
 
   if (!isOpen) return null;
 
@@ -85,7 +105,7 @@ export default function ChangeReasonModal({
                 </div>
               </div>
               
-              {change.newValue ? (
+              {changeRequiresReason(change) ? (
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     Reason for change <span className="text-red-500">*</span>
@@ -102,7 +122,7 @@ export default function ChangeReasonModal({
                 </div>
               ) : (
                 <div className="text-sm text-gray-500 italic">
-                  Field is being cleared - no reason required
+                  No reason required for this change
                 </div>
               )}
             </div>

--- a/app/components/employees/EmployeeSaveButton.tsx
+++ b/app/components/employees/EmployeeSaveButton.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Button from "@/components/ui/Button";
 import { Save } from "lucide-react";
 import { toast } from "sonner";
-import ChangeReasonModal, { ChangeInfo } from "../audit/ChangeReasonModal";
+import ChangeReasonModal, { ChangeInfo, changeRequiresReason } from "../audit/ChangeReasonModal";
 
 interface EmployeeSaveButtonProps {
   employeeId: string;
@@ -66,8 +66,8 @@ export default function EmployeeSaveButton({
         return;
       }
 
-      // Check if any changes have non-empty new values (require reasons)
-      if (changes.some(change => change.newValue)) {
+      // Check if any changes require reasons (existing values being updated or synthetic changes)
+      if (changes.some(changeRequiresReason)) {
         setPendingChanges(changes);
         setIsReasonModalOpen(true);
         return;

--- a/app/components/employees/PersonalInfoSaveButton.tsx
+++ b/app/components/employees/PersonalInfoSaveButton.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Button from "@/components/ui/Button";
 import { Save } from "lucide-react";
 import { toast } from "sonner";
-import ChangeReasonModal, { ChangeInfo } from "../audit/ChangeReasonModal";
+import ChangeReasonModal, { ChangeInfo, changeRequiresReason } from "../audit/ChangeReasonModal";
 import { useUnsavedChangesContext } from "@/components/ui/UnsavedChangesGuard";
 
 export default function PersonalInfoSaveButton({
@@ -76,8 +76,8 @@ export default function PersonalInfoSaveButton({
         return;
       }
 
-      // Check if any changes have non-empty new values (require reasons)
-      if (changes.some(change => change.newValue)) {
+      // Check if any changes require reasons (existing values being updated or synthetic changes)
+      if (changes.some(changeRequiresReason)) {
         setPendingChanges(changes);
         setPendingPayload(payload);
         setIsReasonModalOpen(true);

--- a/app/components/forms/DynamicFormRenderer.tsx
+++ b/app/components/forms/DynamicFormRenderer.tsx
@@ -11,7 +11,7 @@ import Checkbox from "@/components/ui/Checkbox";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { PageLoader } from "@/components/ui/LoadingSpinner";
-import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import ChangeReasonModal, { ChangeInfo, changeRequiresReason } from "@/components/audit/ChangeReasonModal";
 
 interface DynamicFormRendererProps {
   formId: string;
@@ -148,10 +148,20 @@ export function DynamicFormRenderer({
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({ field: k, oldValue: "", newValue: JSON.stringify(v ?? "") }));
-        setPendingData(data);
-        setPendingChanges(changes);
-        setIsReasonOpen(true);
+        const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({
+          field: k,
+          oldValue: "",
+          newValue: JSON.stringify(v ?? ""),
+        }));
+
+        if (changes.some(changeRequiresReason)) {
+          setPendingData(data);
+          setPendingChanges(changes);
+          setIsReasonOpen(true);
+          return;
+        }
+
+        await submitForm(data, {});
       })}
       className="space-y-6 bg-white p-6 rounded-lg shadow-md"
     >

--- a/app/components/forms/EnhancedFormRenderer.tsx
+++ b/app/components/forms/EnhancedFormRenderer.tsx
@@ -12,7 +12,7 @@ import { Loader2, Plus, Trash2, Save } from "lucide-react";
 import { FormField, TableColumn, AnyFormSchema, normalizeToPages, FormPage } from "@/api/forms/[id]/types";
 import { PageLoader } from "@/components/ui/LoadingSpinner";
 import HistoryButton from "@/components/audit/HistoryButton";
-import ChangeReasonModal, { ChangeInfo } from "@/components/audit/ChangeReasonModal";
+import ChangeReasonModal, { ChangeInfo, changeRequiresReason } from "@/components/audit/ChangeReasonModal";
 
 const isSerializableValue = (value: unknown) => {
   if (value === undefined) return false;
@@ -387,7 +387,7 @@ export function EnhancedFormRenderer({
           changes.push({ field: k, oldValue: JSON.stringify(oldVal ?? ""), newValue: JSON.stringify(v ?? "") });
         }
       }
-      if (changes.length > 0) {
+      if (changes.length > 0 && changes.some(changeRequiresReason)) {
         setPendingAction("data");
         setPendingChanges(changes);
         setPendingPayload({ data });
@@ -395,17 +395,27 @@ export function EnhancedFormRenderer({
         return;
       }
       if (!formData?.readOnly) {
-        saveData(data);
+        await saveData(data);
       } else {
         toast.error("This screen is read-only.");
       }
     } else {
       // Treat as changes from empty -> value
-      const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({ field: k, oldValue: "", newValue: JSON.stringify(v ?? "") }));
-      setPendingAction("submit");
-      setPendingChanges(changes);
-      setPendingPayload({ data });
-      setIsReasonOpen(true);
+      const changes: ChangeInfo[] = Object.entries(data).map(([k, v]) => ({
+        field: k,
+        oldValue: "",
+        newValue: JSON.stringify(v ?? ""),
+      }));
+
+      if (changes.some(changeRequiresReason)) {
+        setPendingAction("submit");
+        setPendingChanges(changes);
+        setPendingPayload({ data });
+        setIsReasonOpen(true);
+        return;
+      }
+
+      await submitForm(data, {});
     }
   };
 

--- a/app/lib/audit-helpers.ts
+++ b/app/lib/audit-helpers.ts
@@ -47,6 +47,38 @@ export function computeDiffs(
   return diffs;
 }
 
+function hasMeaningfulValue(value: string | null): boolean {
+  if (value === null) return false;
+  return value.trim() !== "";
+}
+
+export function diffRequiresReason(diff: AuditDiff): boolean {
+  const isSynthetic = diff.field === "__create__" || diff.field === "__delete__";
+  if (isSynthetic) {
+    return true;
+  }
+
+  const hasOldValue = hasMeaningfulValue(diff.oldValue);
+  const hasNewValue = hasMeaningfulValue(diff.newValue);
+
+  return hasOldValue && hasNewValue;
+}
+
+function defaultReasonForDiff(diff: AuditDiff): string {
+  const hasNewValue = hasMeaningfulValue(diff.newValue);
+  const hasOldValue = hasMeaningfulValue(diff.oldValue);
+
+  if (!hasNewValue) {
+    return "Field cleared";
+  }
+
+  if (!hasOldValue) {
+    return "Initial value set";
+  }
+
+  return "Change recorded";
+}
+
 export interface CreateAuditLogsOptions {
   skipNotifications?: boolean;
 }
@@ -73,11 +105,7 @@ export async function createAuditLogs(
 
   // Validate that all required reasons are provided
   for (const diff of diffs) {
-    const isSynthetic = diff.field === "__create__" || diff.field === "__delete__";
-    // Only require a reason when value changes from a non-null/meaningful previous value to a different one
-    const hadValue = diff.oldValue !== null && diff.oldValue !== "";
-    const changedToDifferent = diff.newValue !== diff.oldValue;
-    const requiresReason = isSynthetic || (hadValue && changedToDifferent);
+    const requiresReason = diffRequiresReason(diff);
     if (requiresReason && (!reasons[diff.field] || reasons[diff.field].trim() === "")) {
       throw new Error(`Reason required for field: ${diff.field}`);
     }
@@ -92,7 +120,10 @@ export async function createAuditLogs(
       field: diff.field,
       oldValue: diff.oldValue,
       newValue: diff.newValue,
-      reason: reasons[diff.field] || "Field cleared", // Default reason for cleared fields
+      reason:
+        (reasons[diff.field] && reasons[diff.field].trim() !== ""
+          ? reasons[diff.field]
+          : defaultReasonForDiff(diff)),
       changedById,
     })),
   });
@@ -122,10 +153,7 @@ export function validateReasons(
   const errors: string[] = [];
   
   for (const diff of diffs) {
-    const isSynthetic = diff.field === "__create__" || diff.field === "__delete__";
-    const hadValue = diff.oldValue !== null && diff.oldValue !== "";
-    const changedToDifferent = diff.newValue !== diff.oldValue;
-    const requiresReason = isSynthetic || (hadValue && changedToDifferent);
+    const requiresReason = diffRequiresReason(diff);
     if (requiresReason && (!reasons[diff.field] || reasons[diff.field].trim() === "")) {
       errors.push(`Reason required for field: ${diff.field}`);
     }


### PR DESCRIPTION
## Summary
- update change reason modal logic and consumers to only request reasons when existing values change or for synthetic events
- avoid opening the reason dialog for onboarding and employee updates that are filling empty fields while still saving directly
- align server-side audits with the new rule, reusing a diff helper and providing sensible default reasons when none are required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2c04acac4833198b6471b06b11808