### PR TITLE
Handle ambiguous manager name matches during CSV import

### DIFF
--- a/app/api/csv-import/employees/route.ts
+++ b/app/api/csv-import/employees/route.ts
@@ -529,14 +529,21 @@ export async function POST(request: NextRequest) {
             nameSearchConditions.push({ lastName: { equals: singleName, mode: "insensitive" } });
           }
 
-          managerUser = await prisma.user.findFirst({
+          const matchingManagers = await prisma.user.findMany({
             where: {
               companyId: session.user.companyId,
               OR: nameSearchConditions,
             },
+            take: 2,
           });
 
-          if (!managerUser) {
+          if (matchingManagers.length === 1) {
+            managerUser = matchingManagers[0];
+          } else if (matchingManagers.length > 1) {
+            lineManagerErrors.push(
+              `Multiple managers match the name "${lineManagerName}". Provide managerEmail to import this employee.`
+            );
+          } else {
             lineManagerErrors.push(
               `Line manager "${lineManagerName}" not found. Import managers before their team members.`
             );


### PR DESCRIPTION
## Summary
- detect when multiple users satisfy a line manager name query during employee CSV imports
- require managerEmail for disambiguation to avoid linking employees to the wrong manager

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21d04c72c8331b8b448d3e2686c98