### PR TITLE
Handle reset guard rails and stabilize org chart hierarchy

### DIFF
--- a/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
+++ b/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
@@ -271,7 +271,19 @@ function OrgChartPageClient() {
   const employeesByUserId = useMemo(() => {
     const map = new Map<string, ApiEmployee>();
     rawEmployees.forEach((emp) => {
-      map.set(emp.userId, emp);
+      if (emp.userId) {
+        map.set(emp.userId, emp);
+      }
+    });
+    return map;
+  }, [rawEmployees]);
+
+  const employeesByEmployeeId = useMemo(() => {
+    const map = new Map<string, ApiEmployee>();
+    rawEmployees.forEach((emp) => {
+      if (emp.id) {
+        map.set(emp.id, emp);
+      }
     });
     return map;
   }, [rawEmployees]);
@@ -286,7 +298,8 @@ function OrgChartPageClient() {
         .trim();
       const safeName = fullName.length > 0 ? fullName : emp.email;
       const manager = emp.managerUserId
-        ? employeesByUserId.get(emp.managerUserId)
+        ? employeesByUserId.get(emp.managerUserId) ??
+          employeesByEmployeeId.get(emp.managerUserId)
         : undefined;
       const managerFullName = manager
         ? `${manager.firstName ?? ""} ${manager.lastName ?? ""}`
@@ -310,17 +323,21 @@ function OrgChartPageClient() {
         managerName: managerFullName,
       } satisfies OrgEmployee;
     });
-  }, [rawEmployees, employeesByUserId]);
+  }, [rawEmployees, employeesByUserId, employeesByEmployeeId]);
 
   const orgForest = useMemo<OrgNode[]>(() => {
     const byUserId = new Map<string, OrgNode>();
+    const byEmployeeId = new Map<string, OrgNode>();
     const nodes = normalizedEmployees.map<OrgNode>((emp) => ({
       ...emp,
       children: [],
     }));
 
     nodes.forEach((node) => {
-      byUserId.set(node.userId, node);
+      if (node.userId) {
+        byUserId.set(node.userId, node);
+      }
+      byEmployeeId.set(node.id, node);
     });
 
     const roots: OrgNode[] = [];
@@ -329,11 +346,23 @@ function OrgChartPageClient() {
       const managerId = node.managerUserId;
       if (
         managerId &&
-        managerId !== node.userId &&
-        byUserId.has(managerId)
+        managerId !== node.userId
       ) {
-        byUserId.get(managerId)!.children.push(node);
+        const managerNode =
+          byUserId.get(managerId) ?? byEmployeeId.get(managerId);
+
+        if (managerNode && managerNode !== node) {
+          managerNode.children.push(node);
+          return;
+        }
       } else {
+        roots.push(node);
+        return;
+      }
+
+      if (!managerId) {
+        roots.push(node);
+      } else if (!byUserId.has(managerId) && !byEmployeeId.has(managerId)) {
         roots.push(node);
       }
     });

--- a/app/api/system/reset/route.ts
+++ b/app/api/system/reset/route.ts
@@ -41,7 +41,9 @@ export async function POST() {
       });
 
       const employeeIds = employees.map((emp) => emp.id);
-      const userIds = employees.map((emp) => emp.userId);
+      const userIds = employees
+        .map((emp) => emp.userId)
+        .filter((userId): userId is string => typeof userId === "string" && userId.length > 0);
 
       if (employeeIds.length) {
         await Promise.all([
@@ -161,25 +163,27 @@ export async function POST() {
         where: { id: { in: employeeIds } },
       });
 
-      for (const userId of userIds) {
-        const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
-        await tx.user.update({
-          where: { id: userId },
-          data: {
-            email: placeholderEmail,
-            firstName: "Deleted",
-            lastName: "User",
-            phone: null,
-            managerId: null,
-            permissionProfileId: null,
-            departmentId: null,
-            jobRoleId: null,
-            genderOptionId: null,
-            isActivated: false,
-            role: Role.EMPLOYEE,
-            canManageTenants: false,
-          },
-        });
+      if (userIds.length) {
+        for (const userId of userIds) {
+          const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
+          await tx.user.update({
+            where: { id: userId },
+            data: {
+              email: placeholderEmail,
+              firstName: "Deleted",
+              lastName: "User",
+              phone: null,
+              managerId: null,
+              permissionProfileId: null,
+              departmentId: null,
+              jobRoleId: null,
+              genderOptionId: null,
+              isActivated: false,
+              role: Role.EMPLOYEE,
+              canManageTenants: false,
+            },
+          });
+        }
       }
 
       const departments = await tx.department.deleteMany({ where: { companyId } });


### PR DESCRIPTION
## Summary
- skip user scoped cleanup during tenant reset when no related user ids are found so the reset endpoint no longer 500s
- tighten the org chart hierarchy builder by ignoring empty user ids and falling back to employee ids when resolving managers so imported employees render reliably

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated form/news components)*

------
https://chatgpt.com/codex/tasks/task_e_68e268aba6408331bc2c460d27eee55e