### PR TITLE
Fix org chart visibility and stabilize tenant reset

### DIFF
--- a/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
+++ b/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
@@ -118,6 +118,7 @@ interface ApiEmployee {
   isActive: boolean;
   profileImageUrl?: string | null;
   managerUserId?: string | null;
+  permissionProfileName?: string | null;
 }
 
 interface OrgEmployee {
@@ -199,8 +200,12 @@ function OrgChartPageClient() {
       }
 
       try {
-        const res = await fetch("/api/employees?status=all", {
+        const res = await fetch("/api/org-chart", {
           credentials: "include",
+          cache: "no-store",
+          headers: {
+            "Cache-Control": "no-cache",
+          },
         });
 
         if (!res.ok) {
@@ -228,12 +233,19 @@ function OrgChartPageClient() {
               }
             })();
 
+            const employeeId = String(emp.id ?? "").trim();
+            const userId = String(emp.userId ?? "").trim();
+            const managerIdRaw =
+              typeof emp.managerUserId === "string"
+                ? emp.managerUserId.trim()
+                : "";
+
             return {
-              id: String(emp.id ?? ""),
-              userId: String(emp.userId ?? ""),
+              id: employeeId,
+              userId: userId || employeeId,
               firstName: (emp.firstName as string | null | undefined) ?? null,
               lastName: (emp.lastName as string | null | undefined) ?? null,
-              email: String(emp.email ?? ""),
+              email: String(emp.email ?? "").trim(),
               phone: (emp.phone as string | null | undefined) ?? null,
               role: safeRole,
               departmentId: (emp.departmentId as string | null | undefined) ?? null,
@@ -245,8 +257,9 @@ function OrgChartPageClient() {
               isActive: Boolean(emp.isActive),
               profileImageUrl:
                 (emp.profileImageUrl as string | null | undefined) ?? null,
-              managerUserId:
-                (emp.managerUserId as string | null | undefined) ?? null,
+              managerUserId: managerIdRaw.length > 0 ? managerIdRaw : null,
+              permissionProfileName:
+                (emp.permissionProfileName as string | null | undefined) ?? null,
             } satisfies ApiEmployee;
           }),
         );
@@ -271,7 +284,19 @@ function OrgChartPageClient() {
   const employeesByUserId = useMemo(() => {
     const map = new Map<string, ApiEmployee>();
     rawEmployees.forEach((emp) => {
-      map.set(emp.userId, emp);
+      if (emp.userId) {
+        map.set(emp.userId, emp);
+      }
+    });
+    return map;
+  }, [rawEmployees]);
+
+  const employeesByEmployeeId = useMemo(() => {
+    const map = new Map<string, ApiEmployee>();
+    rawEmployees.forEach((emp) => {
+      if (emp.id) {
+        map.set(emp.id, emp);
+      }
     });
     return map;
   }, [rawEmployees]);
@@ -286,7 +311,8 @@ function OrgChartPageClient() {
         .trim();
       const safeName = fullName.length > 0 ? fullName : emp.email;
       const manager = emp.managerUserId
-        ? employeesByUserId.get(emp.managerUserId)
+        ? employeesByUserId.get(emp.managerUserId) ??
+          employeesByEmployeeId.get(emp.managerUserId)
         : undefined;
       const managerFullName = manager
         ? `${manager.firstName ?? ""} ${manager.lastName ?? ""}`
@@ -308,34 +334,56 @@ function OrgChartPageClient() {
         profileImageUrl: emp.profileImageUrl ?? null,
         managerUserId: emp.managerUserId ?? null,
         managerName: managerFullName,
+        permissionProfileName: emp.permissionProfileName ?? null,
       } satisfies OrgEmployee;
     });
-  }, [rawEmployees, employeesByUserId]);
+  }, [rawEmployees, employeesByUserId, employeesByEmployeeId]);
 
   const orgForest = useMemo<OrgNode[]>(() => {
     const byUserId = new Map<string, OrgNode>();
+    const byEmployeeId = new Map<string, OrgNode>();
+    const byEmail = new Map<string, OrgNode>();
     const nodes = normalizedEmployees.map<OrgNode>((emp) => ({
       ...emp,
       children: [],
     }));
 
     nodes.forEach((node) => {
-      byUserId.set(node.userId, node);
+      if (node.userId) {
+        byUserId.set(node.userId, node);
+      }
+      if (node.id) {
+        byEmployeeId.set(node.id, node);
+      }
+      if (node.email) {
+        byEmail.set(node.email.toLowerCase(), node);
+      }
     });
 
     const roots: OrgNode[] = [];
 
     nodes.forEach((node) => {
-      const managerId = node.managerUserId;
-      if (
-        managerId &&
-        managerId !== node.userId &&
-        byUserId.has(managerId)
-      ) {
-        byUserId.get(managerId)!.children.push(node);
-      } else {
+      const managerId =
+        typeof node.managerUserId === "string"
+          ? node.managerUserId.trim()
+          : "";
+
+      if (!managerId || managerId === node.userId) {
         roots.push(node);
+        return;
       }
+
+      const managerNode =
+        byUserId.get(managerId) ??
+        byEmployeeId.get(managerId) ??
+        byEmail.get(managerId.toLowerCase());
+
+      if (managerNode && managerNode !== node) {
+        managerNode.children.push(node);
+        return;
+      }
+
+      roots.push(node);
     });
 
     const sortNodes = (list: OrgNode[]) => {

--- a/app/api/org-chart/route.ts
+++ b/app/api/org-chart/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import supabase from "@/lib/supabase-admin";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.companyId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const companyId = session.user.companyId;
+
+    const users = await prisma.user.findMany({
+      where: { companyId },
+      include: {
+        Employee: {
+          select: {
+            id: true,
+            isActive: true,
+            departmentId: true,
+            jobRoleId: true,
+            Department: { select: { id: true, name: true } },
+            JobRole: { select: { id: true, name: true } },
+          },
+        },
+        Department_User_departmentIdToDepartment: {
+          select: { id: true, name: true },
+        },
+        JobRole: {
+          select: { id: true, name: true },
+        },
+        PermissionProfile: {
+          select: { name: true },
+        },
+      },
+      orderBy: [
+        { firstName: "asc" },
+        { lastName: "asc" },
+        { email: "asc" },
+      ],
+    });
+
+    const enriched = await Promise.all(
+      users.map(async (user) => {
+        let profileUrl: string | null = null;
+
+        if (user.profileImageUrl) {
+          try {
+            const { data } = await supabase.storage
+              .from("documents")
+              .createSignedUrl(user.profileImageUrl, 60 * 5);
+            profileUrl = data?.signedUrl ?? null;
+          } catch {
+            profileUrl = null;
+          }
+        }
+
+        const employee = user.Employee;
+        const department =
+          employee?.Department ?? user.Department_User_departmentIdToDepartment;
+        const jobRole = employee?.JobRole ?? user.JobRole;
+
+        return {
+          id: employee?.id ?? user.id,
+          userId: user.id,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          phone: user.phone,
+          role: user.role,
+          departmentId: department?.id ?? null,
+          departmentName: department?.name ?? null,
+          jobRoleId: jobRole?.id ?? null,
+          jobRoleName: jobRole?.name ?? null,
+          isActive: employee?.isActive ?? user.isActivated ?? false,
+          profileImageUrl: profileUrl,
+          managerUserId: user.managerId,
+          permissionProfileName: user.PermissionProfile?.name ?? null,
+        } as const;
+      }),
+    );
+
+    return NextResponse.json(enriched);
+  } catch (error) {
+    console.error("Failed to load org chart data", error);
+    return NextResponse.json(
+      { error: "Unable to load organisation chart" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/system/reset/route.ts
+++ b/app/api/system/reset/route.ts
@@ -31,184 +31,203 @@ export async function POST() {
   const currentUserId = session.user.id;
 
   try {
-    const summary = await prisma.$transaction(async (tx) => {
-      const employees = await tx.employee.findMany({
-        where: {
-          companyId,
-          NOT: { userId: currentUserId },
-        },
-        select: { id: true, userId: true },
-      });
-
-      const employeeIds = employees.map((emp) => emp.id);
-      const userIds = employees.map((emp) => emp.userId);
-
-      if (employeeIds.length) {
-        await Promise.all([
-          tx.documentSignatureArtifact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureEmployee.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureField.deleteMany({
-            where: { assignedEmployeeId: { in: employeeIds } },
-          }),
-          tx.documentAcknowledgement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.driverLicence.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.emergencyContact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeAuditLog.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeOffboarding.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeePerformanceReview.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeWorkingPatternAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employmentCheck.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formDataRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formSubmission.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyRecipient.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyResponse.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveEntitlement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.onboardingInstance.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.trainingRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.transactionalChangeRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.actionItem.deleteMany({
-            where: { relatedEmployeeId: { in: employeeIds } },
-          }),
-        ]);
-      }
-
-      if (userIds.length) {
-        const userScopedTasks = [
-          tx.leaveRequest.deleteMany({
-            where: {
-              companyId,
-              OR: [
-                { requesterId: { in: userIds } },
-                { approvedById: { in: userIds } },
-              ],
-            },
-          }),
-          tx.actionItem.deleteMany({
-            where: {
-              companyId,
-              assignedToId: { in: userIds },
-            },
-          }),
-          tx.activationToken.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsPost.deleteMany({ where: { authorId: { in: userIds } } }),
-          tx.newsReaction.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsBookmark.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.globalAuditLog.deleteMany({
-            where: { companyId, actorId: { in: userIds } },
-          }),
-          tx.user.updateMany({
-            where: { id: { in: userIds } },
-            data: { role: Role.EMPLOYEE, canManageTenants: false },
-          }),
-        ];
-
-        await Promise.all(userScopedTasks);
-
-        try {
-          await tx.$executeRaw(
-            Prisma.sql`DELETE FROM "Session" WHERE "userId" IN (${Prisma.join(
-              userIds,
-            )})`,
-          );
-        } catch (error) {
-          console.warn("Failed to remove persisted sessions during reset", error);
-        }
-      }
-
-      const { count: removedEmployees } = await tx.employee.deleteMany({
-        where: { id: { in: employeeIds } },
-      });
-
-      for (const userId of userIds) {
-        const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
-        await tx.user.update({
-          where: { id: userId },
-          data: {
-            email: placeholderEmail,
-            firstName: "Deleted",
-            lastName: "User",
-            phone: null,
-            managerId: null,
-            permissionProfileId: null,
-            departmentId: null,
-            jobRoleId: null,
-            genderOptionId: null,
-            isActivated: false,
-            role: Role.EMPLOYEE,
-            canManageTenants: false,
+    const summary = await prisma.$transaction(
+      async (tx) => {
+        const employees = await tx.employee.findMany({
+          where: {
+            companyId,
+            NOT: { userId: currentUserId },
           },
+          select: { id: true, userId: true },
         });
-      }
 
-      const departments = await tx.department.deleteMany({ where: { companyId } });
-      const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
-      const workingPatterns = await tx.workingPattern.deleteMany({
-        where: { companyId },
-      });
-      const genderOptions = await tx.genderOption.deleteMany({
-        where: { companyId },
-      });
-      const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
-        where: { companyId },
-      });
-      const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
-      const eventCategories = await tx.eventCategory.deleteMany({
-        where: { companyId, systemDefined: false },
-      });
+        const employeeIds = employees.map((emp) => emp.id);
+        const userIds = employees
+          .map((emp) => emp.userId)
+          .filter(
+            (userId): userId is string =>
+              typeof userId === "string" && userId.length > 0,
+          );
 
-      return {
-        removedEmployees,
-        scrubbedUsers: userIds.length,
-        removedDepartments: departments.count,
-        removedJobRoles: jobRoles.count,
-        removedWorkingPatterns: workingPatterns.count,
-        removedGenderOptions: genderOptions.count,
-        removedEventCategories: eventCategories.count,
-        removedEventRules: eventRules.count + eventRuleOverrides.count,
-      } as const;
-    });
+        let removedEmployees = 0;
+        let scrubbedUsers = 0;
+
+        if (employeeIds.length) {
+          const employeeScope = Prisma.sql`
+            SELECT "id"
+            FROM "Employee"
+            WHERE "companyId" = ${companyId}
+              AND ("userId" IS NULL OR "userId" <> ${currentUserId})
+          `;
+
+          const employeeScopedTargets: Array<{
+            table: string;
+            column?: string;
+          }> = [
+            { table: "DocumentSignatureArtifact" },
+            { table: "DocumentSignatureEmployee" },
+            { table: "DocumentSignatureField", column: '"assignedEmployeeId"' },
+            { table: "DocumentAcknowledgement" },
+            { table: "DriverLicence" },
+            { table: "EmergencyContact" },
+            { table: "EmployeeAuditLog" },
+            { table: "EmployeeOffboarding" },
+            { table: "EmployeePerformanceReview" },
+            { table: "EmployeeWorkingPatternAssignment" },
+            { table: "EmploymentCheck" },
+            { table: "FormAssignment" },
+            { table: "FormDataRecord" },
+            { table: "FormSubmission" },
+            { table: "SurveyRecipient" },
+            { table: "SurveyResponse" },
+            { table: "LeaveEntitlement" },
+            { table: "LeaveRequest" },
+            { table: "OnboardingInstance" },
+            { table: "TrainingRecord" },
+            { table: "TransactionalChangeRequest" },
+            { table: "ActionItem", column: '"relatedEmployeeId"' },
+          ];
+
+          for (const { table, column = '"employeeId"' } of employeeScopedTargets) {
+            await tx.$executeRaw(
+              Prisma.sql`
+                DELETE FROM ${Prisma.raw(`"${table}"`)}
+                WHERE ${Prisma.raw(column)} IN (${employeeScope})
+              `,
+            );
+          }
+        }
+
+        if (userIds.length) {
+          const userScope = Prisma.sql`
+            SELECT "userId"
+            FROM "Employee"
+            WHERE "companyId" = ${companyId}
+              AND "userId" IS NOT NULL
+              AND "userId" <> ${currentUserId}
+          `;
+
+          await tx.$executeRaw(
+            Prisma.sql`
+              DELETE FROM "LeaveRequest"
+              WHERE "companyId" = ${companyId}
+                AND (
+                  "requesterId" IN (${userScope}) OR
+                  "approvedById" IN (${userScope})
+                )
+            `,
+          );
+
+          const userScopedTargets: Array<{
+            table: string;
+            column?: string;
+            extra?: Prisma.Sql;
+          }> = [
+            {
+              table: "ActionItem",
+              column: '"assignedToId"',
+              extra: Prisma.sql`"companyId" = ${companyId}`,
+            },
+            { table: "ActivationToken" },
+            { table: "NewsPost", column: '"authorId"' },
+            { table: "NewsReaction" },
+            { table: "NewsBookmark" },
+          ];
+
+          for (const { table, column = '"userId"', extra } of userScopedTargets) {
+            const extraCondition = extra
+              ? Prisma.sql`${extra} AND`
+              : Prisma.sql``;
+
+            await tx.$executeRaw(
+              Prisma.sql`
+                DELETE FROM ${Prisma.raw(`"${table}"`)}
+                WHERE ${extraCondition} ${Prisma.raw(column)} IN (${userScope})
+              `,
+            );
+          }
+
+          await tx.$executeRaw(
+            Prisma.sql`
+              DELETE FROM "GlobalAuditLog"
+              WHERE "companyId" = ${companyId}
+                AND "actorId" IN (${userScope})
+            `,
+          );
+
+          await tx.$executeRaw(
+            Prisma.sql`
+              DELETE FROM "Session"
+              WHERE "userId" IN (${userScope})
+            `,
+          );
+
+          const placeholderSuffix = `@${RESET_EMAIL_DOMAIN}`;
+          const scrubbed = await tx.$queryRaw<Array<{ count: bigint }>>(
+            Prisma.sql`
+              SELECT COUNT(*)::int AS count
+              FROM (
+                UPDATE "User"
+                SET
+                  "email" = "id" || ${placeholderSuffix},
+                  "firstName" = 'Deleted',
+                  "lastName" = 'User',
+                  "phone" = NULL,
+                  "managerId" = NULL,
+                  "permissionProfileId" = NULL,
+                  "departmentId" = NULL,
+                  "jobRoleId" = NULL,
+                  "genderOptionId" = NULL,
+                  "isActivated" = FALSE,
+                  "role" = ${Role.EMPLOYEE},
+                  "canManageTenants" = FALSE,
+                  "updatedAt" = NOW()
+                WHERE "id" IN (${userScope})
+                RETURNING 1
+              ) AS updated
+            `,
+          );
+
+          scrubbedUsers = Number(scrubbed[0]?.count ?? 0);
+        }
+
+        const deletionResult = await tx.employee.deleteMany({
+          where: { companyId, NOT: { userId: currentUserId } },
+        });
+        removedEmployees = deletionResult.count;
+
+        const departments = await tx.department.deleteMany({ where: { companyId } });
+        const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
+        const workingPatterns = await tx.workingPattern.deleteMany({
+          where: { companyId },
+        });
+        const genderOptions = await tx.genderOption.deleteMany({
+          where: { companyId },
+        });
+        const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
+          where: { companyId },
+        });
+        const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
+        const eventCategories = await tx.eventCategory.deleteMany({
+          where: { companyId, systemDefined: false },
+        });
+
+        return {
+          removedEmployees,
+          scrubbedUsers,
+          removedDepartments: departments.count,
+          removedJobRoles: jobRoles.count,
+          removedWorkingPatterns: workingPatterns.count,
+          removedGenderOptions: genderOptions.count,
+          removedEventCategories: eventCategories.count,
+          removedEventRules: eventRules.count + eventRuleOverrides.count,
+        } as const;
+      },
+      {
+        maxWait: 5_000,
+        timeout: 60_000,
+      },
+    );
 
     const resetActor = session.user.email ?? currentUserId;
 


### PR DESCRIPTION
## Summary
- add a dedicated `/api/org-chart` endpoint that assembles hierarchy data from users and employees so imported staff are included
- update the org chart client to consume the new payload, normalise identifiers, and surface permission profile details
- replace iterative tenant reset cleanup with set-based deletes and a bulk user scrub to avoid transaction aborts
- adjust the scrubbed user update query typing so the build succeeds

## Testing
- npm run build *(fails: unable to download required Google Fonts because the sandbox has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68e268aba6408331bc2c460d27eee55e