### PR TITLE
Improve org chart visibility and reset robustness

### DIFF
--- a/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
+++ b/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
@@ -201,6 +201,10 @@ function OrgChartPageClient() {
       try {
         const res = await fetch("/api/employees?status=all", {
           credentials: "include",
+          cache: "no-store",
+          headers: {
+            "Cache-Control": "no-cache",
+          },
         });
 
         if (!res.ok) {
@@ -228,12 +232,19 @@ function OrgChartPageClient() {
               }
             })();
 
+            const employeeId = String(emp.id ?? "").trim();
+            const userId = String(emp.userId ?? "").trim();
+            const managerIdRaw =
+              typeof emp.managerUserId === "string"
+                ? emp.managerUserId.trim()
+                : "";
+
             return {
-              id: String(emp.id ?? ""),
-              userId: String(emp.userId ?? ""),
+              id: employeeId,
+              userId: userId || employeeId,
               firstName: (emp.firstName as string | null | undefined) ?? null,
               lastName: (emp.lastName as string | null | undefined) ?? null,
-              email: String(emp.email ?? ""),
+              email: String(emp.email ?? "").trim(),
               phone: (emp.phone as string | null | undefined) ?? null,
               role: safeRole,
               departmentId: (emp.departmentId as string | null | undefined) ?? null,
@@ -245,8 +256,7 @@ function OrgChartPageClient() {
               isActive: Boolean(emp.isActive),
               profileImageUrl:
                 (emp.profileImageUrl as string | null | undefined) ?? null,
-              managerUserId:
-                (emp.managerUserId as string | null | undefined) ?? null,
+              managerUserId: managerIdRaw.length > 0 ? managerIdRaw : null,
             } satisfies ApiEmployee;
           }),
         );
@@ -271,7 +281,19 @@ function OrgChartPageClient() {
   const employeesByUserId = useMemo(() => {
     const map = new Map<string, ApiEmployee>();
     rawEmployees.forEach((emp) => {
-      map.set(emp.userId, emp);
+      if (emp.userId) {
+        map.set(emp.userId, emp);
+      }
+    });
+    return map;
+  }, [rawEmployees]);
+
+  const employeesByEmployeeId = useMemo(() => {
+    const map = new Map<string, ApiEmployee>();
+    rawEmployees.forEach((emp) => {
+      if (emp.id) {
+        map.set(emp.id, emp);
+      }
     });
     return map;
   }, [rawEmployees]);
@@ -286,7 +308,8 @@ function OrgChartPageClient() {
         .trim();
       const safeName = fullName.length > 0 ? fullName : emp.email;
       const manager = emp.managerUserId
-        ? employeesByUserId.get(emp.managerUserId)
+        ? employeesByUserId.get(emp.managerUserId) ??
+          employeesByEmployeeId.get(emp.managerUserId)
         : undefined;
       const managerFullName = manager
         ? `${manager.firstName ?? ""} ${manager.lastName ?? ""}`
@@ -310,32 +333,53 @@ function OrgChartPageClient() {
         managerName: managerFullName,
       } satisfies OrgEmployee;
     });
-  }, [rawEmployees, employeesByUserId]);
+  }, [rawEmployees, employeesByUserId, employeesByEmployeeId]);
 
   const orgForest = useMemo<OrgNode[]>(() => {
     const byUserId = new Map<string, OrgNode>();
+    const byEmployeeId = new Map<string, OrgNode>();
+    const byEmail = new Map<string, OrgNode>();
     const nodes = normalizedEmployees.map<OrgNode>((emp) => ({
       ...emp,
       children: [],
     }));
 
     nodes.forEach((node) => {
-      byUserId.set(node.userId, node);
+      if (node.userId) {
+        byUserId.set(node.userId, node);
+      }
+      if (node.id) {
+        byEmployeeId.set(node.id, node);
+      }
+      if (node.email) {
+        byEmail.set(node.email.toLowerCase(), node);
+      }
     });
 
     const roots: OrgNode[] = [];
 
     nodes.forEach((node) => {
-      const managerId = node.managerUserId;
-      if (
-        managerId &&
-        managerId !== node.userId &&
-        byUserId.has(managerId)
-      ) {
-        byUserId.get(managerId)!.children.push(node);
-      } else {
+      const managerId =
+        typeof node.managerUserId === "string"
+          ? node.managerUserId.trim()
+          : "";
+
+      if (!managerId || managerId === node.userId) {
         roots.push(node);
+        return;
       }
+
+      const managerNode =
+        byUserId.get(managerId) ??
+        byEmployeeId.get(managerId) ??
+        byEmail.get(managerId.toLowerCase());
+
+      if (managerNode && managerNode !== node) {
+        managerNode.children.push(node);
+        return;
+      }
+
+      roots.push(node);
     });
 
     const sortNodes = (list: OrgNode[]) => {

--- a/app/api/system/reset/route.ts
+++ b/app/api/system/reset/route.ts
@@ -31,184 +31,255 @@ export async function POST() {
   const currentUserId = session.user.id;
 
   try {
-    const summary = await prisma.$transaction(async (tx) => {
-      const employees = await tx.employee.findMany({
-        where: {
-          companyId,
-          NOT: { userId: currentUserId },
-        },
-        select: { id: true, userId: true },
-      });
+    const summary = await prisma.$transaction(
+      async (tx) => {
+        const chunk = <T,>(items: T[], size = 100) => {
+          const result: T[][] = [];
+          for (let i = 0; i < items.length; i += size) {
+            result.push(items.slice(i, i + size));
+          }
+          return result;
+        };
 
-      const employeeIds = employees.map((emp) => emp.id);
-      const userIds = employees.map((emp) => emp.userId);
+        const runInChunks = async <T>(
+          ids: T[],
+          handler: (batch: T[]) => Promise<unknown>,
+        ) => {
+          for (const batch of chunk(ids)) {
+            if (!batch.length) continue;
+            await handler(batch);
+          }
+        };
 
-      if (employeeIds.length) {
-        await Promise.all([
-          tx.documentSignatureArtifact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureEmployee.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureField.deleteMany({
-            where: { assignedEmployeeId: { in: employeeIds } },
-          }),
-          tx.documentAcknowledgement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.driverLicence.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.emergencyContact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeAuditLog.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeOffboarding.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeePerformanceReview.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeWorkingPatternAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employmentCheck.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formDataRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formSubmission.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyRecipient.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyResponse.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveEntitlement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.onboardingInstance.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.trainingRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.transactionalChangeRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.actionItem.deleteMany({
-            where: { relatedEmployeeId: { in: employeeIds } },
-          }),
-        ]);
-      }
+        const employees = await tx.employee.findMany({
+          where: {
+            companyId,
+            NOT: { userId: currentUserId },
+          },
+          select: { id: true, userId: true },
+        });
 
-      if (userIds.length) {
-        const userScopedTasks = [
-          tx.leaveRequest.deleteMany({
-            where: {
-              companyId,
-              OR: [
-                { requesterId: { in: userIds } },
-                { approvedById: { in: userIds } },
-              ],
-            },
-          }),
-          tx.actionItem.deleteMany({
-            where: {
-              companyId,
-              assignedToId: { in: userIds },
-            },
-          }),
-          tx.activationToken.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsPost.deleteMany({ where: { authorId: { in: userIds } } }),
-          tx.newsReaction.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsBookmark.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.globalAuditLog.deleteMany({
-            where: { companyId, actorId: { in: userIds } },
-          }),
-          tx.user.updateMany({
-            where: { id: { in: userIds } },
-            data: { role: Role.EMPLOYEE, canManageTenants: false },
-          }),
+        const employeeIds = employees.map((emp) => emp.id);
+        const userIds = employees
+          .map((emp) => emp.userId)
+          .filter(
+            (userId): userId is string =>
+              typeof userId === "string" && userId.length > 0,
+          );
+
+        if (employeeIds.length) {
+          const employeeScopedDeletions: Array<
+            (ids: string[]) => Promise<unknown>
+          > = [
+          (ids) =>
+            tx.documentSignatureArtifact.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.documentSignatureEmployee.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.documentSignatureField.deleteMany({
+              where: { assignedEmployeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.documentAcknowledgement.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.driverLicence.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.emergencyContact.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.employeeAuditLog.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.employeeOffboarding.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.employeePerformanceReview.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.employeeWorkingPatternAssignment.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.employmentCheck.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.formAssignment.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.formDataRecord.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.formSubmission.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.surveyRecipient.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.surveyResponse.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.leaveEntitlement.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.leaveRequest.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.onboardingInstance.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.trainingRecord.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.transactionalChangeRequest.deleteMany({
+              where: { employeeId: { in: ids } },
+            }),
+          (ids) =>
+            tx.actionItem.deleteMany({
+              where: { relatedEmployeeId: { in: ids } },
+            }),
         ];
 
-        await Promise.all(userScopedTasks);
-
-        try {
-          await tx.$executeRaw(
-            Prisma.sql`DELETE FROM "Session" WHERE "userId" IN (${Prisma.join(
-              userIds,
-            )})`,
-          );
-        } catch (error) {
-          console.warn("Failed to remove persisted sessions during reset", error);
+        for (const deleteOperation of employeeScopedDeletions) {
+          await runInChunks(employeeIds, deleteOperation);
         }
       }
 
-      const { count: removedEmployees } = await tx.employee.deleteMany({
-        where: { id: { in: employeeIds } },
-      });
+      if (userIds.length) {
+        const userScopedOperations: Array<
+          (ids: string[]) => Promise<unknown>
+        > = [
+          (ids) =>
+            tx.leaveRequest.deleteMany({
+              where: {
+                companyId,
+                OR: [
+                  { requesterId: { in: ids } },
+                  { approvedById: { in: ids } },
+                ],
+              },
+            }),
+          (ids) =>
+            tx.actionItem.deleteMany({
+              where: {
+                companyId,
+                assignedToId: { in: ids },
+              },
+            }),
+          (ids) =>
+            tx.activationToken.deleteMany({ where: { userId: { in: ids } } }),
+          (ids) => tx.newsPost.deleteMany({ where: { authorId: { in: ids } } }),
+          (ids) => tx.newsReaction.deleteMany({ where: { userId: { in: ids } } }),
+          (ids) => tx.newsBookmark.deleteMany({ where: { userId: { in: ids } } }),
+          (ids) =>
+            tx.globalAuditLog.deleteMany({
+              where: { companyId, actorId: { in: ids } },
+            }),
+          (ids) =>
+            tx.user.updateMany({
+              where: { id: { in: ids } },
+              data: { role: Role.EMPLOYEE, canManageTenants: false },
+            }),
+        ];
 
-      for (const userId of userIds) {
-        const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
-        await tx.user.update({
-          where: { id: userId },
-          data: {
-            email: placeholderEmail,
-            firstName: "Deleted",
-            lastName: "User",
-            phone: null,
-            managerId: null,
-            permissionProfileId: null,
-            departmentId: null,
-            jobRoleId: null,
-            genderOptionId: null,
-            isActivated: false,
-            role: Role.EMPLOYEE,
-            canManageTenants: false,
-          },
-        });
+        for (const operation of userScopedOperations) {
+          await runInChunks(userIds, operation);
+        }
+
+        for (const batch of chunk(userIds)) {
+          if (!batch.length) continue;
+          try {
+            await tx.$executeRaw(
+              Prisma.sql`DELETE FROM "Session" WHERE "userId" IN (${Prisma.join(
+                batch,
+              )})`,
+            );
+          } catch (error) {
+            console.warn("Failed to remove persisted sessions during reset", error);
+          }
+        }
       }
 
-      const departments = await tx.department.deleteMany({ where: { companyId } });
-      const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
-      const workingPatterns = await tx.workingPattern.deleteMany({
-        where: { companyId },
-      });
-      const genderOptions = await tx.genderOption.deleteMany({
-        where: { companyId },
-      });
-      const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
-        where: { companyId },
-      });
-      const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
-      const eventCategories = await tx.eventCategory.deleteMany({
-        where: { companyId, systemDefined: false },
-      });
+        const { count: removedEmployees } = await tx.employee.deleteMany({
+          where: { id: { in: employeeIds } },
+        });
 
-      return {
-        removedEmployees,
-        scrubbedUsers: userIds.length,
-        removedDepartments: departments.count,
-        removedJobRoles: jobRoles.count,
-        removedWorkingPatterns: workingPatterns.count,
-        removedGenderOptions: genderOptions.count,
-        removedEventCategories: eventCategories.count,
-        removedEventRules: eventRules.count + eventRuleOverrides.count,
-      } as const;
-    });
+        if (userIds.length) {
+          for (const userId of userIds) {
+            const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
+            await tx.user.update({
+              where: { id: userId },
+              data: {
+                email: placeholderEmail,
+                firstName: "Deleted",
+                lastName: "User",
+                phone: null,
+                managerId: null,
+                permissionProfileId: null,
+                departmentId: null,
+                jobRoleId: null,
+                genderOptionId: null,
+                isActivated: false,
+                role: Role.EMPLOYEE,
+                canManageTenants: false,
+              },
+            });
+          }
+        }
+
+        const departments = await tx.department.deleteMany({ where: { companyId } });
+        const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
+        const workingPatterns = await tx.workingPattern.deleteMany({
+          where: { companyId },
+        });
+        const genderOptions = await tx.genderOption.deleteMany({
+          where: { companyId },
+        });
+        const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
+          where: { companyId },
+        });
+        const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
+        const eventCategories = await tx.eventCategory.deleteMany({
+          where: { companyId, systemDefined: false },
+        });
+
+        return {
+          removedEmployees,
+          scrubbedUsers: userIds.length,
+          removedDepartments: departments.count,
+          removedJobRoles: jobRoles.count,
+          removedWorkingPatterns: workingPatterns.count,
+          removedGenderOptions: genderOptions.count,
+          removedEventCategories: eventCategories.count,
+          removedEventRules: eventRules.count + eventRuleOverrides.count,
+        } as const;
+      },
+      {
+        maxWait: 5_000,
+        timeout: 60_000,
+      },
+    );
 
     const resetActor = session.user.email ?? currentUserId;
 


### PR DESCRIPTION
## Summary
- chunk employee- and user-scoped cleanup during tenant resets and extend the transaction timeout to avoid Prisma interactive transaction timeouts
- force org chart employee fetches to bypass caches and tighten hierarchy resolution with trimmed identifiers and email fallbacks so imported staff appear

## Testing
- npm run lint *(fails: numerous pre-existing lint warnings and errors in unrelated form, news, workflow, and other components)*

------
https://chatgpt.com/codex/tasks/task_e_68e268aba6408331bc2c460d27eee55e