### PR TITLE
Fix org chart manager metrics and CSV import manager promotion

### DIFF
--- a/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
+++ b/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
@@ -278,6 +278,9 @@ function OrgChartPageClient() {
 
   const normalizedEmployees = useMemo<OrgEmployee[]>(() => {
     return rawEmployees.map((emp) => {
+      const phoneValue =
+        typeof emp.phone === "string" ? emp.phone.trim() : "";
+      const normalizedPhone = phoneValue.length > 0 ? phoneValue : null;
       const fullName = `${emp.firstName ?? ""} ${emp.lastName ?? ""}`
         .replace(/\s+/g, " ")
         .trim();
@@ -296,7 +299,7 @@ function OrgChartPageClient() {
         userId: emp.userId,
         fullName: safeName,
         email: emp.email,
-        phone: emp.phone ?? null,
+        phone: normalizedPhone,
         jobTitle: emp.jobRoleName ?? null,
         jobRoleId: emp.jobRoleId ?? null,
         department: emp.departmentName ?? null,
@@ -518,10 +521,20 @@ function OrgChartPageClient() {
     () => countNodes(filteredForest),
     [filteredForest],
   );
-  const managerCount = useMemo(
-    () => normalizedEmployees.filter((emp) => emp.role === "MANAGER").length,
-    [normalizedEmployees],
-  );
+  const managerCount = useMemo(() => {
+    const seenManagers = new Set<string>();
+
+    const stack = [...orgForest];
+    while (stack.length) {
+      const node = stack.pop()!;
+      if (node.children.length > 0) {
+        seenManagers.add(node.userId);
+      }
+      node.children.forEach((child) => stack.push(child));
+    }
+
+    return seenManagers.size;
+  }, [orgForest]);
   const departmentCount = departmentOptions.length;
 
   const isFiltered = useMemo(() => {

--- a/app/api/csv-import/employees/route.ts
+++ b/app/api/csv-import/employees/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 import { parse } from "csv-parse/sync";
 import { auditLog } from "@/lib/audit";
-import { Prisma, TaxCode } from "@prisma/client";
+import { Prisma, TaxCode, Role } from "@prisma/client";
 
 const employeeImportSchema = z.object({
   // Personal information
@@ -202,6 +202,53 @@ const normaliseTaxCode = (value: string | undefined): TaxCode | undefined => {
   const withSpaces = upper.replace(/[_-]+/g, " ");
   const condensed = withSpaces.replace(/\s+/g, "");
   return TAX_CODE_LOOKUP[withSpaces] || TAX_CODE_LOOKUP[condensed];
+};
+
+const promoteManagerIfNeeded = async (
+  managerUserId: string,
+  companyId: string,
+) => {
+  try {
+    const managerUser = await prisma.user.findFirst({
+      where: { id: managerUserId, companyId },
+      select: { id: true, role: true },
+    });
+
+    if (!managerUser) {
+      return;
+    }
+
+    if (
+      managerUser.role === Role.ADMIN ||
+      managerUser.role === Role.MANAGER ||
+      managerUser.role === Role.SUPER_ADMIN
+    ) {
+      return;
+    }
+
+    if (managerUser.role === Role.EMPLOYEE) {
+      const managerProfile = await prisma.permissionProfile.findFirst({
+        where: {
+          companyId,
+          name: { equals: "Manager", mode: "insensitive" },
+        },
+        select: { id: true },
+      });
+
+      await prisma.user.update({
+        where: { id: managerUserId },
+        data: {
+          role: Role.MANAGER,
+          ...(managerProfile ? { permissionProfileId: managerProfile.id } : {}),
+        },
+      });
+    }
+  } catch (error) {
+    console.warn(
+      `Failed to auto-promote manager role for ${managerUserId}:`,
+      error,
+    );
+  }
 };
 
 const parseBooleanFlag = (value: unknown): boolean | undefined => {
@@ -647,6 +694,10 @@ export async function POST(request: NextRequest) {
             data: userUpdateData,
           });
 
+          if (managerUser) {
+            await promoteManagerIfNeeded(managerUser.id, session.user.companyId);
+          }
+
           const employeeUpdateData: Record<string, unknown> = {};
           if (bankAccountNumber !== undefined) employeeUpdateData.bankAccountNumber = bankAccountNumber;
           if (contractType !== undefined) employeeUpdateData.contractType = contractType;
@@ -727,6 +778,8 @@ export async function POST(request: NextRequest) {
               where: { id: user.id },
               data: { managerId: managerUser.id },
             });
+
+            await promoteManagerIfNeeded(managerUser.id, session.user.companyId);
           }
 
           employee = await prisma.employee.create({


### PR DESCRIPTION
## Summary
- normalize org chart phone values and count managers based on actual reporting structure so imported data appears in the hierarchy
- auto-promote managers during CSV imports when they gain reports and align permission profiles with manual employee creation

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e227625cd483319c302c1f220a92c5