### PR TITLE
Fix org chart payload and stabilize tenant reset cleanup

### DIFF
--- a/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
+++ b/app/(withSidebar)/org-chart/OrgChartPageClient.tsx
@@ -118,6 +118,7 @@ interface ApiEmployee {
   isActive: boolean;
   profileImageUrl?: string | null;
   managerUserId?: string | null;
+  permissionProfileName?: string | null;
 }
 
 interface OrgEmployee {
@@ -199,8 +200,12 @@ function OrgChartPageClient() {
       }
 
       try {
-        const res = await fetch("/api/employees?status=all", {
+        const res = await fetch("/api/org-chart", {
           credentials: "include",
+          cache: "no-store",
+          headers: {
+            "Cache-Control": "no-cache",
+          },
         });
 
         if (!res.ok) {
@@ -223,17 +228,26 @@ function OrgChartPageClient() {
                 case "MANAGER":
                 case "EMPLOYEE":
                   return emp.role;
+                case "SUPER_ADMIN":
+                  return "ADMIN";
                 default:
                   return "EMPLOYEE";
               }
             })();
 
+            const employeeId = String(emp.id ?? "").trim();
+            const userId = String(emp.userId ?? "").trim();
+            const managerIdRaw =
+              typeof emp.managerUserId === "string"
+                ? emp.managerUserId.trim()
+                : "";
+
             return {
-              id: String(emp.id ?? ""),
-              userId: String(emp.userId ?? ""),
+              id: employeeId,
+              userId: userId || employeeId,
               firstName: (emp.firstName as string | null | undefined) ?? null,
               lastName: (emp.lastName as string | null | undefined) ?? null,
-              email: String(emp.email ?? ""),
+              email: String(emp.email ?? "").trim(),
               phone: (emp.phone as string | null | undefined) ?? null,
               role: safeRole,
               departmentId: (emp.departmentId as string | null | undefined) ?? null,
@@ -245,8 +259,9 @@ function OrgChartPageClient() {
               isActive: Boolean(emp.isActive),
               profileImageUrl:
                 (emp.profileImageUrl as string | null | undefined) ?? null,
-              managerUserId:
-                (emp.managerUserId as string | null | undefined) ?? null,
+              managerUserId: managerIdRaw.length > 0 ? managerIdRaw : null,
+              permissionProfileName:
+                (emp.permissionProfileName as string | null | undefined) ?? null,
             } satisfies ApiEmployee;
           }),
         );
@@ -271,7 +286,19 @@ function OrgChartPageClient() {
   const employeesByUserId = useMemo(() => {
     const map = new Map<string, ApiEmployee>();
     rawEmployees.forEach((emp) => {
-      map.set(emp.userId, emp);
+      if (emp.userId) {
+        map.set(emp.userId, emp);
+      }
+    });
+    return map;
+  }, [rawEmployees]);
+
+  const employeesByEmployeeId = useMemo(() => {
+    const map = new Map<string, ApiEmployee>();
+    rawEmployees.forEach((emp) => {
+      if (emp.id) {
+        map.set(emp.id, emp);
+      }
     });
     return map;
   }, [rawEmployees]);
@@ -286,7 +313,8 @@ function OrgChartPageClient() {
         .trim();
       const safeName = fullName.length > 0 ? fullName : emp.email;
       const manager = emp.managerUserId
-        ? employeesByUserId.get(emp.managerUserId)
+        ? employeesByUserId.get(emp.managerUserId) ??
+          employeesByEmployeeId.get(emp.managerUserId)
         : undefined;
       const managerFullName = manager
         ? `${manager.firstName ?? ""} ${manager.lastName ?? ""}`
@@ -308,34 +336,56 @@ function OrgChartPageClient() {
         profileImageUrl: emp.profileImageUrl ?? null,
         managerUserId: emp.managerUserId ?? null,
         managerName: managerFullName,
+        permissionProfileName: emp.permissionProfileName ?? null,
       } satisfies OrgEmployee;
     });
-  }, [rawEmployees, employeesByUserId]);
+  }, [rawEmployees, employeesByUserId, employeesByEmployeeId]);
 
   const orgForest = useMemo<OrgNode[]>(() => {
     const byUserId = new Map<string, OrgNode>();
+    const byEmployeeId = new Map<string, OrgNode>();
+    const byEmail = new Map<string, OrgNode>();
     const nodes = normalizedEmployees.map<OrgNode>((emp) => ({
       ...emp,
       children: [],
     }));
 
     nodes.forEach((node) => {
-      byUserId.set(node.userId, node);
+      if (node.userId) {
+        byUserId.set(node.userId, node);
+      }
+      if (node.id) {
+        byEmployeeId.set(node.id, node);
+      }
+      if (node.email) {
+        byEmail.set(node.email.toLowerCase(), node);
+      }
     });
 
     const roots: OrgNode[] = [];
 
     nodes.forEach((node) => {
-      const managerId = node.managerUserId;
-      if (
-        managerId &&
-        managerId !== node.userId &&
-        byUserId.has(managerId)
-      ) {
-        byUserId.get(managerId)!.children.push(node);
-      } else {
+      const managerId =
+        typeof node.managerUserId === "string"
+          ? node.managerUserId.trim()
+          : "";
+
+      if (!managerId || managerId === node.userId) {
         roots.push(node);
+        return;
       }
+
+      const managerNode =
+        byUserId.get(managerId) ??
+        byEmployeeId.get(managerId) ??
+        byEmail.get(managerId.toLowerCase());
+
+      if (managerNode && managerNode !== node) {
+        managerNode.children.push(node);
+        return;
+      }
+
+      roots.push(node);
     });
 
     const sortNodes = (list: OrgNode[]) => {

--- a/app/api/org-chart/route.ts
+++ b/app/api/org-chart/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import supabase from "@/lib/supabase-admin";
+
+type OrgRole = "ADMIN" | "MANAGER" | "EMPLOYEE";
+
+const SIGNED_URL_TTL_SECONDS = 60 * 5;
+
+const normalizeRole = (role: string | null | undefined): OrgRole => {
+  switch (role) {
+    case "ADMIN":
+    case "SUPER_ADMIN":
+      return "ADMIN";
+    case "MANAGER":
+      return "MANAGER";
+    default:
+      return "EMPLOYEE";
+  }
+};
+
+const getSignedProfileUrl = async (path: string | null | undefined) => {
+  if (!path) {
+    return null;
+  }
+
+  try {
+    const { data } = await supabase.storage
+      .from("documents")
+      .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+
+    return data?.signedUrl ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.companyId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const companyId = session.user.companyId;
+
+    const employees = await prisma.employee.findMany({
+      where: { companyId },
+      include: {
+        Department: { select: { id: true, name: true } },
+        JobRole: { select: { id: true, name: true } },
+        User: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+            phone: true,
+            role: true,
+            isActivated: true,
+            managerId: true,
+            profileImageUrl: true,
+            PermissionProfile: { select: { name: true } },
+            Department_User_departmentIdToDepartment: {
+              select: { id: true, name: true },
+            },
+            JobRole: { select: { id: true, name: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const employeeUserIds = new Set(employees.map((employee) => employee.userId));
+
+    const standaloneUsers = await prisma.user.findMany({
+      where: {
+        companyId,
+        id: { notIn: Array.from(employeeUserIds) },
+      },
+      include: {
+        Department_User_departmentIdToDepartment: {
+          select: { id: true, name: true },
+        },
+        JobRole: { select: { id: true, name: true } },
+        PermissionProfile: { select: { name: true } },
+        Employee: {
+          select: { id: true },
+        },
+      },
+      orderBy: [
+        { firstName: "asc" },
+        { lastName: "asc" },
+        { email: "asc" },
+      ],
+    });
+
+    const formattedEmployees = await Promise.all(
+      employees.map(async (employee) => {
+        const user = employee.User;
+        const department =
+          employee.Department ?? user?.Department_User_departmentIdToDepartment;
+        const jobRole = employee.JobRole ?? user?.JobRole;
+
+        return {
+          id: employee.id,
+          userId: user?.id ?? employee.userId,
+          firstName: user?.firstName ?? null,
+          lastName: user?.lastName ?? null,
+          email: user?.email ?? "",
+          phone: user?.phone ?? null,
+          role: normalizeRole(user?.role),
+          departmentId: department?.id ?? null,
+          departmentName: department?.name ?? null,
+          jobRoleId: jobRole?.id ?? null,
+          jobRoleName: jobRole?.name ?? null,
+          isActive: employee.isActive,
+          profileImageUrl: await getSignedProfileUrl(user?.profileImageUrl),
+          managerUserId: user?.managerId ?? null,
+          permissionProfileName: user?.PermissionProfile?.name ?? null,
+        } as const;
+      }),
+    );
+
+    const formattedStandaloneUsers = await Promise.all(
+      standaloneUsers.map(async (user) => {
+        const department = user.Department_User_departmentIdToDepartment;
+        const jobRole = user.JobRole;
+
+        return {
+          id: user.Employee?.id ?? user.id,
+          userId: user.id,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          phone: user.phone,
+          role: normalizeRole(user.role),
+          departmentId: department?.id ?? null,
+          departmentName: department?.name ?? null,
+          jobRoleId: jobRole?.id ?? null,
+          jobRoleName: jobRole?.name ?? null,
+          isActive: user.isActivated ?? false,
+          profileImageUrl: await getSignedProfileUrl(user.profileImageUrl),
+          managerUserId: user.managerId,
+          permissionProfileName: user.PermissionProfile?.name ?? null,
+        } as const;
+      }),
+    );
+
+    const combined = [...formattedEmployees, ...formattedStandaloneUsers].sort(
+      (a, b) => {
+        const nameA = `${a.firstName ?? ""} ${a.lastName ?? ""}`
+          .trim()
+          .toLowerCase();
+        const nameB = `${b.firstName ?? ""} ${b.lastName ?? ""}`
+          .trim()
+          .toLowerCase();
+
+        if (nameA && nameB && nameA !== nameB) {
+          return nameA.localeCompare(nameB);
+        }
+
+        return a.email.localeCompare(b.email);
+      },
+    );
+
+    return NextResponse.json(combined);
+  } catch (error) {
+    console.error("Failed to load org chart data", error);
+    return NextResponse.json(
+      { error: "Unable to load organisation chart" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/system/reset/route.ts
+++ b/app/api/system/reset/route.ts
@@ -6,6 +6,33 @@ import { auditLog } from "@/lib/audit";
 import { Prisma, Role } from "@prisma/client";
 
 const RESET_EMAIL_DOMAIN = "reset.peoplecore.invalid";
+const CHUNK_SIZE = 200;
+
+const chunkValues = <T>(values: readonly T[], chunkSize: number): T[][] => {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    result.push(values.slice(index, index + chunkSize));
+  }
+
+  return result;
+};
+
+const runChunked = async <T>(
+  values: readonly T[],
+  chunkSize: number,
+  handler: (chunk: T[]) => Promise<void>,
+) => {
+  const chunks = chunkValues(values, chunkSize);
+  for (const chunk of chunks) {
+    if (chunk.length > 0) {
+      await handler(chunk);
+    }
+  }
+};
 
 export async function POST() {
   const session = await getServerSession(authOptions);
@@ -31,184 +58,264 @@ export async function POST() {
   const currentUserId = session.user.id;
 
   try {
-    const summary = await prisma.$transaction(async (tx) => {
-      const employees = await tx.employee.findMany({
-        where: {
-          companyId,
-          NOT: { userId: currentUserId },
-        },
-        select: { id: true, userId: true },
-      });
-
-      const employeeIds = employees.map((emp) => emp.id);
-      const userIds = employees.map((emp) => emp.userId);
-
-      if (employeeIds.length) {
-        await Promise.all([
-          tx.documentSignatureArtifact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureEmployee.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.documentSignatureField.deleteMany({
-            where: { assignedEmployeeId: { in: employeeIds } },
-          }),
-          tx.documentAcknowledgement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.driverLicence.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.emergencyContact.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeAuditLog.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeOffboarding.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeePerformanceReview.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employeeWorkingPatternAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.employmentCheck.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formAssignment.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formDataRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.formSubmission.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyRecipient.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.surveyResponse.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveEntitlement.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.leaveRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.onboardingInstance.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.trainingRecord.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.transactionalChangeRequest.deleteMany({
-            where: { employeeId: { in: employeeIds } },
-          }),
-          tx.actionItem.deleteMany({
-            where: { relatedEmployeeId: { in: employeeIds } },
-          }),
-        ]);
-      }
-
-      if (userIds.length) {
-        const userScopedTasks = [
-          tx.leaveRequest.deleteMany({
-            where: {
-              companyId,
-              OR: [
-                { requesterId: { in: userIds } },
-                { approvedById: { in: userIds } },
-              ],
-            },
-          }),
-          tx.actionItem.deleteMany({
-            where: {
-              companyId,
-              assignedToId: { in: userIds },
-            },
-          }),
-          tx.activationToken.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsPost.deleteMany({ where: { authorId: { in: userIds } } }),
-          tx.newsReaction.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.newsBookmark.deleteMany({ where: { userId: { in: userIds } } }),
-          tx.globalAuditLog.deleteMany({
-            where: { companyId, actorId: { in: userIds } },
-          }),
-          tx.user.updateMany({
-            where: { id: { in: userIds } },
-            data: { role: Role.EMPLOYEE, canManageTenants: false },
-          }),
-        ];
-
-        await Promise.all(userScopedTasks);
-
-        try {
-          await tx.$executeRaw(
-            Prisma.sql`DELETE FROM "Session" WHERE "userId" IN (${Prisma.join(
-              userIds,
-            )})`,
-          );
-        } catch (error) {
-          console.warn("Failed to remove persisted sessions during reset", error);
-        }
-      }
-
-      const { count: removedEmployees } = await tx.employee.deleteMany({
-        where: { id: { in: employeeIds } },
-      });
-
-      for (const userId of userIds) {
-        const placeholderEmail = `${userId}@${RESET_EMAIL_DOMAIN}`;
-        await tx.user.update({
-          where: { id: userId },
-          data: {
-            email: placeholderEmail,
-            firstName: "Deleted",
-            lastName: "User",
-            phone: null,
-            managerId: null,
-            permissionProfileId: null,
-            departmentId: null,
-            jobRoleId: null,
-            genderOptionId: null,
-            isActivated: false,
-            role: Role.EMPLOYEE,
-            canManageTenants: false,
+    const summary = await prisma.$transaction(
+      async (tx) => {
+        const employees = await tx.employee.findMany({
+          where: {
+            companyId,
+            NOT: { userId: currentUserId },
           },
+          select: { id: true, userId: true },
         });
-      }
 
-      const departments = await tx.department.deleteMany({ where: { companyId } });
-      const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
-      const workingPatterns = await tx.workingPattern.deleteMany({
-        where: { companyId },
-      });
-      const genderOptions = await tx.genderOption.deleteMany({
-        where: { companyId },
-      });
-      const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
-        where: { companyId },
-      });
-      const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
-      const eventCategories = await tx.eventCategory.deleteMany({
-        where: { companyId, systemDefined: false },
-      });
+        const employeeIds = Array.from(new Set(employees.map((emp) => emp.id)));
+        const userIds = Array.from(
+          new Set(
+            employees
+              .map((emp) => emp.userId)
+              .filter(
+                (userId): userId is string =>
+                  typeof userId === "string" && userId.length > 0,
+              ),
+          ),
+        );
 
-      return {
-        removedEmployees,
-        scrubbedUsers: userIds.length,
-        removedDepartments: departments.count,
-        removedJobRoles: jobRoles.count,
-        removedWorkingPatterns: workingPatterns.count,
-        removedGenderOptions: genderOptions.count,
-        removedEventCategories: eventCategories.count,
-        removedEventRules: eventRules.count + eventRuleOverrides.count,
-      } as const;
-    });
+        let removedEmployees = 0;
+        let scrubbedUsers = 0;
+
+        if (employeeIds.length) {
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.documentSignatureArtifact.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.documentSignatureEmployee.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.documentSignatureField.deleteMany({
+              where: { assignedEmployeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.documentAcknowledgement.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.driverLicence.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.emergencyContact.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.employeeAuditLog.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.employeeOffboarding.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.employeePerformanceReview.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.employeeWorkingPatternAssignment.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.employmentCheck.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.formAssignment.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.formDataRecord.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.formSubmission.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.surveyRecipient.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.surveyResponse.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.leaveEntitlement.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.leaveRequest.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.onboardingInstance.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.trainingRecord.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.transactionalChangeRequest.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.actionItem.deleteMany({
+              where: { relatedEmployeeId: { in: chunk } },
+            });
+          });
+          await runChunked(employeeIds, CHUNK_SIZE, async (chunk) => {
+            await tx.document.deleteMany({
+              where: { employeeId: { in: chunk } },
+            });
+          });
+        }
+
+        if (userIds.length) {
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.leaveRequest.deleteMany({
+              where: {
+                companyId,
+                OR: [
+                  { requesterId: { in: chunk } },
+                  { approvedById: { in: chunk } },
+                ],
+              },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.actionItem.deleteMany({
+              where: { companyId, assignedToId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.activationToken.deleteMany({
+              where: { userId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.newsPost.deleteMany({
+              where: { authorId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.newsReaction.deleteMany({
+              where: { userId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.newsBookmark.deleteMany({
+              where: { userId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.globalAuditLog.deleteMany({
+              where: { companyId, actorId: { in: chunk } },
+            });
+          });
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            await tx.session.deleteMany({
+              where: { userId: { in: chunk } },
+            });
+          });
+
+          const placeholderSuffix = `@${RESET_EMAIL_DOMAIN}`;
+
+          await runChunked(userIds, CHUNK_SIZE, async (chunk) => {
+            const updatedCount = await tx.$executeRaw(
+              Prisma.sql`
+                UPDATE "User"
+                SET
+                  "email" = "id" || ${placeholderSuffix},
+                  "firstName" = 'Deleted',
+                  "lastName" = 'User',
+                  "phone" = NULL,
+                  "managerId" = NULL,
+                  "permissionProfileId" = NULL,
+                  "departmentId" = NULL,
+                  "jobRoleId" = NULL,
+                  "genderOptionId" = NULL,
+                  "isActivated" = FALSE,
+                  "role" = ${Role.EMPLOYEE},
+                  "canManageTenants" = FALSE,
+                  "updatedAt" = NOW()
+                WHERE "id" IN (${Prisma.join(
+                  chunk.map((id) => Prisma.sql`${id}`),
+                )})
+              `,
+            );
+
+            scrubbedUsers += Number(updatedCount ?? 0);
+          });
+        }
+
+        const deletionResult = await tx.employee.deleteMany({
+          where: { id: { in: employeeIds } },
+        });
+        removedEmployees = deletionResult.count;
+
+        const departments = await tx.department.deleteMany({ where: { companyId } });
+        const jobRoles = await tx.jobRole.deleteMany({ where: { companyId } });
+        const workingPatterns = await tx.workingPattern.deleteMany({
+          where: { companyId },
+        });
+        const genderOptions = await tx.genderOption.deleteMany({
+          where: { companyId },
+        });
+        const eventRuleOverrides = await tx.eventRuleOverride.deleteMany({
+          where: { companyId },
+        });
+        const eventRules = await tx.eventRule.deleteMany({ where: { companyId } });
+        const eventCategories = await tx.eventCategory.deleteMany({
+          where: { companyId, systemDefined: false },
+        });
+
+        return {
+          removedEmployees,
+          scrubbedUsers,
+          removedDepartments: departments.count,
+          removedJobRoles: jobRoles.count,
+          removedWorkingPatterns: workingPatterns.count,
+          removedGenderOptions: genderOptions.count,
+          removedEventCategories: eventCategories.count,
+          removedEventRules: eventRules.count + eventRuleOverrides.count,
+        } as const;
+      },
+      {
+        maxWait: 5_000,
+        timeout: 60_000,
+      },
+    );
 
     const resetActor = session.user.email ?? currentUserId;
 


### PR DESCRIPTION
## Summary
- rebuild the org chart API to source employees directly, include standalone users, and normalise roles plus signed avatars
- map SUPER_ADMIN responses to ADMIN in the org chart client so privileged accounts still render
- refactor tenant reset cleanup to run chunked deletes and SQL updates, preventing transaction rollbacks while scrubbing user data

## Testing
- npm run build *(fails: unable to download required Google Fonts in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e268aba6408331bc2c460d27eee55e