### PR TITLE
Add curated survey templates and enhance surveys UI

### DIFF
--- a/app/(withSidebar)/settings/surveys/page.tsx
+++ b/app/(withSidebar)/settings/surveys/page.tsx
@@ -2,22 +2,24 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PageShell } from "@/components/ui/PageShell";
 import { breadcrumbConfigs } from "@/components/ui/Breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { Input } from "@/components/ui/Input";
-import { Plus, FileText, Settings, Trash2, MoreVertical, Eye, Filter, Info } from "lucide-react";
+import { Plus, FileText, Settings, Trash2, MoreVertical, Sparkles, Star, Send } from "lucide-react";
 import { toast } from "sonner";
 import { DropdownMenu, DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { DEFAULT_SURVEY_TEMPLATES, ensureDefaultSurveyTemplates } from "@/lib/survey-templates";
 
 interface Survey {
   id: string;
   name: string;
   description?: string;
-  isActive: boolean;
+  slug?: string;
+  isActive?: boolean;
   createdAt: string;
 }
 
@@ -26,25 +28,39 @@ export default function SurveysPage() {
   const [surveys, setSurveys] = useState<Survey[]>([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
+  const [ensuringTemplates, setEnsuringTemplates] = useState(false);
 
   useEffect(() => {
     const loadSurveys = async () => {
+      setLoading(true);
       try {
-        // Fetch only SURVEY type forms
-        const res = await fetch("/api/forms?type=SURVEY");
-        if (res.ok) {
-          const data = await res.json();
-          setSurveys(Array.isArray(data) ? data : []);
-        }
+        setEnsuringTemplates(true);
+        const data = await ensureDefaultSurveyTemplates();
+        setSurveys(Array.isArray(data) ? data : []);
       } catch (error) {
+        console.error("Failed to load surveys", error);
         toast.error("Failed to load surveys");
       } finally {
+        setEnsuringTemplates(false);
         setLoading(false);
       }
     };
 
     loadSurveys();
   }, []);
+
+  const templatesWithInstances = useMemo(() => {
+    const bySlug = new Map((surveys || []).map((survey) => [survey.slug, survey]));
+    return DEFAULT_SURVEY_TEMPLATES.map((template) => ({
+      definition: template,
+      instance: bySlug.get(template.slug),
+    }));
+  }, [surveys]);
+
+  const totalDrafts = useMemo(
+    () => surveys.filter((survey) => !survey.isActive).length,
+    [surveys],
+  );
 
   const filteredSurveys = surveys.filter(
     (s) =>
@@ -85,23 +101,143 @@ export default function SurveysPage() {
       }
     >
       <div className="space-y-6">
-        {/* Info Banner */}
-        <Card className="bg-blue-50 border-blue-200">
-          <CardContent className="flex items-start gap-3 p-4">
-            <Info className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" />
-            <div>
-              <p className="text-sm text-blue-900 font-medium">
-                About Surveys
-              </p>
-              <p className="text-xs text-blue-700 mt-1">
-                Surveys are one-time forms distributed through action items. They're perfect for gathering
-                feedback, conducting polls, or collecting data from specific groups of employees.
-              </p>
+        <Card className="relative overflow-hidden border-0 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_55%)]" />
+          <CardContent className="relative z-10 grid gap-6 p-6 lg:grid-cols-[1.2fr,1fr]">
+            <div className="space-y-4">
+              <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-wider text-white">
+                <Sparkles className="h-3 w-3" /> Premium survey workspace
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-white lg:text-2xl">
+                  Launch curated surveys in seconds
+                </h2>
+                <p className="mt-2 text-sm text-slate-200 lg:text-base">
+                  Save hours of setup with ready-to-use, HR-approved templates that are fully editable for your culture.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs text-slate-200">
+                {templatesWithInstances.map(({ definition }) => (
+                  <span
+                    key={definition.slug}
+                    className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1"
+                  >
+                    <span className="text-base">{definition.emoji}</span>
+                    {definition.name}
+                  </span>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild variant="secondary" className="bg-white text-slate-900 hover:bg-white/90">
+                  <Link href="/surveys/send">
+                    <Send className="mr-2 h-4 w-4" />
+                    Send a survey now
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" className="border-white/40 text-white hover:bg-white/10">
+                  <Link href="/settings/surveys/new">
+                    <Plus className="mr-2 h-4 w-4" />
+                    Build from scratch
+                  </Link>
+                </Button>
+              </div>
+            </div>
+            <div className="grid gap-4 text-sm">
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-wide text-slate-200">Current library</p>
+                <div className="mt-2 flex items-baseline gap-2 text-3xl font-semibold">
+                  {surveys.length}
+                  <span className="text-sm font-medium text-slate-300">templates</span>
+                </div>
+                <div className="mt-3 flex items-center justify-between text-xs text-slate-200/80">
+                  <span>Ready to send</span>
+                  <Badge variant="outline" className="border-white/20 bg-white/10 text-xs text-white">
+                    {surveys.length - totalDrafts} active • {totalDrafts} drafts
+                  </Badge>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-white/5 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-wide text-slate-200">Highlights</p>
+                <ul className="mt-2 space-y-2 text-slate-100">
+                  <li className="flex items-start gap-2">
+                    <Star className="mt-0.5 h-4 w-4 text-amber-300" />
+                    3 premium templates ready to personalise and send
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <Star className="mt-0.5 h-4 w-4 text-amber-300" />
+                    Emotion-driven pulse surveys with expressive responses
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <Star className="mt-0.5 h-4 w-4 text-amber-300" />
+                    Seamlessly integrate templates with automations
+                  </li>
+                </ul>
+              </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Search and Filters */}
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {templatesWithInstances.map(({ definition, instance }) => (
+            <Card key={definition.slug} className="relative overflow-hidden border border-slate-200/60 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+              <div
+                className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${definition.accentGradient}`}
+                aria-hidden
+              />
+              <CardHeader className="space-y-3 pb-3">
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">{definition.emoji}</span>
+                  <div>
+                    <CardTitle className="text-base">{definition.name}</CardTitle>
+                    <CardDescription className="text-xs">{definition.description}</CardDescription>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {definition.highlights.map((highlight) => (
+                    <Badge key={highlight} variant="outline" className="bg-slate-50 text-[11px]">
+                      {highlight}
+                    </Badge>
+                  ))}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex items-center justify-between text-xs text-slate-500">
+                  <span>Editable template</span>
+                  {instance ? (
+                    <span className="text-emerald-600">Live in library</span>
+                  ) : (
+                    <span className="text-amber-600">Generating…</span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button
+                    asChild
+                    variant="primary"
+                    className="flex-1"
+                    disabled={!instance || ensuringTemplates || loading}
+                  >
+                    <Link href={`/surveys/send?template=${definition.slug}`}>
+                      <Sparkles className="mr-2 h-4 w-4" />
+                      Use template
+                    </Link>
+                  </Button>
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="flex-1"
+                    disabled={!instance || ensuringTemplates || loading}
+                  >
+                    <Link href={instance ? `/settings/surveys/${instance.id}/edit` : "#"}>
+                      <Settings className="mr-2 h-4 w-4" />
+                      Refine
+                    </Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
         <div className="flex items-center gap-4">
           <div className="relative flex-1">
             <Input
@@ -117,22 +253,21 @@ export default function SurveysPage() {
           </Badge>
         </div>
 
-        {/* Surveys List */}
         {loading ? (
-          <div className="text-center py-12 text-gray-500">
+          <div className="py-12 text-center text-gray-500">
             Loading surveys...
           </div>
         ) : filteredSurveys.length === 0 ? (
           <Card>
             <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-              <FileText className="h-12 w-12 text-gray-300 mb-4" />
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <FileText className="mb-4 h-12 w-12 text-gray-300" />
+              <h3 className="mb-2 text-lg font-semibold text-gray-900">
                 {query ? "No surveys found" : "No surveys yet"}
               </h3>
-              <p className="text-sm text-gray-500 mb-6 max-w-md">
+              <p className="mb-6 max-w-md text-sm text-gray-500">
                 {query
                   ? "Try adjusting your search terms"
-                  : "Get started by creating your first survey to gather feedback from employees"}
+                  : "Get started by customising one of our premium templates or building your own from scratch."}
               </p>
               {!query && (
                 <Button asChild variant="primary">
@@ -147,13 +282,13 @@ export default function SurveysPage() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {filteredSurveys.map((survey) => (
-              <Card key={survey.id} className="group hover:shadow-lg transition-shadow">
+              <Card key={survey.id} className="group transition-shadow hover:-translate-y-1 hover:shadow-lg">
                 <CardHeader>
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <CardTitle className="text-base">{survey.name}</CardTitle>
                       {survey.description && (
-                        <CardDescription className="text-xs mt-1 line-clamp-2">
+                        <CardDescription className="mt-1 text-xs line-clamp-2">
                           {survey.description}
                         </CardDescription>
                       )}
@@ -167,14 +302,14 @@ export default function SurveysPage() {
                       align="right"
                     >
                       <DropdownMenuItem onClick={() => router.push(`/settings/surveys/${survey.id}/edit`)}>
-                        <Settings className="h-4 w-4 mr-2" />
+                        <Settings className="mr-2 h-4 w-4" />
                         Edit
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() => handleDelete(survey.id)}
                         className="text-red-600 hover:text-red-700 hover:bg-red-50"
                       >
-                        <Trash2 className="h-4 w-4 mr-2" />
+                        <Trash2 className="mr-2 h-4 w-4" />
                         Delete
                       </DropdownMenuItem>
                     </DropdownMenu>
@@ -189,14 +324,9 @@ export default function SurveysPage() {
                       {new Date(survey.createdAt).toLocaleDateString()}
                     </span>
                   </div>
-                  <Button
-                    asChild
-                    variant="outline"
-                    size="sm"
-                    className="w-full"
-                  >
+                  <Button asChild variant="outline" size="sm" className="w-full">
                     <Link href={`/settings/surveys/${survey.id}/edit`}>
-                      <Settings className="h-4 w-4 mr-2" />
+                      <Settings className="mr-2 h-4 w-4" />
                       Manage Survey
                     </Link>
                   </Button>

--- a/app/(withSidebar)/surveys/automation/new/page.tsx
+++ b/app/(withSidebar)/surveys/automation/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { PageShell } from "@/components/ui/PageShell";
@@ -14,6 +15,7 @@ import Button from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/Badge";
 import {
   Select,
   SelectContent,
@@ -24,6 +26,7 @@ import {
 import { Checkbox } from "@/components/ui/Checkbox";
 import {
   Repeat,
+  Send,
   Calendar,
   Users,
   Clock,
@@ -33,8 +36,10 @@ import {
   Zap,
   Brain,
   Settings,
+  Sparkles,
 } from "lucide-react";
 import { toast } from "sonner";
+import { ensureDefaultSurveyTemplates, findTemplateMetaBySlug } from "@/lib/survey-templates";
 
 interface SurveyTemplate {
   id: string;
@@ -42,6 +47,7 @@ interface SurveyTemplate {
   description?: string;
   formType: string;
   schema: any;
+  slug?: string;
 }
 
 interface Department {
@@ -80,18 +86,25 @@ export default function CreateAutomationPage() {
   const [jobRoles, setJobRoles] = useState<JobRole[]>([]);
 
   useEffect(() => {
+    if (!formId && templates.length) {
+      setFormId(templates[0].id);
+    }
+  }, [templates, formId]);
+
+  useEffect(() => {
     const loadData = async () => {
+      setLoading(true);
       try {
-        const [templatesRes, departmentsRes, jobRolesRes] = await Promise.all([
-          fetch("/api/forms?type=SURVEY"),
+        const ensuredTemplates = await ensureDefaultSurveyTemplates();
+        const normalizedTemplates = Array.isArray(ensuredTemplates)
+          ? ensuredTemplates
+          : ensuredTemplates?.forms || [];
+        setTemplates(normalizedTemplates);
+
+        const [departmentsRes, jobRolesRes] = await Promise.all([
           fetch("/api/departments"),
           fetch("/api/job-roles"),
         ]);
-
-        if (templatesRes.ok) {
-          const templatesData = await templatesRes.json();
-          setTemplates(templatesData.forms || []);
-        }
 
         if (departmentsRes.ok) {
           const departmentsData = await departmentsRes.json();
@@ -105,11 +118,29 @@ export default function CreateAutomationPage() {
       } catch (error) {
         console.error("Failed to load data:", error);
         toast.error("Failed to load automation data");
+      } finally {
+        setLoading(false);
       }
     };
 
     loadData();
   }, []);
+
+  const selectedTemplate = templates.find((template) => template.id === formId);
+  const selectedTemplateMeta = findTemplateMetaBySlug(selectedTemplate?.slug);
+
+  const handleTemplateChange = (value: string) => {
+    setFormId(value);
+    const template = templates.find((t) => t.id === value);
+    if (template) {
+      if (!name) {
+        setName(`${template.name} Automation`);
+      }
+      if (!description) {
+        setDescription(template.description || "");
+      }
+    }
+  };
 
   const getSelectedTemplate = () => {
     return templates.find(t => t.id === formId);
@@ -211,6 +242,60 @@ export default function CreateAutomationPage() {
       }}
     >
       <div className="max-w-4xl mx-auto space-y-6">
+        <Card className="relative overflow-hidden border-0 bg-gradient-to-br from-indigo-900 via-slate-900 to-slate-900 text-white">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_55%)]" />
+          <CardContent className="relative z-10 flex flex-col gap-5 p-6 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-wider text-white">
+                <Sparkles className="h-3 w-3" /> Automated survey journeys
+              </div>
+              <h2 className="text-xl font-semibold text-white md:text-2xl">
+                Put your survey library on autopilot
+              </h2>
+              <p className="text-sm text-slate-200">
+                Schedule eNPS, pulse, and annual engagement templates once and gather rich sentiment throughout the year.
+              </p>
+              <div className="flex flex-wrap gap-2 text-xs text-slate-200">
+                {templates.slice(0, 3).map((template) => {
+                  const meta = findTemplateMetaBySlug(template.slug);
+                  return (
+                    <span
+                      key={template.id}
+                      className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1"
+                    >
+                      <span className="text-base">{meta?.emoji ?? "🗂️"}</span>
+                      {template.name}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-4 text-sm backdrop-blur-md">
+              <p className="text-xs uppercase tracking-wide text-slate-200">Library ready</p>
+              <div className="mt-2 flex items-baseline gap-2 text-3xl font-semibold">
+                {templates.length}
+                <span className="text-sm text-slate-200">templates</span>
+              </div>
+              <p className="mt-3 text-xs text-slate-100">
+                Edit templates in settings before automation kicks in.
+              </p>
+              <div className="mt-4 flex flex-col gap-2">
+                <Button asChild variant="secondary" className="bg-white text-slate-900 hover:bg-white/90">
+                  <Link href="/surveys/send">
+                    <Send className="mr-2 h-4 w-4" />
+                    Send instantly
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" className="border-white/40 text-white hover:bg-white/10">
+                  <Link href="/settings/surveys">
+                    <Settings className="mr-2 h-4 w-4" />
+                    Manage templates
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Main Form */}
           <div className="lg:col-span-2 space-y-6">
@@ -249,26 +334,94 @@ export default function CreateAutomationPage() {
 
                 <div className="space-y-2">
                   <Label htmlFor="template">Survey Template *</Label>
-                  <Select value={formId} onValueChange={setFormId}>
+                  <Select
+                    value={formId}
+                    onValueChange={handleTemplateChange}
+                    disabled={loading || templates.length === 0}
+                  >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select a survey template" />
+                      <SelectValue
+                        placeholder={loading ? "Loading templates..." : "Select a survey template"}
+                      />
                     </SelectTrigger>
                     <SelectContent>
-                      {templates.map((template) => (
-                        <SelectItem key={template.id} value={template.id}>
-                          <div className="flex flex-col">
-                            <span className="font-medium">{template.name}</span>
-                            {template.description && (
-                              <span className="text-sm text-muted-foreground">
-                                {template.description}
+                      {templates.map((template) => {
+                        const meta = findTemplateMetaBySlug(template.slug);
+                        return (
+                          <SelectItem key={template.id} value={template.id} className="py-2">
+                            <div className="flex flex-col gap-1 text-left">
+                              <div className="flex items-center gap-2">
+                                <span className="text-lg">{meta?.emoji ?? "🗂️"}</span>
+                                <span className="font-medium">{template.name}</span>
+                              </div>
+                              <span className="text-xs text-muted-foreground">
+                                {meta?.description ?? template.description ?? "Custom automation"}
                               </span>
-                            )}
-                          </div>
-                        </SelectItem>
-                      ))}
+                            </div>
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Personalise any template in settings—the automation always pulls the latest version.
+                  </p>
                 </div>
+
+                {selectedTemplate && (
+                  <div className="rounded-lg border border-dashed border-primary/30 bg-primary/5 p-4">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                      <div
+                        className={`flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br ${
+                          selectedTemplateMeta?.accentGradient || "from-slate-200 via-slate-100 to-slate-200"
+                        }`}
+                      >
+                        <span className="text-xl">{selectedTemplateMeta?.emoji ?? "🗂️"}</span>
+                      </div>
+                      <div className="flex-1 space-y-2">
+                        <div>
+                          <h4 className="text-sm font-semibold text-primary">{selectedTemplate.name}</h4>
+                          <p className="text-sm text-muted-foreground">
+                            {selectedTemplateMeta?.description ||
+                              selectedTemplate.description ||
+                              "Automate recurring touchpoints with a polished employee experience."}
+                          </p>
+                        </div>
+                        {selectedTemplateMeta?.highlights?.length ? (
+                          <div className="flex flex-wrap gap-2">
+                            {selectedTemplateMeta.highlights.map((highlight) => (
+                              <Badge key={highlight} variant="outline" className="bg-white text-[11px] text-primary">
+                                {highlight}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : null}
+                        <div className="flex flex-wrap gap-2 pt-1">
+                          <Button asChild variant="outline" size="sm">
+                            <Link
+                              href={`/settings/surveys/${selectedTemplate.id}/edit`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Settings className="mr-2 h-4 w-4" />
+                              Edit template
+                            </Link>
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-primary hover:bg-primary/10"
+                            onClick={() => setFormId("")}
+                          >
+                            <Sparkles className="mr-2 h-4 w-4" />
+                            Swap template
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
               </CardContent>
             </Card>
 

--- a/app/(withSidebar)/surveys/page.tsx
+++ b/app/(withSidebar)/surveys/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { PageShell } from "@/components/ui/PageShell";
 import { breadcrumbConfigs } from "@/components/ui/Breadcrumb";
@@ -30,9 +30,15 @@ import {
   Zap,
   ArrowUpRight,
   ArrowDownRight,
+  Sparkles,
 } from "lucide-react";
 import { toast } from "sonner";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from "recharts";
+import {
+  DEFAULT_SURVEY_TEMPLATES,
+  ensureDefaultSurveyTemplates,
+  findTemplateMetaBySlug,
+} from "@/lib/survey-templates";
 
 interface SurveyStats {
   totalSurveys: number;
@@ -77,6 +83,8 @@ export default function SurveysDashboard() {
   });
   const [activeSurveys, setActiveSurveys] = useState<ActiveSurvey[]>([]);
   const [loading, setLoading] = useState(true);
+  const [templateLibrary, setTemplateLibrary] = useState<any[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
 
   useEffect(() => {
     const loadDashboardData = async () => {
@@ -105,6 +113,30 @@ export default function SurveysDashboard() {
 
     loadDashboardData();
   }, []);
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        setTemplatesLoading(true);
+        const forms = await ensureDefaultSurveyTemplates();
+        setTemplateLibrary(Array.isArray(forms) ? forms : []);
+      } catch (error) {
+        console.error("Failed to load survey templates:", error);
+      } finally {
+        setTemplatesLoading(false);
+      }
+    };
+
+    loadTemplates();
+  }, []);
+
+  const curatedTemplates = useMemo(() => {
+    const bySlug = new Map((templateLibrary || []).map((template: any) => [template.slug, template]));
+    return DEFAULT_SURVEY_TEMPLATES.map((definition) => ({
+      definition,
+      instance: bySlug.get(definition.slug),
+    }));
+  }, [templateLibrary]);
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -156,6 +188,67 @@ export default function SurveysDashboard() {
       }
     >
       <div className="space-y-6">
+        <Card className="relative overflow-hidden border border-primary/10 bg-gradient-to-br from-slate-900 via-indigo-900 to-blue-900 text-white">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_55%)]" />
+          <CardContent className="relative z-10 flex flex-col gap-5 p-6 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-3">
+              <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-wider">
+                <Sparkles className="h-3 w-3" /> Template library spotlight
+              </div>
+              <h2 className="text-xl font-semibold text-white md:text-2xl">
+                Kickstart surveys with curated experiences
+              </h2>
+              <p className="text-sm text-slate-200">
+                Choose from eNPS, pulse, and annual engagement templates—each crafted with premium employee experience in mind.
+              </p>
+              <div className="flex flex-wrap gap-2 text-xs text-slate-200">
+                {curatedTemplates.map(({ definition, instance }) => (
+                  <span
+                    key={definition.slug}
+                    className={`inline-flex items-center gap-2 rounded-full px-3 py-1 ${
+                      instance ? "bg-white/10" : "bg-white/5"
+                    }`}
+                  >
+                    <span className="text-base">{definition.emoji}</span>
+                    {definition.name}
+                    {!instance && (
+                      <Badge variant="secondary" className="ml-2 border-white/30 bg-white/20 text-[10px] text-white">
+                        Seeding…
+                      </Badge>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-4 text-sm backdrop-blur">
+              <p className="text-xs uppercase tracking-wide text-slate-200">Templates ready</p>
+              <div className="mt-2 flex items-baseline gap-2 text-3xl font-semibold">
+                {templateLibrary.length}
+                <span className="text-sm text-slate-200">available</span>
+              </div>
+              <p className="mt-3 text-xs text-slate-100">
+                {templatesLoading
+                  ? "Generating your starter library…"
+                  : "Edit any template before sending or scheduling."}
+              </p>
+              <div className="mt-4 flex flex-col gap-2">
+                <Button asChild variant="secondary" className="bg-white text-slate-900 hover:bg-white/90">
+                  <Link href="/surveys/send">
+                    <Send className="mr-2 h-4 w-4" />
+                    Send a survey
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" className="border-white/40 text-white hover:bg-white/10">
+                  <Link href="/settings/surveys">
+                    <Settings className="mr-2 h-4 w-4" />
+                    Refine templates
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
         {/* Overview Stats */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <Card className="relative overflow-hidden bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">

--- a/app/(withSidebar)/surveys/send/page.tsx
+++ b/app/(withSidebar)/surveys/send/page.tsx
@@ -48,6 +48,7 @@ import {
   Briefcase,
   User,
   Sparkles,
+  Settings,
 } from "lucide-react";
 import { toast } from "sonner";
 import { ensureDefaultSurveyTemplates, findTemplateMetaBySlug } from "@/lib/survey-templates";

--- a/app/(withSidebar)/surveys/send/page.tsx
+++ b/app/(withSidebar)/surveys/send/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { PageShell } from "@/components/ui/PageShell";
 import {
   Card,
@@ -14,6 +15,7 @@ import Button from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/Badge";
 import {
   Select,
   SelectContent,
@@ -45,8 +47,10 @@ import {
   Building,
   Briefcase,
   User,
+  Sparkles,
 } from "lucide-react";
 import { toast } from "sonner";
+import { ensureDefaultSurveyTemplates, findTemplateMetaBySlug } from "@/lib/survey-templates";
 
 interface SurveyTemplate {
   id: string;
@@ -54,6 +58,7 @@ interface SurveyTemplate {
   description?: string;
   formType: string;
   schema: any;
+  slug?: string;
 }
 
 interface Department {
@@ -86,8 +91,11 @@ interface Employee {
 
 export default function SendSurveyPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [step, setStep] = useState(1);
   const [loading, setLoading] = useState(false);
+  const [initializing, setInitializing] = useState(true);
+  const [templatePrefilled, setTemplatePrefilled] = useState(false);
   
   // Form data
   const [selectedTemplate, setSelectedTemplate] = useState<string>("");
@@ -114,22 +122,24 @@ export default function SendSurveyPage() {
   const [filteredExcludedEmployees, setFilteredExcludedEmployees] = useState<Employee[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [excludedSearchTerm, setExcludedSearchTerm] = useState("");
+  const templateFromQuery = searchParams?.get("template") || "";
 
   useEffect(() => {
     const loadData = async () => {
+      setInitializing(true);
       try {
-        const [templatesRes, departmentsRes, jobRolesRes, locationsRes, employeesRes] = await Promise.all([
-          fetch("/api/forms?type=SURVEY"),
+        const ensuredTemplates = await ensureDefaultSurveyTemplates();
+        const normalizedTemplates = Array.isArray(ensuredTemplates)
+          ? ensuredTemplates
+          : ensuredTemplates?.forms || [];
+        setTemplates(normalizedTemplates);
+
+        const [departmentsRes, jobRolesRes, locationsRes, employeesRes] = await Promise.all([
           fetch("/api/departments"),
           fetch("/api/job-roles"),
           fetch("/api/locations"),
           fetch("/api/employees"),
         ]);
-
-        if (templatesRes.ok) {
-          const templatesData = await templatesRes.json();
-          setTemplates(Array.isArray(templatesData) ? templatesData : []);
-        }
 
         if (departmentsRes.ok) {
           const departmentsData = await departmentsRes.json();
@@ -155,11 +165,33 @@ export default function SendSurveyPage() {
       } catch (error) {
         console.error("Failed to load data:", error);
         toast.error("Failed to load survey data");
+      } finally {
+        setInitializing(false);
       }
     };
 
     loadData();
   }, []);
+
+  useEffect(() => {
+    if (!templateFromQuery || !templates.length || templatePrefilled) return;
+    const match = templates.find((template) => template.slug === templateFromQuery);
+    if (match) {
+      setSelectedTemplate(match.id);
+      setSurveyName(match.name);
+      setSurveyDescription(match.description || "");
+      setTemplatePrefilled(true);
+    }
+  }, [templateFromQuery, templates, templatePrefilled]);
+
+  const handleTemplateChange = (value: string) => {
+    setSelectedTemplate(value);
+    const template = templates.find((t) => t.id === value);
+    if (template) {
+      setSurveyName(template.name);
+      setSurveyDescription(template.description || "");
+    }
+  };
 
   useEffect(() => {
     // Filter employees based on search term
@@ -294,6 +326,8 @@ export default function SendSurveyPage() {
   };
 
   const renderStepContent = () => {
+    const selectedTemplateData = getSelectedTemplate();
+    const selectedTemplateMeta = findTemplateMetaBySlug(selectedTemplateData?.slug);
     switch (step) {
       case 1:
         return (
@@ -307,26 +341,106 @@ export default function SendSurveyPage() {
             <CardContent className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="template">Survey Template *</Label>
-                <Select value={selectedTemplate} onValueChange={setSelectedTemplate}>
+                <Select
+                  value={selectedTemplate}
+                  onValueChange={handleTemplateChange}
+                  disabled={initializing || templates.length === 0}
+                >
                   <SelectTrigger>
-                    <SelectValue placeholder="Select a survey template" />
+                    <SelectValue
+                      placeholder={initializing ? "Loading templates..." : "Select a survey template"}
+                    />
                   </SelectTrigger>
                   <SelectContent>
-                    {templates.map((template) => (
-                      <SelectItem key={template.id} value={template.id}>
-                        <div className="flex flex-col">
-                          <span className="font-medium">{template.name}</span>
-                          {template.description && (
-                            <span className="text-sm text-muted-foreground">
-                              {template.description}
+                    {templates.map((template) => {
+                      const meta = findTemplateMetaBySlug(template.slug);
+                      return (
+                        <SelectItem key={template.id} value={template.id} className="py-2">
+                          <div className="flex flex-col gap-1 text-left">
+                            <div className="flex items-center gap-2">
+                              <span className="text-lg">{meta?.emoji ?? "📝"}</span>
+                              <span className="font-medium">{template.name}</span>
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              {meta?.description ?? template.description ?? "Custom survey"}
                             </span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
+                          </div>
+                        </SelectItem>
+                      );
+                    })}
                   </SelectContent>
                 </Select>
+                <p className="text-xs text-muted-foreground">
+                  Need tweaks? Open any template in settings to tailor tone, branding, or follow-up prompts before sending.
+                </p>
+                {initializing && (
+                  <p className="text-xs text-muted-foreground">Preparing curated templates…</p>
+                )}
               </div>
+
+              {selectedTemplateData && (
+                <div className="rounded-lg border border-dashed border-primary/30 bg-primary/5 p-4 transition">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                    <div
+                      className={`flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br ${
+                        selectedTemplateMeta?.accentGradient || "from-slate-200 via-slate-100 to-slate-200"
+                      }`}
+                    >
+                      <span className="text-2xl">{selectedTemplateMeta?.emoji ?? "📝"}</span>
+                    </div>
+                    <div className="flex-1 space-y-3">
+                      <div>
+                        <h4 className="text-sm font-semibold text-primary">
+                          {selectedTemplateData.name}
+                        </h4>
+                        <p className="text-sm text-muted-foreground">
+                          {selectedTemplateMeta?.description ||
+                            selectedTemplateData.description ||
+                            "Personalise this survey to match your employee voice before sharing."}
+                        </p>
+                      </div>
+                      {selectedTemplateMeta?.highlights?.length ? (
+                        <div className="flex flex-wrap gap-2">
+                          {selectedTemplateMeta.highlights.map((highlight) => (
+                            <Badge key={highlight} variant="secondary" className="bg-white text-[11px] text-primary">
+                              {highlight}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : null}
+                      <div className="flex flex-wrap gap-2 pt-1">
+                        <Button
+                          asChild
+                          variant="outline"
+                          size="sm"
+                        >
+                          <Link
+                            href={`/settings/surveys/${selectedTemplateData.id}/edit`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <Settings className="mr-2 h-4 w-4" />
+                            Edit template
+                          </Link>
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-primary hover:bg-primary/10"
+                          onClick={() => {
+                            setSelectedTemplate("");
+                            setTemplatePrefilled(false);
+                          }}
+                        >
+                          <Sparkles className="mr-2 h-4 w-4" />
+                          Choose another
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               <div className="space-y-2">
                 <Label htmlFor="name">Survey Name *</Label>

--- a/app/lib/survey-templates.ts
+++ b/app/lib/survey-templates.ts
@@ -320,9 +320,11 @@ export const DEFAULT_SURVEY_TEMPLATES: SurveyTemplateDefinition[] = [
   },
 ];
 
-let ensurePromise: Promise<any[]> | null = null;
+let ensurePromise: Promise<any[] | { forms?: any[] }> | null = null;
 
-export async function ensureDefaultSurveyTemplates(): Promise<any[]> {
+export async function ensureDefaultSurveyTemplates(): Promise<
+  any[] | { forms?: any[] }
+> {
   if (!ensurePromise) {
     ensurePromise = (async () => {
       let list: any[] = [];

--- a/app/lib/survey-templates.ts
+++ b/app/lib/survey-templates.ts
@@ -1,0 +1,388 @@
+import { AnyFormSchema } from "@/api/forms/[id]/types";
+
+export interface SurveyTemplateDefinition {
+  name: string;
+  slug: string;
+  description: string;
+  emoji: string;
+  accentColor: string;
+  accentGradient: string;
+  highlights: string[];
+  schema: AnyFormSchema;
+}
+
+export const DEFAULT_SURVEY_TEMPLATES: SurveyTemplateDefinition[] = [
+  {
+    name: "Employee Net Promoter Score (eNPS)",
+    slug: "employee-net-promoter-score",
+    description:
+      "Measure employee loyalty with a quick, industry-standard 0-10 promoter score and gather context on the rating.",
+    emoji: "📈",
+    accentColor: "text-blue-600",
+    accentGradient: "from-blue-500/90 via-indigo-500/90 to-sky-500/80",
+    highlights: ["0-10 promoter scale", "Follow-up sentiment", "Actionable improvement ideas"],
+    schema: {
+      version: 2,
+      sections: [
+        {
+          id: "enps-core-insight",
+          title: "Promoter Score",
+          description:
+            "Help us understand how likely you are to recommend working at our company to friends or colleagues.",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "enps-score",
+              type: "chips",
+              label: "How likely are you to recommend working here to a friend?",
+              required: true,
+              helpText: "0 = Not at all likely, 10 = Extremely likely",
+              appearance: "buttons",
+              optionItems: Array.from({ length: 11 }, (_, index) => ({
+                label: `${index}`,
+                value: String(index),
+              })),
+              validation: {
+                required: true,
+              },
+            },
+            {
+              id: "enps-driver",
+              type: "textarea",
+              label: "What is the primary reason for your score?",
+              placeholder: "Share the context behind your rating...",
+              required: false,
+              helpText: "This helps us celebrate wins and address friction points.",
+            },
+            {
+              id: "enps-improvement",
+              type: "textarea",
+              label: "What is one thing we could do to improve your experience?",
+              placeholder: "Tell us what would move your score closer to a 10...",
+              required: false,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    name: "Weekly Pulse Survey",
+    slug: "weekly-pulse-survey",
+    description:
+      "Capture quick snapshots of team sentiment with expressive mood pickers and lightweight follow-up prompts.",
+    emoji: "🌈",
+    accentColor: "text-pink-600",
+    accentGradient: "from-pink-500/90 via-rose-500/90 to-orange-400/80",
+    highlights: ["Mood tracker with emojis", "Workload & energy check", "Weekly wins & support"],
+    schema: {
+      version: 2,
+      sections: [
+        {
+          id: "pulse-today",
+          title: "How are you feeling?",
+          description: "A quick pulse on energy, focus, and workload.",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "pulse-mood",
+              type: "chips",
+              label: "How are you feeling today?",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "😀 Energized", value: "energized" },
+                { label: "🙂 Balanced", value: "balanced" },
+                { label: "😌 Calm", value: "calm" },
+                { label: "😕 Stretched", value: "stretched" },
+                { label: "😔 Drained", value: "drained" },
+              ],
+              helpText: "Your honest mood helps us shape support for the week.",
+              validation: {
+                required: true,
+              },
+            },
+            {
+              id: "pulse-energy",
+              type: "chips",
+              label: "How manageable is your workload right now?",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "🟢 Sustainable", value: "sustainable" },
+                { label: "🟡 Busy", value: "busy" },
+                { label: "🟠 At capacity", value: "capacity" },
+                { label: "🔴 Overloaded", value: "overloaded" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+          ],
+        },
+        {
+          id: "pulse-retrospective",
+          title: "Weekly reflection",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "pulse-highlight",
+              type: "textarea",
+              label: "What was a highlight or win this week?",
+              placeholder: "Celebrate progress, shout out teammates, or share momentum...",
+              required: false,
+            },
+            {
+              id: "pulse-support",
+              type: "textarea",
+              label: "Where could leadership support you better?",
+              placeholder: "Let us know what would make next week smoother...",
+              required: false,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    name: "Annual Engagement Survey",
+    slug: "annual-engagement-survey",
+    description:
+      "A comprehensive temperature check covering engagement, leadership, growth, and culture touchpoints.",
+    emoji: "🧭",
+    accentColor: "text-emerald-600",
+    accentGradient: "from-emerald-500/90 via-teal-500/90 to-cyan-500/80",
+    highlights: ["Engagement benchmarks", "Leadership & culture insights", "Open feedback prompts"],
+    schema: {
+      version: 2,
+      sections: [
+        {
+          id: "annual-engagement",
+          title: "Engagement & Experience",
+          description: "Help us understand the overall employee experience across the organisation.",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "annual-engagement-level",
+              type: "chips",
+              label: "Overall, how engaged do you feel at work?",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "1 - Disengaged", value: "1" },
+                { label: "2", value: "2" },
+                { label: "3", value: "3" },
+                { label: "4", value: "4" },
+                { label: "5 - Highly Engaged", value: "5" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+            {
+              id: "annual-advocacy",
+              type: "chips",
+              label: "How likely are you to recommend our company as a great place to work?",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "Very unlikely", value: "very-unlikely" },
+                { label: "Unlikely", value: "unlikely" },
+                { label: "Neutral", value: "neutral" },
+                { label: "Likely", value: "likely" },
+                { label: "Very likely", value: "very-likely" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+          ],
+        },
+        {
+          id: "annual-leadership",
+          title: "Leadership & Culture",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "annual-leadership-confidence",
+              type: "chips",
+              label: "I feel confident in the direction leadership is setting.",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "Strongly disagree", value: "strongly-disagree" },
+                { label: "Disagree", value: "disagree" },
+                { label: "Neutral", value: "neutral" },
+                { label: "Agree", value: "agree" },
+                { label: "Strongly agree", value: "strongly-agree" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+            {
+              id: "annual-voice",
+              type: "chips",
+              label: "I have the opportunity to voice ideas and concerns.",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "Strongly disagree", value: "strongly-disagree" },
+                { label: "Disagree", value: "disagree" },
+                { label: "Neutral", value: "neutral" },
+                { label: "Agree", value: "agree" },
+                { label: "Strongly agree", value: "strongly-agree" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+          ],
+        },
+        {
+          id: "annual-growth",
+          title: "Growth & Support",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "annual-growth-path",
+              type: "chips",
+              label: "I can see a clear path for growth here.",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "Strongly disagree", value: "strongly-disagree" },
+                { label: "Disagree", value: "disagree" },
+                { label: "Neutral", value: "neutral" },
+                { label: "Agree", value: "agree" },
+                { label: "Strongly agree", value: "strongly-agree" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+            {
+              id: "annual-learning",
+              type: "chips",
+              label: "I have access to the learning resources I need.",
+              required: true,
+              appearance: "buttons",
+              optionItems: [
+                { label: "Strongly disagree", value: "strongly-disagree" },
+                { label: "Disagree", value: "disagree" },
+                { label: "Neutral", value: "neutral" },
+                { label: "Agree", value: "agree" },
+                { label: "Strongly agree", value: "strongly-agree" },
+              ],
+              validation: {
+                required: true,
+              },
+            },
+          ],
+        },
+        {
+          id: "annual-open-feedback",
+          title: "Open feedback",
+          columns: 1,
+          layout: "single",
+          hidden: false,
+          fields: [
+            {
+              id: "annual-proud",
+              type: "textarea",
+              label: "What makes you most proud to work here?",
+              placeholder: "Share moments, values, or experiences that stand out...",
+              required: false,
+            },
+            {
+              id: "annual-improvement",
+              type: "textarea",
+              label: "What is one thing we should start, stop, or continue doing next year?",
+              placeholder: "Help us prioritise meaningful change...",
+              required: false,
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+let ensurePromise: Promise<any[]> | null = null;
+
+export async function ensureDefaultSurveyTemplates(): Promise<any[]> {
+  if (!ensurePromise) {
+    ensurePromise = (async () => {
+      let list: any[] = [];
+      try {
+        const existingRes = await fetch("/api/forms?type=SURVEY");
+        if (existingRes.ok) {
+          const payload = await existingRes.json();
+          list = Array.isArray(payload) ? payload : payload.forms || [];
+        }
+
+        const missing = DEFAULT_SURVEY_TEMPLATES.filter(
+          (template) =>
+            !list.some(
+              (form: any) =>
+                form?.slug === template.slug ||
+                form?.name?.toLowerCase() === template.name.toLowerCase(),
+            ),
+        );
+
+        if (missing.length) {
+          for (const template of missing) {
+            await fetch("/api/forms", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                name: template.name,
+                slug: template.slug,
+                description: template.description,
+                formType: "SURVEY",
+                schema: template.schema,
+                visibleToRoles: ["ADMIN", "MANAGER"],
+                visibleToDepartments: [],
+                visibleToJobRoles: [],
+              }),
+            });
+          }
+
+          const refreshRes = await fetch("/api/forms?type=SURVEY");
+          if (refreshRes.ok) {
+            const payload = await refreshRes.json();
+            list = Array.isArray(payload) ? payload : payload.forms || [];
+          }
+        }
+      } catch (error) {
+        console.error("Failed to ensure default survey templates", error);
+      } finally {
+        ensurePromise = null;
+      }
+
+      return list;
+    })();
+  }
+
+  return ensurePromise;
+}
+
+export function findTemplateMetaBySlug(slug?: string) {
+  if (!slug) return undefined;
+  return DEFAULT_SURVEY_TEMPLATES.find((template) => template.slug === slug);
+}
+


### PR DESCRIPTION
## Summary
- seed eNPS, pulse, and annual engagement survey templates with reusable metadata and auto-provision them via `ensureDefaultSurveyTemplates`
- redesign the settings, send, automation, and dashboard survey experiences with premium template spotlights and contextual previews
- enrich the send/automation flows to auto-select templates from query strings, prefill details, and expose quick editing entry points

## Testing
- npm run lint *(fails: repository has existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e201967d9883318d076c45b7e62a9e