### PR TITLE
Fix report preview columns resolving to null for dynamic data

### DIFF
--- a/app/reports/preview/ReportsPreviewClient.tsx
+++ b/app/reports/preview/ReportsPreviewClient.tsx
@@ -639,9 +639,6 @@ export default function ReportsPreviewClient() {
     return fields;
   }, [effectiveSelectedFields]);
 
-  // Use a sample row (when available) to detect which accessor path resolves
-  const sampleRow = data && data.length > 0 ? data[0] : undefined;
-
   const columns = useMemo<ColumnDefinition[]>(() => {
     return visibleFields.map((field) => {
       const keys = field.split(".");
@@ -683,10 +680,12 @@ export default function ReportsPreviewClient() {
       if (field === "LeaveEntitlement.carryoverDays") candidates.push("carryoverDays", "LeaveEntitlement.carryoverDays");
       if (field === "_computed.remainingEntitlement") candidates.push("_computed.remainingEntitlement", "remainingEntitlement");
 
-      // Choose first candidate that resolves on a sample row
+      // Choose the first candidate that resolves for any fetched row
       let accessorKey = candidates[0] || field;
-      if (sampleRow) {
-        const found = candidates.find((c) => getNested(sampleRow, c) !== undefined);
+      if (data.length > 0) {
+        const found = candidates.find((candidate) =>
+          data.some((row) => getNested(row, candidate) !== undefined),
+        );
         if (found) accessorKey = found;
       }
 
@@ -698,7 +697,7 @@ export default function ReportsPreviewClient() {
 
       return { header: label, accessorKey };
     });
-  }, [visibleFields, fieldLabels, translateLegacy, sampleRow]);
+  }, [visibleFields, fieldLabels, translateLegacy, data]);
 
   const logAndToastPII = useCallback(
     (rowCount: number) => {


### PR DESCRIPTION
## Summary
- update the report preview column accessor selection to scan all fetched rows instead of relying on a single sample
- ensure column headers continue to resolve against legacy field metadata while avoiding null renders when later rows contain data

## Testing
- npm test -- tests/reportsPreviewCsv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df7b6e41b48331bdd51f3508de7c98