### PR TITLE
Add line manager support to employee CSV import

### DIFF
--- a/app/(withSidebar)/settings/system/csv-import/page.tsx
+++ b/app/(withSidebar)/settings/system/csv-import/page.tsx
@@ -266,6 +266,10 @@ const getImportTypeInfo = (type: ImportType): ImportTypeInfo => {
               { label: "contractEndDate" },
               { label: "workingPatternName", note: "Must match an imported working pattern" },
               { label: "managerEmail" },
+              {
+                label: "lineManagerName",
+                note: "Full name of the line manager (used if managerEmail is not provided)",
+              },
               { label: "salaryAmount" },
               { label: "hourlyRate" },
             ],

--- a/app/api/csv-import/download-all/route.ts
+++ b/app/api/csv-import/download-all/route.ts
@@ -206,6 +206,7 @@ export async function GET() {
       "contractEndDate",
       "workingPatternName",
       "managerEmail",
+      "lineManagerName",
       "salaryAmount",
       "hourlyRate",
       "bankAccountNumber",
@@ -259,6 +260,7 @@ export async function GET() {
         "",
         workingPatterns[0]?.name || "Standard 40hr",
         "engineering.lead@company.com",
+        "Amelia Clark",
         "85000",
         "",
         "12-1234-1234567-00",
@@ -310,6 +312,7 @@ export async function GET() {
         "2025-08-31",
         workingPatterns[1]?.name || "Hybrid 32hr",
         "marketing.director@company.com",
+        "Liam Johnson",
         "92000",
         "",
         "98-7654-0987654-00",
@@ -373,7 +376,7 @@ Please import the files in this exact order:
 
 ### Employees
 - **Required**: firstName, lastName, email (keep these as the first columns)
-- **Recommended**: departmentName, jobRoleName, workingPatternName, employmentType, contractType, startDate, managerEmail
+- **Recommended**: departmentName, jobRoleName, workingPatternName, employmentType, contractType, startDate, managerEmail or lineManagerName
 - **Optional**: Holiday balances, payroll & bank data, KiwiSaver settings, emergency contacts, driver licence, training, employment checks
 - **Formatting**:
   - Dates must use YYYY-MM-DD

--- a/app/api/csv-import/employees/route.ts
+++ b/app/api/csv-import/employees/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 import { parse } from "csv-parse/sync";
 import { auditLog } from "@/lib/audit";
-import { TaxCode } from "@prisma/client";
+import { Prisma, TaxCode } from "@prisma/client";
 
 const employeeImportSchema = z.object({
   // Personal information
@@ -42,6 +42,8 @@ const employeeImportSchema = z.object({
   contractEndDate: z.string().optional(),
   workingPatternName: z.string().optional(),
   managerEmail: z.string().optional(),
+  lineManagerName: z.string().optional(),
+  lineManager: z.string().optional(),
   salaryAmount: z.string().optional(),
   salary: z.string().optional(),
   hourlyRate: z.string().optional(),
@@ -330,6 +332,8 @@ export async function POST(request: NextRequest) {
         const contractEndDate = parseOptionalDate(validatedData.contractEndDate, "contractEndDate");
         const workingPatternName = trimToUndefined(validatedData.workingPatternName);
         const managerEmail = trimToUndefined(validatedData.managerEmail);
+        const lineManagerName =
+          trimToUndefined(validatedData.lineManagerName) ?? trimToUndefined(validatedData.lineManager);
         if (managerEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(managerEmail)) {
           throw new Error(`Invalid managerEmail "${managerEmail}". Provide a valid email address.`);
         }
@@ -479,6 +483,8 @@ export async function POST(request: NextRequest) {
 
         // Find manager if provided
         let managerUser = null;
+        const managerErrors: string[] = [];
+
         if (managerEmail) {
           managerUser = await prisma.user.findFirst({
             where: {
@@ -488,13 +494,62 @@ export async function POST(request: NextRequest) {
           });
 
           if (!managerUser) {
-            results.failed++;
-            results.errors.push({
-              row: rowNumber,
-              errors: [`Manager with email "${managerEmail}" not found. Import managers before their team members.`],
-            });
-            continue;
+            managerErrors.push(
+              `Manager with email "${managerEmail}" not found. Import managers before their team members.`
+            );
           }
+        }
+
+        if (!managerUser && lineManagerName) {
+          const managerNameParts = lineManagerName.split(/\s+/).filter(Boolean);
+          const nameSearchConditions: Prisma.UserWhereInput[] = [];
+
+          if (managerNameParts.length >= 2) {
+            const firstName = managerNameParts[0];
+            const lastName = managerNameParts.slice(1).join(" ");
+            nameSearchConditions.push({
+              AND: [
+                { firstName: { equals: firstName, mode: "insensitive" } },
+                { lastName: { equals: lastName, mode: "insensitive" } },
+              ],
+            });
+          }
+
+          nameSearchConditions.push({
+            name: { equals: lineManagerName, mode: "insensitive" },
+          });
+
+          if (managerNameParts.length === 1) {
+            const [singleName] = managerNameParts;
+            nameSearchConditions.push({
+              firstName: { equals: singleName, mode: "insensitive" },
+            });
+            nameSearchConditions.push({
+              lastName: { equals: singleName, mode: "insensitive" },
+            });
+          }
+
+          managerUser = await prisma.user.findFirst({
+            where: {
+              companyId: session.user.companyId,
+              OR: nameSearchConditions,
+            },
+          });
+
+          if (!managerUser) {
+            managerErrors.push(
+              `Line manager "${lineManagerName}" not found. Import managers before their team members.`
+            );
+          }
+        }
+
+        if (!managerUser && managerErrors.length > 0) {
+          results.failed++;
+          results.errors.push({
+            row: rowNumber,
+            errors: managerErrors,
+          });
+          continue;
         }
 
         // Find working pattern (must exist if provided)
@@ -1070,6 +1125,7 @@ export async function GET() {
       "contractEndDate",
       "workingPatternName",
       "managerEmail",
+      "lineManagerName",
       "salaryAmount",
       "hourlyRate",
       "bankAccountNumber",
@@ -1123,6 +1179,7 @@ export async function GET() {
         "",
         workingPatterns[0]?.name || "Standard 40hr",
         "engineering.lead@company.com",
+        "Amelia Clark",
         "85000",
         "",
         "12-1234-1234567-00",
@@ -1174,6 +1231,7 @@ export async function GET() {
         "2025-08-31",
         workingPatterns[1]?.name || "Hybrid 32hr",
         "marketing.director@company.com",
+        "Liam Johnson",
         "92000",
         "",
         "98-7654-0987654-00",

--- a/app/lib/ai/csv-assistant.ts
+++ b/app/lib/ai/csv-assistant.ts
@@ -33,7 +33,7 @@ USER QUERY: ${userQuery}
 Available CSV fields and their descriptions:
 - firstName, lastName, email (REQUIRED)
 - Personal info: phoneNumber, dateOfBirth, gender, street, city, postcode, country, nationalId, pronouns, residencyStatus
-- Employment: departmentName, jobRoleName, jobTitle, employmentType, contractType, siteLocation, startDate, contractEndDate, workingPatternName, managerEmail
+- Employment: departmentName, jobRoleName, jobTitle, employmentType, contractType, siteLocation, startDate, contractEndDate, workingPatternName, managerEmail, lineManagerName
 - Compensation: salaryAmount, hourlyRate
 - Payroll: bankAccountNumber, irdNumber, taxCode, kiwiSaverEnrolled, kiwiSaverContribution
 - Emergency contacts: emergencyContactName, emergencyContactRelationship, emergencyContactPhone, emergencyContactEmail
@@ -50,7 +50,7 @@ IMPORTANT RULES:
 5. Tax codes: M, ME, M SL, ME SL, SB, SB SL, S, S SL, SH, SH SL, ST, ST SL, SA, SA SL, SL, SED, STC, CAE, EDW, ND, NS, NC, NCC, WT, P
 6. Boolean values: Yes/No, True/False, 1/0
 7. Departments and job roles must exist in the system before importing employees
-8. Manager emails must belong to existing employees
+8. Manager details must match an existing employee (by email or lineManagerName)
 9. Working patterns must exist in the system
 
 Provide helpful, conversational guidance. If the user is asking about:
@@ -132,6 +132,7 @@ export async function generateCSVTemplate(
       contractEndDate: "",
       workingPatternName: "Standard 40hr",
       managerEmail: "engineering.lead@company.com",
+      lineManagerName: "Amelia Clark",
       salaryAmount: "85000",
       hourlyRate: "",
       bankAccountNumber: "12-1234-1234567-00",
@@ -174,7 +175,7 @@ export async function generateCSVTemplate(
 
     return {
       success: true,
-      message: `Here's a CSV template with the fields you requested:\n\n\`\`\`csv\n${template}\n\`\`\`\n\n**Important Notes:**\n- Only firstName, lastName, and email are required\n- Dates must be in YYYY-MM-DD format\n- Department and job role names must exist in your system\n- Manager emails must belong to existing employees\n- Boolean values: Yes/No, True/False, or 1/0`,
+      message: `Here's a CSV template with the fields you requested:\n\n\`\`\`csv\n${template}\n\`\`\`\n\n**Important Notes:**\n- Only firstName, lastName, and email are required\n- Dates must be in YYYY-MM-DD format\n- Department and job role names must exist in your system\n- Provide managerEmail or lineManagerName to link reporting lines\n- Boolean values: Yes/No, True/False, or 1/0`,
       template,
     };
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- allow employee CSV imports to match managers by name via a new optional lineManagerName field
- update generated templates, download bundles, and AI CSV assistant guidance to expose the line manager column
- surface the lineManagerName column in the CSV Import UI with context on how it is used

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e20c7340f88331a28a5c61725662a5