### PR TITLE
Allow employee CSV imports to update existing records

### DIFF
--- a/app/(withSidebar)/settings/system/csv-import/page.tsx
+++ b/app/(withSidebar)/settings/system/csv-import/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/Badge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Switch } from "@/components/ui/switch";
 import {
   Upload,
   Download,
@@ -44,6 +45,7 @@ import {
   Eye,
   X,
   ListChecks,
+  RefreshCcw,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -53,6 +55,7 @@ interface ImportResult {
   failed: number;
   errors: Array<{ row: number; errors: string[] }>;
   created: Array<{ id: string; email: string; name: string }>;
+  updated: Array<{ id: string; email: string; name: string }>;
   activation?: {
     total: number;
     activated: number;
@@ -101,6 +104,9 @@ const importSequence: Array<{ label: string; value: ImportType }> = [
   { label: "Working Patterns", value: "working-patterns" },
   { label: "Employees", value: "employees" },
 ];
+
+const getImportLabel = (type: ImportType) =>
+  importSequence.find(step => step.value === type)?.label ?? type;
 
 const getImportTypeInfo = (type: ImportType): ImportTypeInfo => {
   switch (type) {
@@ -301,6 +307,8 @@ export default function CSVImportPage() {
     checkPermissions: true,
     promoteManagers: true,
   });
+  const [lastImportedType, setLastImportedType] = useState<ImportType | null>(null);
+  const [allowUpdates, setAllowUpdates] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importInfo = getImportTypeInfo(selectedImportType);
 
@@ -327,23 +335,28 @@ export default function CSVImportPage() {
   const handleImport = async () => {
     if (!selectedFile) return;
 
+    const currentType = selectedImportType;
+    const currentTypeLabel = getImportLabel(currentType);
+
     setImportProgress({
       status: "uploading",
       progress: 0,
-      message: "Uploading file...",
+      message: `Uploading ${currentTypeLabel.toLowerCase()} file...`,
     });
+    setLastImportedType(currentType);
 
     try {
       const formData = new FormData();
       formData.append("file", selectedFile);
+      formData.append("allowUpdates", allowUpdates ? "true" : "false");
 
       setImportProgress({
         status: "processing",
         progress: 50,
-        message: `Processing ${selectedImportType} data...`,
+        message: `Processing ${currentTypeLabel.toLowerCase()} data...`,
       });
 
-      const response = await fetch(`/api/csv-import/${selectedImportType}`, {
+      const response = await fetch(`/api/csv-import/${currentType}`, {
         method: "POST",
         body: formData,
       });
@@ -354,16 +367,52 @@ export default function CSVImportPage() {
         throw new Error(data.error || "Import failed");
       }
 
+      const hasFailures = (data.results?.failed ?? 0) > 0;
+      const rawResults = data.results ?? {};
+      const normalisedResults: ImportResult = {
+        total: rawResults.total ?? 0,
+        successful: rawResults.successful ?? 0,
+        failed: rawResults.failed ?? 0,
+        errors: rawResults.errors ?? [],
+        created: rawResults.created ?? [],
+        updated: rawResults.updated ?? [],
+        activation: rawResults.activation,
+      };
+
       setImportProgress({
         status: "completed",
         progress: 100,
-        message: "Import completed successfully!",
-        result: data.results,
+        message: `${currentTypeLabel} import completed successfully!`,
+        result: normalisedResults,
       });
 
       setShowResults(true);
-      toast.success(`Import completed: ${data.results.successful} ${selectedImportType} processed`);
+      const summarySegments = [] as string[];
+      if ((normalisedResults.created?.length ?? 0) > 0) {
+        summarySegments.push(`${normalisedResults.created.length} created`);
+      }
+      if ((normalisedResults.updated?.length ?? 0) > 0) {
+        summarySegments.push(`${normalisedResults.updated.length} updated`);
+      }
+      const summaryMessage =
+        summarySegments.length > 0
+          ? summarySegments.join(" · ")
+          : `${normalisedResults.successful} ${currentTypeLabel} processed`;
+      toast.success(`Import completed: ${summaryMessage}`);
 
+      setSelectedFile(null);
+      setValidationErrors([]);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+
+      if (!hasFailures) {
+        const currentStepIndex = importSequence.findIndex(step => step.value === currentType);
+        const nextStep = currentStepIndex === -1 ? null : importSequence[currentStepIndex + 1];
+        if (nextStep) {
+          setSelectedImportType(nextStep.value);
+        }
+      }
     } catch (error) {
       setImportProgress({
         status: "error",
@@ -426,6 +475,8 @@ export default function CSVImportPage() {
     setShowResults(false);
     setShowActivationOptions(false);
     setValidationErrors([]);
+    setLastImportedType(null);
+    setAllowUpdates(false);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -765,6 +816,34 @@ export default function CSVImportPage() {
               </Alert>
             )}
 
+            {selectedImportType === "employees" && (
+              <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-4 space-y-3">
+                <div className="space-y-1">
+                  <h4 className="text-sm font-medium">Existing employee updates</h4>
+                  <p className="text-xs text-muted-foreground">
+                    Enable this option to merge new personal, employment, and payroll details for people who already exist in
+                    Corenz.
+                  </p>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <Label htmlFor="allow-updates" className="text-sm font-medium">
+                      Allow updates for existing employees
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Matching emails will be updated while new rows are created as usual.
+                    </p>
+                  </div>
+                  <Switch
+                    id="allow-updates"
+                    checked={allowUpdates}
+                    onCheckedChange={setAllowUpdates}
+                    disabled={importProgress.status === "processing" || importProgress.status === "uploading"}
+                  />
+                </div>
+              </div>
+            )}
+
             <div className="flex gap-2">
               <Button
                 onClick={handleImport}
@@ -788,6 +867,11 @@ export default function CSVImportPage() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
+              {lastImportedType && (
+                <div className="text-sm text-muted-foreground">
+                  Import summary for {getImportLabel(lastImportedType)}
+                </div>
+              )}
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
                   <span className={getStatusColor()}>{importProgress.message}</span>
@@ -798,12 +882,18 @@ export default function CSVImportPage() {
 
               {importProgress.status === "completed" && importProgress.result && (
                 <div className="space-y-4">
-                  <div className="grid grid-cols-3 gap-4">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                     <div className="text-center">
                       <div className="text-2xl font-bold text-green-600">
-                        {importProgress.result.successful}
+                        {importProgress.result.created.length}
                       </div>
-                      <div className="text-sm text-muted-foreground">Successful</div>
+                      <div className="text-sm text-muted-foreground">Created</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-blue-600">
+                        {importProgress.result.updated.length}
+                      </div>
+                      <div className="text-sm text-muted-foreground">Updated</div>
                     </div>
                     <div className="text-center">
                       <div className="text-2xl font-bold text-red-600">
@@ -812,12 +902,15 @@ export default function CSVImportPage() {
                       <div className="text-sm text-muted-foreground">Failed</div>
                     </div>
                     <div className="text-center">
-                      <div className="text-2xl font-bold text-blue-600">
+                      <div className="text-2xl font-bold text-indigo-600">
                         {importProgress.result.total}
                       </div>
-                      <div className="text-sm text-muted-foreground">Total</div>
+                      <div className="text-sm text-muted-foreground">Total processed</div>
                     </div>
                   </div>
+                  <p className="text-xs text-muted-foreground text-center md:text-left">
+                    Successful rows: {importProgress.result.successful}
+                  </p>
 
                   {/* Employee Activation Options */}
                   {selectedImportType === "employees" && importProgress.result.created && importProgress.result.created.length > 0 && (
@@ -972,6 +1065,26 @@ export default function CSVImportPage() {
                           <div className="text-sm text-muted-foreground">{employee.email}</div>
                         </div>
                         <Badge className="bg-green-100 text-green-800">Created</Badge>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {importProgress.result.updated.length > 0 && (
+                <div>
+                  <h4 className="font-medium mb-2 flex items-center gap-2">
+                    <RefreshCcw className="h-4 w-4 text-blue-600" />
+                    Updated ({importProgress.result.updated.length})
+                  </h4>
+                  <div className="space-y-2 max-h-40 overflow-y-auto">
+                    {importProgress.result.updated.map((employee, index) => (
+                      <div key={index} className="flex items-center justify-between p-2 bg-blue-50 rounded border">
+                        <div>
+                          <div className="font-medium">{employee.name}</div>
+                          <div className="text-sm text-muted-foreground">{employee.email}</div>
+                        </div>
+                        <Badge className="bg-blue-100 text-blue-800">Updated</Badge>
                       </div>
                     ))}
                   </div>

--- a/app/api/csv-import/employees/route.ts
+++ b/app/api/csv-import/employees/route.ts
@@ -210,6 +210,7 @@ export async function POST(request: NextRequest) {
     }
 
     const formData = await request.formData();
+    const allowUpdates = String(formData.get("allowUpdates") ?? "false").toLowerCase() === "true";
     const file = formData.get("file") as File;
     
     if (!file) {
@@ -233,7 +234,10 @@ export async function POST(request: NextRequest) {
       failed: 0,
       errors: [] as Array<{ row: number; errors: string[] }>,
       created: [] as Array<{ id: string; email: string; name: string }>,
+      updated: [] as Array<{ id: string; email: string; name: string }>,
     };
+
+    const importBatchId = `csv_import_${Date.now()}`;
 
     // Process each record
     for (let i = 0; i < records.length; i++) {
@@ -250,10 +254,16 @@ export async function POST(request: NextRequest) {
 
         // Check if user already exists
         const existingUser = await prisma.user.findFirst({
-          where: { email },
+          where: {
+            email,
+            companyId: session.user.companyId,
+          },
+          include: {
+            Employee: true,
+          },
         });
 
-        if (existingUser) {
+        if (existingUser && !allowUpdates) {
           results.failed++;
           results.errors.push({
             row: rowNumber,
@@ -262,8 +272,11 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
+        const canUpdateExistingUser = Boolean(existingUser && allowUpdates);
+
         const phoneNumber = trimToUndefined(validatedData.phoneNumber);
-        const dateOfBirth = parseOptionalDate(validatedData.dateOfBirth, "dateOfBirth") ?? null;
+        const dateOfBirthValue = parseOptionalDate(validatedData.dateOfBirth, "dateOfBirth");
+        const dateOfBirth = dateOfBirthValue ?? null;
         const gender = trimToUndefined(validatedData.gender);
         const street = trimToUndefined(validatedData.street) ?? trimToUndefined(validatedData.address);
         const city = trimToUndefined(validatedData.city);
@@ -313,8 +326,9 @@ export async function POST(request: NextRequest) {
         );
         const bankAccountNumber = trimToUndefined(validatedData.bankAccountNumber);
         const irdNumber = trimToUndefined(validatedData.irdNumber);
+        const taxCodeInput = trimToUndefined(validatedData.taxCode);
         const taxCode = normaliseTaxCode(validatedData.taxCode);
-        if (trimToUndefined(validatedData.taxCode) && !taxCode) {
+        if (taxCodeInput && !taxCode) {
           throw new Error(
             `Invalid taxCode "${validatedData.taxCode}". Please use a valid New Zealand tax code (e.g. M, M SL, S, etc.).`
           );
@@ -517,64 +531,147 @@ export async function POST(request: NextRequest) {
           }
         }
 
-        // Create user first
-        const user = await prisma.user.create({
-          data: {
-            id: crypto.randomUUID(),
-            email,
-            password: "temp-password", // Will need to be reset
+        let user;
+        let employee;
+        let employeeAction: "CREATED" | "UPDATED" = "CREATED";
+
+        if (canUpdateExistingUser && existingUser) {
+          const userUpdateData: Record<string, unknown> = {
             firstName,
             lastName,
-            phone: phoneNumber,
-            dateOfBirth,
-            addressStreet: street,
-            addressCity: city,
-            addressPostcode: postcode,
-            addressCountry: country,
-            emergencyContactName,
-            emergencyContactPhone,
-            emergencyContactRelationship,
-            nationalId,
-            pronouns,
-            residencyStatus,
-            genderOptionId,
-            companyId: session.user.companyId,
-            isActivated: false, // Will need to activate
             updatedAt: new Date(),
-          },
-        });
+          };
 
-        if (managerUser) {
-          await prisma.user.update({
-            where: { id: user.id },
-            data: { managerId: managerUser.id },
+          if (phoneNumber !== undefined) userUpdateData.phone = phoneNumber;
+          if (dateOfBirthValue !== undefined) userUpdateData.dateOfBirth = dateOfBirth;
+          if (street !== undefined) userUpdateData.addressStreet = street;
+          if (city !== undefined) userUpdateData.addressCity = city;
+          if (postcode !== undefined) userUpdateData.addressPostcode = postcode;
+          if (country !== undefined) userUpdateData.addressCountry = country;
+          if (emergencyContactName !== undefined) userUpdateData.emergencyContactName = emergencyContactName;
+          if (emergencyContactPhone !== undefined) userUpdateData.emergencyContactPhone = emergencyContactPhone;
+          if (emergencyContactRelationship !== undefined) {
+            userUpdateData.emergencyContactRelationship = emergencyContactRelationship;
+          }
+          if (nationalId !== undefined) userUpdateData.nationalId = nationalId;
+          if (pronouns !== undefined) userUpdateData.pronouns = pronouns;
+          if (residencyStatus !== undefined) userUpdateData.residencyStatus = residencyStatus;
+          if (genderOptionId !== undefined) userUpdateData.genderOptionId = genderOptionId;
+          if (managerUser) {
+            userUpdateData.managerId = managerUser.id;
+          }
+
+          user = await prisma.user.update({
+            where: { id: existingUser.id },
+            data: userUpdateData,
+          });
+
+          const employeeUpdateData: Record<string, unknown> = {};
+          if (bankAccountNumber !== undefined) employeeUpdateData.bankAccountNumber = bankAccountNumber;
+          if (contractType !== undefined) employeeUpdateData.contractType = contractType;
+          if (employmentType !== undefined) employeeUpdateData.employmentType = employmentType;
+          if (salaryAmount !== undefined) employeeUpdateData.salaryAmount = salaryAmount;
+          if (hourlyRate !== undefined) employeeUpdateData.hourlyRate = hourlyRate;
+          if (startDate !== undefined) employeeUpdateData.startDate = startDate ?? null;
+          if (contractEndDate !== undefined) employeeUpdateData.contractEndDate = contractEndDate ?? null;
+          if (siteLocation !== undefined) employeeUpdateData.siteLocation = siteLocation;
+          if (irdNumber !== undefined) employeeUpdateData.irdNumber = irdNumber;
+          if (taxCodeInput !== undefined) employeeUpdateData.taxCode = taxCode ?? null;
+          if (kiwiSaverEnrolled !== undefined) employeeUpdateData.kiwiSaverEnrolled = kiwiSaverEnrolled;
+          if (kiwiSaverContribution !== undefined) {
+            employeeUpdateData.kiwiSaverContribution = kiwiSaverContribution;
+          }
+          if (department) employeeUpdateData.departmentId = department.id;
+          if (jobRole) employeeUpdateData.jobRoleId = jobRole.id;
+          if (workingPattern) employeeUpdateData.workingPatternId = workingPattern.id;
+
+          const employeeWasExisting = Boolean(existingUser.Employee);
+          const upsertedEmployee = await prisma.employee.upsert({
+            where: { userId: existingUser.id },
+            update: employeeUpdateData,
+            create: {
+              id: crypto.randomUUID(),
+              userId: existingUser.id,
+              bankAccountNumber,
+              contractType,
+              employmentType,
+              salaryAmount,
+              hourlyRate,
+              startDate: startDate ?? null,
+              contractEndDate: contractEndDate ?? null,
+              siteLocation,
+              irdNumber,
+              taxCode: taxCode ?? null,
+              kiwiSaverEnrolled,
+              kiwiSaverContribution,
+              departmentId: department?.id,
+              jobRoleId: jobRole?.id,
+              workingPatternId: workingPattern?.id,
+              companyId: session.user.companyId,
+              isActive: true,
+            },
+          });
+
+          employee = upsertedEmployee;
+          employeeAction = employeeWasExisting ? "UPDATED" : "CREATED";
+        } else {
+          user = await prisma.user.create({
+            data: {
+              id: crypto.randomUUID(),
+              email,
+              password: "temp-password", // Will need to be reset
+              firstName,
+              lastName,
+              phone: phoneNumber,
+              dateOfBirth,
+              addressStreet: street,
+              addressCity: city,
+              addressPostcode: postcode,
+              addressCountry: country,
+              emergencyContactName,
+              emergencyContactPhone,
+              emergencyContactRelationship,
+              nationalId,
+              pronouns,
+              residencyStatus,
+              genderOptionId,
+              companyId: session.user.companyId,
+              isActivated: false, // Will need to activate
+              updatedAt: new Date(),
+            },
+          });
+
+          if (managerUser) {
+            await prisma.user.update({
+              where: { id: user.id },
+              data: { managerId: managerUser.id },
+            });
+          }
+
+          employee = await prisma.employee.create({
+            data: {
+              id: crypto.randomUUID(),
+              userId: user.id,
+              bankAccountNumber,
+              contractType,
+              employmentType,
+              salaryAmount,
+              hourlyRate,
+              startDate: startDate ?? null,
+              contractEndDate: contractEndDate ?? null,
+              siteLocation,
+              irdNumber,
+              taxCode: taxCode ?? null,
+              kiwiSaverEnrolled,
+              kiwiSaverContribution,
+              departmentId: department?.id,
+              jobRoleId: jobRole?.id,
+              workingPatternId: workingPattern?.id,
+              companyId: session.user.companyId,
+              isActive: true,
+            },
           });
         }
-
-        // Create employee
-        const employee = await prisma.employee.create({
-          data: {
-            id: crypto.randomUUID(),
-            userId: user.id,
-            bankAccountNumber,
-            contractType,
-            employmentType,
-            salaryAmount,
-            hourlyRate,
-            startDate: startDate ?? null,
-            contractEndDate: contractEndDate ?? null,
-            siteLocation,
-            irdNumber,
-            taxCode: taxCode ?? null,
-            kiwiSaverEnrolled,
-            kiwiSaverContribution,
-            departmentId: department?.id,
-            jobRoleId: jobRole?.id,
-            workingPatternId: workingPattern?.id,
-            companyId: session.user.companyId,
-            isActive: true,
-          },
-        });
 
         if (holidayTotalBalance !== undefined || holidayCarryover !== undefined || holidayCurrentBalance !== undefined) {
           let annualCategory = await prisma.eventCategory.findFirst({
@@ -638,31 +735,70 @@ export async function POST(request: NextRequest) {
           });
         }
 
-        if (emergencyContactName) {
-          await prisma.emergencyContact.create({
-            data: {
-              id: crypto.randomUUID(),
-              employeeId: employee.id,
-              name: emergencyContactName,
-              relationship: emergencyContactRelationship ?? null,
-              phone: emergencyContactPhone ?? null,
-              email: emergencyContactEmail ?? null,
-            },
+        if (
+          emergencyContactName !== undefined ||
+          emergencyContactRelationship !== undefined ||
+          emergencyContactPhone !== undefined ||
+          emergencyContactEmail !== undefined
+        ) {
+          const existingContact = await prisma.emergencyContact.findFirst({
+            where: { employeeId: employee.id },
           });
+
+          if (existingContact) {
+            await prisma.emergencyContact.update({
+              where: { id: existingContact.id },
+              data: {
+                name: emergencyContactName ?? existingContact.name,
+                relationship: emergencyContactRelationship ?? existingContact.relationship,
+                phone: emergencyContactPhone ?? existingContact.phone,
+                email: emergencyContactEmail ?? existingContact.email,
+              },
+            });
+          } else if (emergencyContactName) {
+            await prisma.emergencyContact.create({
+              data: {
+                id: crypto.randomUUID(),
+                employeeId: employee.id,
+                name: emergencyContactName,
+                relationship: emergencyContactRelationship ?? null,
+                phone: emergencyContactPhone ?? null,
+                email: emergencyContactEmail ?? null,
+              },
+            });
+          }
         }
 
         if (driverLicenceType) {
-          await prisma.driverLicence.create({
-            data: {
-              id: crypto.randomUUID(),
-              employeeId: employee.id,
-              type: driverLicenceType,
-              licenceNumber: driverLicenceNumber!,
-              issueDate: driverLicenceIssueDate!,
-              expiryDate: driverLicenceExpiryDate!,
-              updatedAt: new Date(),
-            },
+          const existingLicence = await prisma.driverLicence.findFirst({
+            where: { employeeId: employee.id },
+            orderBy: { updatedAt: "desc" },
           });
+
+          if (existingLicence) {
+            await prisma.driverLicence.update({
+              where: { id: existingLicence.id },
+              data: {
+                type: driverLicenceType,
+                licenceNumber: driverLicenceNumber!,
+                issueDate: driverLicenceIssueDate!,
+                expiryDate: driverLicenceExpiryDate!,
+                updatedAt: new Date(),
+              },
+            });
+          } else {
+            await prisma.driverLicence.create({
+              data: {
+                id: crypto.randomUUID(),
+                employeeId: employee.id,
+                type: driverLicenceType,
+                licenceNumber: driverLicenceNumber!,
+                issueDate: driverLicenceIssueDate!,
+                expiryDate: driverLicenceExpiryDate!,
+                updatedAt: new Date(),
+              },
+            });
+          }
         }
 
         if (trainingCourse) {
@@ -706,49 +842,90 @@ export async function POST(request: NextRequest) {
             });
           }
 
-          await prisma.trainingRecord.create({
-            data: {
-              id: crypto.randomUUID(),
+          const existingTraining = await prisma.trainingRecord.findFirst({
+            where: {
               employeeId: employee.id,
               courseId: course.id,
               providerId: provider.id,
-              dateCompleted: trainingDateCompleted!,
-              expiryDate: trainingExpiryDate ?? null,
-              updatedAt: new Date(),
             },
           });
+
+          if (existingTraining) {
+            await prisma.trainingRecord.update({
+              where: { id: existingTraining.id },
+              data: {
+                dateCompleted: trainingDateCompleted!,
+                expiryDate: trainingExpiryDate ?? null,
+                updatedAt: new Date(),
+              },
+            });
+          } else {
+            await prisma.trainingRecord.create({
+              data: {
+                id: crypto.randomUUID(),
+                employeeId: employee.id,
+                courseId: course.id,
+                providerId: provider.id,
+                dateCompleted: trainingDateCompleted!,
+                expiryDate: trainingExpiryDate ?? null,
+                updatedAt: new Date(),
+              },
+            });
+          }
         }
 
         if (employmentCheckType) {
-          await prisma.employmentCheck.create({
-            data: {
-              id: crypto.randomUUID(),
+          const existingCheck = await prisma.employmentCheck.findFirst({
+            where: {
               employeeId: employee.id,
               typeOfCheck: employmentCheckType,
-              documentNumber: employmentCheckDocumentNumber!,
-              dateOfIssue: employmentCheckIssueDate!,
-              expiryDate: employmentCheckExpiryDate!,
-              updatedAt: new Date(),
             },
           });
+
+          if (existingCheck) {
+            await prisma.employmentCheck.update({
+              where: { id: existingCheck.id },
+              data: {
+                documentNumber: employmentCheckDocumentNumber!,
+                dateOfIssue: employmentCheckIssueDate!,
+                expiryDate: employmentCheckExpiryDate!,
+                updatedAt: new Date(),
+              },
+            });
+          } else {
+            await prisma.employmentCheck.create({
+              data: {
+                id: crypto.randomUUID(),
+                employeeId: employee.id,
+                typeOfCheck: employmentCheckType,
+                documentNumber: employmentCheckDocumentNumber!,
+                dateOfIssue: employmentCheckIssueDate!,
+                expiryDate: employmentCheckExpiryDate!,
+                updatedAt: new Date(),
+              },
+            });
+          }
         }
 
         // Create audit log entry
         await auditLog({
           entityType: "EMPLOYEE",
           entityId: employee.id,
-          action: "CREATED",
+          action: employeeAction,
           actorId: session.user.id,
           actorType: "USER",
           companyId: session.user.companyId,
           employeeId: employee.id,
           section: "CSV_IMPORT",
-          field: "__create__",
+          field: employeeAction === "UPDATED" ? "__update__" : "__create__",
           oldValue: undefined,
-          newValue: "Employee created via CSV import",
+          newValue:
+            employeeAction === "UPDATED"
+              ? "Employee updated via CSV import"
+              : "Employee created via CSV import",
           reason: "CSV Import",
           metadata: {
-            importBatch: `csv_import_${Date.now()}`,
+            importBatch: `${importBatchId}_row_${rowNumber}`,
             rowNumber,
             importedFields: Object.keys(validatedData),
             holiday: {
@@ -762,15 +939,25 @@ export async function POST(request: NextRequest) {
               trainingRecordCreated: Boolean(trainingCourse),
               employmentCheckCreated: Boolean(employmentCheckType),
             },
+            updateMode: canUpdateExistingUser,
           },
         });
 
         results.successful++;
-        results.created.push({
-          id: employee.id,
-          email: user.email,
-          name: `${user.firstName} ${user.lastName}`,
-        });
+        const displayName = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email;
+        if (employeeAction === "UPDATED") {
+          results.updated.push({
+            id: employee.id,
+            email: user.email,
+            name: displayName,
+          });
+        } else {
+          results.created.push({
+            id: employee.id,
+            email: user.email,
+            name: displayName,
+          });
+        }
 
       } catch (error) {
         results.failed++;
@@ -800,10 +987,12 @@ export async function POST(request: NextRequest) {
         successful: results.successful,
         failed: results.failed,
         fileName: file.name,
+        updated: results.updated.length,
       },
       metadata: {
         importType: "EMPLOYEES",
         errors: results.errors,
+        allowUpdates,
       },
     });
 


### PR DESCRIPTION
## Summary
- add an "allow updates" toggle to the CSV import UI and surface created/updated counts in the progress and results summaries
- normalise CSV import responses on the client so updated rows display consistently
- enable the employee CSV import API to update existing records, capture updated rows, and enrich audit metadata

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e17107bab88331b3824973b4921e9f