### PR TITLE
Improve saved report UX handling

### DIFF
--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -22,7 +22,7 @@ interface SavedReport {
   id: number;
   name: string;
   category: string;
-  fields: string[]; // ✅ native array
+  fields: string[] | string | null;
   createdAt: string;
   createdBy: {
     email: string;
@@ -34,15 +34,22 @@ export default function ReportsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [deletingIds, setDeletingIds] = useState<number[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const router = useRouter();
   const breadcrumbs = useBreadcrumbs();
 
-  const fetchReports = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const fetchReports = useCallback(
+    async ({ initial = false }: { initial?: boolean } = {}) => {
+      if (initial) {
+        setLoading(true);
+      } else {
+        setIsRefreshing(true);
+      }
 
-    try {
-      const res = await fetch("/api/reports");
+      setError(null);
+
+      try {
+        const res = await fetch("/api/reports");
 
       if (!res.ok) {
         let message = "Failed to load reports.";
@@ -58,10 +65,12 @@ export default function ReportsPage() {
 
       const data = await res.json();
       setReports(data);
-      toast({
-        title: "Reports loaded",
-        description: "Saved reports are up to date.",
-      });
+      if (!initial) {
+        toast({
+          title: "Reports updated",
+          description: "Saved reports have been refreshed.",
+        });
+      }
     } catch (err) {
       console.error("Failed to fetch reports", err);
       const message =
@@ -75,17 +84,21 @@ export default function ReportsPage() {
         variant: "destructive",
       });
     } finally {
-      setLoading(false);
+      if (initial) {
+        setLoading(false);
+      } else {
+        setIsRefreshing(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    void fetchReports();
+    void fetchReports({ initial: true });
   }, [fetchReports]);
 
   const handleDelete = async (id: number) => {
     if (!confirm("Delete this report?")) return;
-    const previousReports = reports;
+    const previousReports = [...reports];
     const reportToDelete = reports.find((report) => report.id === id);
 
     setDeletingIds((prev) => [...prev, id]);
@@ -150,6 +163,13 @@ export default function ReportsPage() {
       breadcrumbs={breadcrumbs}
       action={
         <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => void fetchReports()}
+            disabled={isRefreshing}
+          >
+            {isRefreshing ? "Refreshing..." : "Refresh"}
+          </Button>
           <Button onClick={() => router.push("/reports/builder-new")}>
             + New Report Builder
           </Button>
@@ -169,7 +189,10 @@ export default function ReportsPage() {
               <p className="font-medium text-destructive">Unable to load reports</p>
               <p className="text-sm text-destructive/80">{error}</p>
             </div>
-            <Button variant="outline" onClick={() => void fetchReports()}>
+            <Button
+              variant="outline"
+              onClick={() => void fetchReports({ initial: reports.length === 0 })}
+            >
               Retry
             </Button>
           </div>
@@ -212,7 +235,10 @@ export default function ReportsPage() {
                     onClick={() => {
                       console.log("🧪 Raw report.fields:", report.fields);
 
-                      if (!report.fields) {
+                      if (
+                        !report.fields ||
+                        (Array.isArray(report.fields) && report.fields.length === 0)
+                      ) {
                         toast({
                           title: "Unable to open report",
                           description: "No fields were saved with this report configuration.",
@@ -221,9 +247,34 @@ export default function ReportsPage() {
                         return;
                       }
 
-                      const fieldArray = Array.isArray(report.fields)
-                        ? report.fields
-                        : JSON.parse(report.fields || "[]");
+                      let fieldArray: string[] = [];
+                      if (Array.isArray(report.fields)) {
+                        fieldArray = report.fields.filter(
+                          (field): field is string =>
+                            typeof field === "string" && field.trim() !== "",
+                        );
+                      } else if (typeof report.fields === "string") {
+                        try {
+                          const parsed = JSON.parse(report.fields || "[]");
+                          if (Array.isArray(parsed)) {
+                            fieldArray = parsed.filter(
+                              (field): field is string =>
+                                typeof field === "string" && field.trim() !== "",
+                            );
+                          } else {
+                            fieldArray = report.fields
+                              .split(",")
+                              .map((field) => field.trim())
+                              .filter((field) => field.length > 0);
+                          }
+                        } catch (parseError) {
+                          console.error("Failed to parse report fields", parseError);
+                          fieldArray = report.fields
+                            .split(",")
+                            .map((field) => field.trim())
+                            .filter((field) => field.length > 0);
+                        }
+                      }
 
                       if (!fieldArray.length) {
                         toast({
@@ -235,7 +286,8 @@ export default function ReportsPage() {
                       }
 
                       const params = new URLSearchParams();
-                      params.set("fields", fieldArray.join(","));
+                      params.set("fields", JSON.stringify(fieldArray));
+                      params.set("reportId", String(report.id));
                       params.set("returnTo", "/reports");
                       router.push(`/reports/preview?${params.toString()}`);
                     }}

--- a/app/reports/preview/ReportsPreviewClient.tsx
+++ b/app/reports/preview/ReportsPreviewClient.tsx
@@ -37,7 +37,7 @@ function getNested(obj: any, path: string): any {
   }, obj);
 }
 
-function parseFieldsParam(value: string | null): string[] {
+function parseFieldsParam(value: string | null | undefined): string[] {
   if (!value) return [];
 
   try {

--- a/app/reports/preview/ReportsPreviewClient.tsx
+++ b/app/reports/preview/ReportsPreviewClient.tsx
@@ -37,6 +37,26 @@ function getNested(obj: any, path: string): any {
   }, obj);
 }
 
+function parseFieldsParam(value: string | null): string[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((field) => (typeof field === "string" ? field.trim() : ""))
+        .filter((field) => field.length > 0);
+    }
+  } catch {
+    // Fall back to comma separated values.
+  }
+
+  return value
+    .split(",")
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+}
+
 function downloadCSV(data: any[], columns: ColumnDefinition[]) {
   if (!data || data.length === 0) return;
 
@@ -73,9 +93,23 @@ export default function ReportsPreviewClient() {
   const { toast } = useToast();
   const { template, regionName } = useTenantRegion();
 
+  const initialFields = useMemo(() => parseFieldsParam(fieldsParam), [fieldsParam]);
+
   const [selectedFields, setSelectedFields] = useState<string[]>(() => {
-    return reportIdParam ? [] : fieldsParam ? fieldsParam.split(",") : [];
+    return reportIdParam ? [] : initialFields;
   });
+  useEffect(() => {
+    if (reportIdParam) return;
+    setSelectedFields((current) => {
+      if (
+        current.length === initialFields.length &&
+        current.every((field, index) => field === initialFields[index])
+      ) {
+        return current;
+      }
+      return initialFields;
+    });
+  }, [initialFields, reportIdParam]);
   const [reportConfig, setReportConfig] = useState<any>(null);
 
   const [data, setData] = useState<any[]>([]);


### PR DESCRIPTION
## Summary
- add a manual refresh action and selective toast handling to the saved reports table
- harden saved field parsing before routing to the preview, including passing the report id and serialised fields payload
- update the preview client to understand the new fields payload while remaining backward compatible

## Testing
- npm run lint *(fails: existing lint errors across unrelated API files)*
- npx eslint app/reports/page.tsx app/reports/preview/ReportsPreviewClient.tsx *(fails: existing @typescript-eslint any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d52c6b1bc483318f45582cf01c7371