### PR TITLE
Secure audience audience API endpoint

### DIFF
--- a/app/api/audience/route.ts
+++ b/app/api/audience/route.ts
@@ -3,14 +3,38 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma"; // Adjust this path if needed
 
 export async function GET(req: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id || !session.user.companyId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const allowedRoles = new Set(["ADMIN", "MANAGER", "SUPER_ADMIN"]);
+    if (!session.user.role || !allowedRoles.has(session.user.role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const companyId = session.user.companyId;
+
     const [departments, jobRoles, locations] = await Promise.all([
-      prisma.department.findMany({ select: { id: true, name: true } }),
-      prisma.jobRole.findMany({ select: { id: true, name: true } }),
-      prisma.location.findMany({ select: { id: true, name: true } }),
+      prisma.department.findMany({
+        where: { companyId },
+        select: { id: true, name: true },
+      }),
+      prisma.jobRole.findMany({
+        where: { companyId },
+        select: { id: true, name: true },
+      }),
+      prisma.location.findMany({
+        where: { companyId },
+        select: { id: true, name: true },
+      }),
     ]);
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- gate the audience API behind getServerSession authentication
- restrict responses to the caller's company and enforce admin/manager access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da60d01d00833182b81427b18397d9